### PR TITLE
create_request: avoid u16 overflow panic

### DIFF
--- a/crates/dht/src/dht.rs
+++ b/crates/dht/src/dht.rs
@@ -81,7 +81,12 @@ impl DhtState {
     fn create_request(&mut self, request: Request, addr: SocketAddr) -> Message<ByteString> {
         let transaction_id = self.next_transaction_id;
         let transaction_id_buf = [(transaction_id >> 8) as u8, (transaction_id & 0xff) as u8];
-        self.next_transaction_id += 1;
+
+        self.next_transaction_id = if transaction_id == u16::MAX {
+            0
+        } else {
+            transaction_id + 1
+        };
         let message = match request {
             Request::GetPeers(info_hash) => Message {
                 transaction_id: ByteString::from(transaction_id_buf.as_ref()),


### PR DESCRIPTION
To repro:

* use dht with empty options (could it be "zero" sleeps on some durations ?)
* peek (`list_only=true`) the following alpine torrent : [alpine-standard-3.17.3-aarch64.iso.torrent.zip](https://github.com/ikatson/rqbit/files/11304185/alpine-standard-3.17.3-aarch64.iso.torrent.zip)

Now this just prevents the panic, but I would like to avoid that seemingly infinite loop.
If you have any ideas I'm all ears. Here's a backtrace:
```
 INFO  dht::dht         > next_transaction_id: 50738
Custom backtrace:    0: std::backtrace_rs::backtrace::libunwind::trace
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/std/src/../../backtrace/src/backtrace/libunwind.rs:93:5
   1: std::backtrace_rs::backtrace::trace_unsynchronized
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2: std::backtrace::Backtrace::create
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/std/src/backtrace.rs:332:13
   3: dht::dht::DhtState::create_request
             at /Users/azr/go/src/github.com/azr/rqbit/crates/dht/src/dht.rs:89:45
   4: dht::dht::DhtState::send_find_peers_if_not_yet
             at /Users/azr/go/src/github.com/azr/rqbit/crates/dht/src/dht.rs:303:23
   5: dht::dht::DhtState::on_found_peers_or_nodes
             at /Users/azr/go/src/github.com/azr/rqbit/crates/dht/src/dht.rs:403:17
   6: dht::dht::DhtState::on_incoming_from_remote
             at /Users/azr/go/src/github.com/azr/rqbit/crates/dht/src/dht.rs:171:25
   7: dht::dht::DhtWorker::on_response
             at /Users/azr/go/src/github.com/azr/rqbit/crates/dht/src/dht.rs:488:9
   8: dht::dht::DhtWorker::start::{{closure}}::{{closure}}
             at /Users/azr/go/src/github.com/azr/rqbit/crates/dht/src/dht.rs:541:37
   9: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/core/src/future/future.rs:125:9
  10: <&mut F as core::future::future::Future>::poll
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/core/src/future/future.rs:113:9
  11: dht::dht::DhtWorker::start::{{closure}}::{{closure}}
             at /Users/azr/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/macros/select.rs:524:49
  12: <tokio::future::poll_fn::PollFn<F> as core::future::future::Future>::poll
             at /Users/azr/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/future/poll_fn.rs:58:9
  13: dht::dht::DhtWorker::start::{{closure}}
             at /Users/azr/go/src/github.com/azr/rqbit/crates/dht/src/dht.rs:556:13
  14: dht::dht::Dht::with_config::{{closure}}::{{closure}}
             at /Users/azr/go/src/github.com/azr/rqbit/crates/dht/src/dht.rs:670:74
  15: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/core/src/future/future.rs:125:9
  16: tokio::runtime::task::core::Core<T,S>::poll::{{closure}}
             at /Users/azr/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/core.rs:223:17
  17: tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut
             at /Users/azr/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/loom/std/unsafe_cell.rs:14:9
  18: tokio::runtime::task::core::Core<T,S>::poll
             at /Users/azr/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/core.rs:212:13
  19: tokio::runtime::task::harness::poll_future::{{closure}}
             at /Users/azr/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/harness.rs:476:19
  20: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/core/src/panic/unwind_safe.rs:271:9
  21: std::panicking::try::do_call
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/std/src/panicking.rs:483:40
  22: ___rust_try
  23: std::panicking::try
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/std/src/panicking.rs:447:19
  24: std::panic::catch_unwind
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/std/src/panic.rs:140:14
  25: tokio::runtime::task::harness::poll_future
             at /Users/azr/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/harness.rs:464:18
  26: tokio::runtime::task::harness::Harness<T,S>::poll_inner
             at /Users/azr/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/harness.rs:198:27
  27: tokio::runtime::task::harness::Harness<T,S>::poll
             at /Users/azr/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/harness.rs:152:15
  28: tokio::runtime::task::raw::poll
             at /Users/azr/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/raw.rs:255:5
  29: tokio::runtime::task::raw::RawTask::poll
             at /Users/azr/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/raw.rs:200:18
  30: tokio::runtime::task::LocalNotified<S>::run
             at /Users/azr/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/mod.rs:394:9
  31: tokio::runtime::scheduler::multi_thread::worker::Context::run_task::{{closure}}
             at /Users/azr/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/scheduler/multi_thread/worker.rs:464:13
  32: tokio::runtime::coop::with_budget
             at /Users/azr/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/coop.rs:107:5
  33: tokio::runtime::coop::budget
             at /Users/azr/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/coop.rs:73:5
  34: tokio::runtime::scheduler::multi_thread::worker::Context::run_task
             at /Users/azr/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/scheduler/multi_thread/worker.rs:463:9
  35: tokio::runtime::scheduler::multi_thread::worker::Context::run
             at /Users/azr/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/scheduler/multi_thread/worker.rs:426:24
  36: tokio::runtime::scheduler::multi_thread::worker::run::{{closure}}
             at /Users/azr/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/scheduler/multi_thread/worker.rs:406:17
  37: tokio::macros::scoped_tls::ScopedKey<T>::set
             at /Users/azr/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/macros/scoped_tls.rs:61:9
  38: tokio::runtime::scheduler::multi_thread::worker::run
             at /Users/azr/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/scheduler/multi_thread/worker.rs:403:5
  39: tokio::runtime::scheduler::multi_thread::worker::Launch::launch::{{closure}}
             at /Users/azr/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/scheduler/multi_thread/worker.rs:365:45
  40: <tokio::runtime::blocking::task::BlockingTask<T> as core::future::future::Future>::poll
             at /Users/azr/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/blocking/task.rs:42:21
  41: tokio::runtime::task::core::Core<T,S>::poll::{{closure}}
             at /Users/azr/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/core.rs:223:17
  42: tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut
             at /Users/azr/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/loom/std/unsafe_cell.rs:14:9
  43: tokio::runtime::task::core::Core<T,S>::poll
             at /Users/azr/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/core.rs:212:13
  44: tokio::runtime::task::harness::poll_future::{{closure}}
             at /Users/azr/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/harness.rs:476:19
  45: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/core/src/panic/unwind_safe.rs:271:9
  46: std::panicking::try::do_call
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/std/src/panicking.rs:483:40
  47: ___rust_try
  48: std::panicking::try
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/std/src/panicking.rs:447:19
  49: std::panic::catch_unwind
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/std/src/panic.rs:140:14
  50: tokio::runtime::task::harness::poll_future
             at /Users/azr/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/harness.rs:464:18
  51: tokio::runtime::task::harness::Harness<T,S>::poll_inner
             at /Users/azr/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/harness.rs:198:27
  52: tokio::runtime::task::harness::Harness<T,S>::poll
             at /Users/azr/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/harness.rs:152:15
  53: tokio::runtime::task::raw::poll
             at /Users/azr/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/raw.rs:255:5
  54: tokio::runtime::task::raw::RawTask::poll
             at /Users/azr/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/raw.rs:200:18
  55: tokio::runtime::task::UnownedTask<S>::run
             at /Users/azr/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/mod.rs:431:9
  56: tokio::runtime::blocking::pool::Task::run
             at /Users/azr/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/blocking/pool.rs:159:9
  57: tokio::runtime::blocking::pool::Inner::run
             at /Users/azr/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/blocking/pool.rs:513:17
  58: tokio::runtime::blocking::pool::Spawner::spawn_thread::{{closure}}
             at /Users/azr/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/blocking/pool.rs:471:13
  59: std::sys_common::backtrace::__rust_begin_short_backtrace
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/std/src/sys_common/backtrace.rs:121:18
  60: std::thread::Builder::spawn_unchecked_::{{closure}}::{{closure}}
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/std/src/thread/mod.rs:558:17
  61: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/core/src/panic/unwind_safe.rs:271:9
  62: std::panicking::try::do_call
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/std/src/panicking.rs:483:40
  63: ___rust_try
  64: std::panicking::try
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/std/src/panicking.rs:447:19
  65: std::panic::catch_unwind
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/std/src/panic.rs:140:14
  66: std::thread::Builder::spawn_unchecked_::{{closure}}
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/std/src/thread/mod.rs:557:30
  67: core::ops::function::FnOnce::call_once{{vtable.shim}}
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/core/src/ops/function.rs:250:5
  68: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/alloc/src/boxed.rs:1988:9
  69: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/alloc/src/boxed.rs:1988:9
  70: std::sys::unix::thread::Thread::new::thread_start
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/std/src/sys/unix/thread.rs:108:17
  71: __pthread_joiner_wake
```