### PR TITLE
Fix: multiply the number of bytes by 8

### DIFF
--- a/crates/librqbit/src/http_api.rs
+++ b/crates/librqbit/src/http_api.rs
@@ -52,7 +52,7 @@ impl Speed {
     fn new(mbps: f64) -> Self {
         Self {
             mbps,
-            human_readable: format!("{:.2}Mbps", mbps),
+            human_readable: format!("{:.2} MiB/s", mbps),
         }
     }
 }
@@ -221,7 +221,7 @@ impl ApiInternal {
         Some(StatsResponse {
             average_piece_download_time: snapshot.average_piece_download_time(),
             snapshot,
-            all_time_download_speed: (downloaded_mb * 8f64 / elapsed.as_secs_f64()).into(),
+            all_time_download_speed: (downloaded_mb / elapsed.as_secs_f64()).into(),
             download_speed: estimator.download_mbps().into(),
             time_remaining: estimator.time_remaining(),
         })

--- a/crates/librqbit_core/src/speed_estimator.rs
+++ b/crates/librqbit_core/src/speed_estimator.rs
@@ -68,7 +68,7 @@ impl SpeedEstimator {
 
         let downloaded_bytes_diff = downloaded_bytes - first.downloaded_bytes;
         let elapsed = instant - first.instant;
-        let bps = downloaded_bytes_diff as f64 * 8f64 / elapsed.as_secs_f64();
+        let bps = downloaded_bytes_diff as f64 / elapsed.as_secs_f64();
 
         let time_remaining_millis_rounded: u64 = if downloaded_bytes_diff > 0 {
             let time_remaining_secs = remaining_bytes as f64 / bps;

--- a/crates/rqbit/src/main.rs
+++ b/crates/rqbit/src/main.rs
@@ -216,7 +216,7 @@ async fn async_main(opts: Opts, spawner: BlockingSpawner) -> anyhow::Result<()> 
                                     (progress as f64 / total as f64) * 100f64
                                 };
                                 info!(
-                                    "[{}]: {:.2}% ({:.2}), down speed {:.2} Mbps, fetched {}, remaining {:.2} of {:.2}, uploaded {:.2}, peers: {{live: {}, connecting: {}, queued: {}, seen: {}}}",
+                                    "[{}]: {:.2}% ({:.2}), down speed {:.2} MiB/s, fetched {}, remaining {:.2} of {:.2}, uploaded {:.2}, peers: {{live: {}, connecting: {}, queued: {}, seen: {}}}",
                                     idx,
                                     downloaded_pct,
                                     SF::new(progress),


### PR DESCRIPTION
When expressed in Mbps, it means megabits per second whitch should be the number of bytes multiplied by 8