### PR TITLE
Update: add sub_folder in AddTorrentOptions

### DIFF
--- a/crates/librqbit/src/http_api.rs
+++ b/crates/librqbit/src/http_api.rs
@@ -276,6 +276,7 @@ fn json_or_404<T: Serialize>(idx: usize, v: Option<T>) -> warp::reply::Response 
 pub struct TorrentAddQueryParams {
     pub overwrite: Option<bool>,
     pub output_folder: Option<String>,
+    pub sub_folder: Option<String>,
     pub only_files_regex: Option<String>,
     pub list_only: Option<bool>,
 }
@@ -362,6 +363,7 @@ impl HttpApi {
                             overwrite: params.overwrite.unwrap_or(false),
                             only_files_regex: params.only_files_regex,
                             output_folder: params.output_folder,
+                            sub_folder: params.sub_folder,
                             list_only: params.list_only.unwrap_or(false),
                             ..Default::default()
                         };

--- a/crates/librqbit/src/http_api_client.rs
+++ b/crates/librqbit/src/http_api_client.rs
@@ -76,6 +76,7 @@ impl HttpApiClient {
             overwrite: Some(opts.overwrite),
             only_files_regex: opts.only_files_regex,
             output_folder: opts.output_folder,
+            sub_folder: opts.sub_folder,
             list_only: Some(opts.list_only),
         };
         let qs = serde_urlencoded::to_string(&params).unwrap();

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -124,6 +124,7 @@ pub struct AddTorrentOptions {
     pub overwrite: bool,
     pub list_only: bool,
     pub output_folder: Option<String>,
+    pub sub_folder: Option<String>,
     pub peer_opts: Option<PeerConnectionOptions>,
     pub force_tracker_interval: Option<Duration>,
 }
@@ -318,10 +319,12 @@ impl Session {
             }));
         }
 
+        let sub_folder = opts.sub_folder.map(PathBuf::from).unwrap_or_default();
         let output_folder = opts
             .output_folder
             .map(PathBuf::from)
-            .unwrap_or_else(|| self.output_folder.clone());
+            .unwrap_or_else(|| self.output_folder.clone())
+            .join(sub_folder.as_path());
 
         let managed_torrent = ManagedTorrent {
             info_hash,


### PR DESCRIPTION
Add sub folder in options, it will download to `target/sub/`, Example:
```bash
curl -d '/path/to/torrent' 'http://127.0.0.1:3030/torrents?output_folder=target&sub_folder=sub'
````