### PR TITLE
Completely change the CLI so that we have a server and a client.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,9 +137,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.0.0-beta.4"
+version = "3.0.0-beta.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcd70aa5597dbc42f7217a543f9ef2768b2ef823ba29036072d30e1d88e98406"
+checksum = "feff3878564edb93745d58cf63e17b63f24142506e7a20c87a5521ed7bfb1d63"
 dependencies = [
  "atty",
  "bitflags",
@@ -150,14 +150,14 @@ dependencies = [
  "strsim",
  "termcolor",
  "textwrap",
- "vec_map",
+ "unicase",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.0.0-beta.4"
+version = "3.0.0-beta.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5bb0d655624a0b8770d1c178fb8ffcb1f91cc722cb08f451e3dc72465421ac"
+checksum = "8b15c6b4f786ffb6192ffe65a36855bc1fc2444bcd0945ae16748dcd6ed7d0d3"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -743,6 +743,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sha1",
  "sha1w",
  "size_format",
@@ -1017,9 +1018,12 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "3.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6acbef58a60fe69ab50510a55bc8cdd4d6cf2283d27ad338f54cb52747a9cf2d"
+checksum = "addaa943333a514159c80c97ff4a93306530d965d27e139188283cd13e06a799"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1380,7 +1384,7 @@ dependencies = [
 
 [[package]]
 name = "rqbit"
-version = "1.1.2"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1391,6 +1395,9 @@ dependencies = [
  "parse_duration",
  "pretty_env_logger",
  "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
  "size_format",
  "tokio",
 ]
@@ -1905,12 +1912,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/README.md
+++ b/README.md
@@ -27,13 +27,17 @@ Just a regular Rust binary build process.
 
 ## Usage quick start
 
-Assuming you are downloading to ~/Downloads
+### Optional - start the server
 
-    rqbit 'magnet:?....' ~/Downloads
+Assuming you are downloading to ~/Downloads.
 
-or
+    rqbit server start ~/Downloads
 
-    rqbit /some/file.torrent ~/Downloads
+### Download torrents
+
+Assuming you are downloading to ~/Downloads. If the server is already started, ```-o ~/Downloads``` can be omitted.
+
+    rqbit download -o ~/Downloads 'magnet:?....' [https?://url/to/.torrent] [/path/to/local/file.torrent]
 
 ## Useful options
 
@@ -73,12 +77,9 @@ Use a regex here to select files by their names.
 ### Bugs, missing features and other caveats
 Below points are all easily fixable, PRs welcome.
 
-- The CLI support only one mode of operation: download one torrent to a given folder.
-- If you try to run multiple instances, there's some port conflicts (already listening on port). This happens because DHT stores persistence information on disk, and that includes the port it last listened on.
-  To work around this either use ```--disable-dht-persistence``` flag on the second (3rd, etc) instance of rqbit, or add the other torrent with HTTP API like this ```curl -d 'magnet:?...' http://127.0.0.1:3030/torrents```
+- Doesn't survive switching networks, i.e. doesn't reconnect to a peer once the TCP connection is closed.
 - Only supports BitTorrent V1 over TCP
 - As this was created for personal needs, and for educational purposes, documentation, commit message quality etc. leave a lot to be desired.
-- Doesn't survive switching networks, i.e. doesn't reconnect to a peer once the TCP connection is closed.
 
 ## Code organization
 - crates/rqbit - main binary

--- a/crates/librqbit/Cargo.toml
+++ b/crates/librqbit/Cargo.toml
@@ -27,6 +27,7 @@ tokio = {version = "1", features = ["macros", "rt-multi-thread"]}
 tokio-stream = "0.1"
 serde = {version = "1", features=["derive"]}
 serde_json = "1"
+serde_urlencoded = "*"
 anyhow = "1"
 
 regex = "1"

--- a/crates/librqbit/src/http_api_client.rs
+++ b/crates/librqbit/src/http_api_client.rs
@@ -1,0 +1,92 @@
+use anyhow::Context;
+use serde::Deserialize;
+
+use crate::{http_api::TorrentAddQueryParams, session::AddTorrentOptions};
+
+#[derive(Clone)]
+pub struct HttpApiClient {
+    client: reqwest::Client,
+    base_url: reqwest::Url,
+}
+
+async fn check_response(r: reqwest::Response) -> anyhow::Result<reqwest::Response> {
+    if r.status().is_success() {
+        return Ok(r);
+    }
+    let status = r.status();
+    let url = r.url().clone();
+    let body = r.text().await.with_context(|| {
+        format!(
+            "cannot read response body for request to {} ({})",
+            url, status,
+        )
+    })?;
+    anyhow::bail!("{} -> {}: {}", url, status, body)
+}
+
+#[derive(Deserialize)]
+struct ApiRoot {
+    server: String,
+}
+
+async fn json_response<T: serde::de::DeserializeOwned + std::any::Any>(
+    url: &reqwest::Url,
+    response: reqwest::Response,
+) -> anyhow::Result<T> {
+    let response = check_response(response).await?;
+    let body = response.bytes().await?;
+    let response: T = serde_json::from_slice(&body).with_context(|| {
+        format!(
+            "error deserializing response from {:?} as {:?}",
+            url,
+            std::any::type_name::<T>(),
+        )
+    })?;
+    Ok(response)
+}
+
+impl HttpApiClient {
+    pub fn new(url: &str) -> anyhow::Result<Self> {
+        Ok(Self {
+            base_url: reqwest::Url::parse(url)?,
+            client: reqwest::ClientBuilder::new().build()?,
+        })
+    }
+
+    pub fn base_url(&self) -> &reqwest::Url {
+        &self.base_url
+    }
+
+    pub async fn validate_rqbit_server(&self) -> anyhow::Result<()> {
+        let response = self.client.get(self.base_url.clone()).send().await?;
+        let root: ApiRoot = json_response(&self.base_url, response).await?;
+        if root.server == "rqbit" {
+            return Ok(());
+        }
+        anyhow::bail!("not an rqbit server at {}", &self.base_url)
+    }
+
+    pub async fn add_torrent(
+        &self,
+        torrent: &str,
+        opts: Option<AddTorrentOptions>,
+    ) -> anyhow::Result<usize> {
+        let opts = opts.unwrap_or_default();
+        let params = TorrentAddQueryParams {
+            overwrite: Some(opts.overwrite),
+            only_files_regex: opts.only_files_regex,
+            output_folder: opts.output_folder,
+        };
+        let qs = serde_urlencoded::to_string(&params).unwrap();
+        let url = format!("{}torrents?{}", &self.base_url, qs);
+        let response = check_response(
+            self.client
+                .post(&url)
+                .body(torrent.to_owned())
+                .send()
+                .await?,
+        )
+        .await?;
+        Ok(response.text().await?.parse::<usize>()?)
+    }
+}

--- a/crates/librqbit/src/lib.rs
+++ b/crates/librqbit/src/lib.rs
@@ -2,6 +2,7 @@ pub mod chunk_tracker;
 pub mod dht_utils;
 pub mod file_ops;
 pub mod http_api;
+pub mod http_api_client;
 pub mod peer_connection;
 pub mod peer_handler;
 pub mod peer_info_reader;

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -115,7 +115,7 @@ fn compute_only_files<ByteBuf: AsRef<[u8]>>(
     Ok(only_files)
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct AddTorrentOptions {
     pub only_files_regex: Option<String>,
     pub overwrite: bool,
@@ -177,7 +177,7 @@ impl Session {
     }
     pub async fn add_torrent(
         &self,
-        url: String,
+        url: &str,
         opts: Option<AddTorrentOptions>,
     ) -> anyhow::Result<Option<TorrentManagerHandle>> {
         // Magnet links are different in that we first need to discover the metadata.
@@ -186,7 +186,7 @@ impl Session {
             let Magnet {
                 info_hash,
                 trackers,
-            } = Magnet::parse(&url).context("provided path is not a valid magnet URL")?;
+            } = Magnet::parse(url).context("provided path is not a valid magnet URL")?;
 
             let dht_rx = self
                 .dht
@@ -230,9 +230,9 @@ impl Session {
             .await
         } else {
             let torrent = if url.starts_with("http://") || url.starts_with("https://") {
-                torrent_from_url(&url).await?
+                torrent_from_url(url).await?
             } else {
-                torrent_from_file(&url)?
+                torrent_from_file(url)?
             };
             let dht_rx = match self.dht.as_ref() {
                 Some(dht) => Some(dht.get_peers(torrent.info_hash).await?),

--- a/crates/rqbit/Cargo.toml
+++ b/crates/rqbit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rqbit"
 description = "A bittorent client"
-version = "1.1.2"
+version = "2.0.0"
 authors = ["Igor Katson <igor.katson@gmail.com>"]
 edition = "2018"
 
@@ -18,12 +18,15 @@ librqbit = {path="../librqbit", default-features=false}
 dht = {path="../dht"}
 tokio = {version = "1", features = ["macros", "rt-multi-thread"]}
 anyhow = "1"
-clap = "3.0.0-beta.2"
+clap = "3.0.0-beta.5"
 log = "0.4"
 pretty_env_logger = "0.4"
 regex = "1"
 futures = "0.3"
 parse_duration = "2"
+reqwest = "*"
+serde = {version = "1", features=["derive"]}
+serde_json = "1"
 size_format = "1"
 
 [dev-dependencies]


### PR DESCRIPTION
This is a breaking change.

Adds support for "rqbit server" command and "rqbit download" commands.
Previous functionality is part of "rqbit download".

"rqbit download" tries to connect to the server if it's already running, and if it's not starts one within the process.