### PR TITLE
Fix only files not working properly

### DIFF
--- a/crates/librqbit/src/torrent_state/initializing.rs
+++ b/crates/librqbit/src/torrent_state/initializing.rs
@@ -86,9 +86,10 @@ impl TorrentStateInitializing {
         })?;
 
         info!(
-            "Initial check results: have {}, needed {}",
+            "Initial check results: have {}, needed {}, total selected {}",
             SF::new(initial_check_results.have_bytes),
-            SF::new(initial_check_results.needed_bytes)
+            SF::new(initial_check_results.needed_bytes),
+            SF::new(initial_check_results.total_selected_bytes)
         );
 
         self.meta.spawner.spawn_block_in_place(|| {
@@ -126,6 +127,7 @@ impl TorrentStateInitializing {
             initial_check_results.needed_pieces,
             initial_check_results.have_pieces,
             self.meta.lengths,
+            initial_check_results.total_selected_bytes,
         );
 
         let paused = TorrentStatePaused {
@@ -134,6 +136,7 @@ impl TorrentStateInitializing {
             filenames,
             chunk_tracker,
             have_bytes: initial_check_results.have_bytes,
+            needed_bytes: initial_check_results.needed_bytes,
         };
         Ok(paused)
     }

--- a/crates/librqbit/src/torrent_state/live/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/mod.rs
@@ -602,6 +602,10 @@ impl TorrentStateLive {
         });
     }
 
+    pub fn get_total_selected_bytes(&self) -> u64 {
+        self.total_selected_bytes
+    }
+
     pub fn get_uploaded_bytes(&self) -> u64 {
         self.stats.uploaded_bytes.load(Ordering::Relaxed)
     }
@@ -693,16 +697,11 @@ impl TorrentStateLive {
     pub fn stats_snapshot(&self) -> StatsSnapshot {
         use Ordering::*;
         let downloaded_bytes = self.stats.downloaded_and_checked_bytes.load(Relaxed);
-        let remaining = self.initially_needed_bytes - downloaded_bytes;
         StatsSnapshot {
-            have_bytes: self.stats.have_bytes.load(Relaxed),
             downloaded_and_checked_bytes: downloaded_bytes,
             downloaded_and_checked_pieces: self.stats.downloaded_and_checked_pieces.load(Relaxed),
             fetched_bytes: self.stats.fetched_bytes.load(Relaxed),
             uploaded_bytes: self.stats.uploaded_bytes.load(Relaxed),
-            total_bytes: self.total_selected_bytes,
-            initially_needed_bytes: self.initially_needed_bytes,
-            remaining_bytes: remaining,
             total_piece_download_ms: self.stats.total_piece_download_ms.load(Relaxed),
             peer_stats: self.peers.stats(),
         }

--- a/crates/librqbit/src/torrent_state/live/stats/snapshot.rs
+++ b/crates/librqbit/src/torrent_state/live/stats/snapshot.rs
@@ -6,14 +6,12 @@ use crate::torrent_state::live::peers::stats::snapshot::AggregatePeerStats;
 
 #[derive(Debug, Serialize, Default)]
 pub struct StatsSnapshot {
-    pub have_bytes: u64,
     pub downloaded_and_checked_bytes: u64,
-    pub downloaded_and_checked_pieces: u64,
+
     pub fetched_bytes: u64,
     pub uploaded_bytes: u64,
-    pub initially_needed_bytes: u64,
-    pub remaining_bytes: u64,
-    pub total_bytes: u64,
+
+    pub downloaded_and_checked_pieces: u64,
     pub total_piece_download_ms: u64,
     pub peer_stats: AggregatePeerStats,
 }

--- a/crates/librqbit/src/torrent_state/mod.rs
+++ b/crates/librqbit/src/torrent_state/mod.rs
@@ -364,8 +364,9 @@ impl ManagedTorrent {
                 }
                 ManagedTorrentState::Paused(p) => {
                     resp.state = "paused";
-                    resp.progress_bytes = p.have_bytes;
-                    resp.finished = p.have_bytes == resp.total_bytes;
+                    resp.total_bytes = p.chunk_tracker.get_total_selected_bytes();
+                    resp.progress_bytes = resp.total_bytes - p.needed_bytes;
+                    resp.finished = resp.progress_bytes == resp.total_bytes;
                 }
                 ManagedTorrentState::Live(l) => {
                     resp.state = "live";

--- a/crates/librqbit/src/torrent_state/mod.rs
+++ b/crates/librqbit/src/torrent_state/mod.rs
@@ -371,8 +371,13 @@ impl ManagedTorrent {
                 ManagedTorrentState::Live(l) => {
                     resp.state = "live";
                     let live_stats = LiveStats::from(l.as_ref());
-                    resp.progress_bytes = live_stats.snapshot.have_bytes;
-                    resp.finished = resp.progress_bytes == resp.total_bytes;
+                    let total = l.get_total_selected_bytes();
+                    let remaining = l.get_left_to_download_bytes();
+                    let progress = total - remaining;
+
+                    resp.progress_bytes = progress;
+                    resp.total_bytes = total;
+                    resp.finished = remaining == 0;
                     resp.live = Some(live_stats);
                 }
                 ManagedTorrentState::Error(e) => {

--- a/crates/librqbit/src/torrent_state/paused.rs
+++ b/crates/librqbit/src/torrent_state/paused.rs
@@ -12,6 +12,7 @@ pub struct TorrentStatePaused {
     pub(crate) filenames: Vec<PathBuf>,
     pub(crate) chunk_tracker: ChunkTracker,
     pub(crate) have_bytes: u64,
+    pub(crate) needed_bytes: u64,
 }
 
 // impl TorrentStatePaused {


### PR DESCRIPTION
In recent refactorings, there was a bug introduced when handling "only_files".

When you picked only a few files, after downloading the needed files, the torrent kept being live, and not reporting to the user that it was completed.

Also UI stats were reported confusingly, as they didn't account for only files, and showed that there's still remaining progress, while in fact the file was fully ready on disk.