### PR TITLE
Small refactor - introduce ReadBuf

### DIFF
--- a/crates/librqbit/src/lib.rs
+++ b/crates/librqbit/src/lib.rs
@@ -31,6 +31,7 @@ pub mod http_api;
 pub mod http_api_client;
 mod peer_connection;
 mod peer_info_reader;
+mod read_buf;
 mod session;
 mod spawn_utils;
 mod torrent_state;

--- a/crates/librqbit/src/read_buf.rs
+++ b/crates/librqbit/src/read_buf.rs
@@ -10,58 +10,72 @@ use tokio::io::AsyncReadExt;
 
 pub struct ReadBuf {
     buf: Vec<u8>,
-    read_so_far: usize,
-    last_size: usize,
+    // How many bytes into the buffer we have read from the connection.
+    // New reads should go past this.
+    filled: usize,
+    // How many bytes have we successfully deserialized.
+    processed: usize,
 }
 
 impl ReadBuf {
     pub fn new() -> Self {
         Self {
             buf: vec![0; PIECE_MESSAGE_DEFAULT_LEN * 2],
-            read_so_far: 0,
-            last_size: 0,
+            filled: 0,
+            processed: 0,
         }
     }
 
-    fn prepare_for_read(&mut self) {
-        if self.read_so_far > self.last_size {
-            self.buf.copy_within(self.last_size..self.read_so_far, 0);
+    fn prepare_for_read(&mut self, need_additional_bytes: usize) {
+        // Ensure the buffer starts from the to-be-deserialized message.
+        if self.processed > 0 {
+            if self.filled > self.processed {
+                self.buf.copy_within(self.processed..self.filled, 0);
+            }
+            self.filled -= self.processed;
+            self.processed = 0;
         }
-        self.read_so_far -= self.last_size;
-        self.last_size = 0;
+
+        // Ensure we have enough capacity to deserialize the message.
+        if self.buf.len() < self.filled + need_additional_bytes {
+            self.buf.reserve(need_additional_bytes);
+            self.buf.resize(self.buf.capacity(), 0);
+        }
     }
 
+    // Read the BT handshake.
     // This MUST be run as the first operation on the buffer.
     pub async fn read_handshake(
         &mut self,
         mut conn: impl AsyncReadExt + Unpin,
         timeout: Duration,
     ) -> anyhow::Result<Handshake<ByteBuf<'_>>> {
-        self.read_so_far = with_timeout(timeout, conn.read(&mut self.buf))
+        self.filled = with_timeout(timeout, conn.read(&mut self.buf))
             .await
             .context("error reading handshake")?;
-        if self.read_so_far == 0 {
-            anyhow::bail!("bad handshake");
+        if self.filled == 0 {
+            anyhow::bail!("peer disconnected while reading handshake");
         }
-        let (h, size) = Handshake::deserialize(&self.buf[..self.read_so_far])
+        let (h, size) = Handshake::deserialize(&self.buf[..self.filled])
             .map_err(|e| anyhow::anyhow!("error deserializing handshake: {:?}", e))?;
-        self.last_size = size;
+        self.processed = size;
         Ok(h)
     }
 
+    // Read a message into the buffer, try to deserialize it and call the callback on it.
+    // We can't return the message because of a borrow checker issue.
     pub async fn read_message(
         &mut self,
         mut conn: impl AsyncReadExt + Unpin,
         timeout: Duration,
         on_message: impl for<'a> FnOnce(MessageBorrowed<'a>) -> anyhow::Result<()>,
     ) -> anyhow::Result<()> {
-        self.prepare_for_read();
         loop {
             let need_additional_bytes =
-                match MessageBorrowed::deserialize(&self.buf[..self.read_so_far]) {
+                match MessageBorrowed::deserialize(&self.buf[self.processed..self.filled]) {
                     Err(MessageDeserializeError::NotEnoughData(d, _)) => d,
                     Ok((msg, size)) => {
-                        self.last_size = size;
+                        self.processed += size;
                         // Rust's borrow checker can't do this early return. So we are using a callback instead.
                         // return Ok(msg);
                         on_message(msg)?;
@@ -69,20 +83,14 @@ impl ReadBuf {
                     }
                     Err(e) => return Err(e.into()),
                 };
-            if self.buf.len() < self.read_so_far + need_additional_bytes {
-                self.buf.reserve(need_additional_bytes);
-                self.buf.resize(self.buf.capacity(), 0);
-            }
-            let size = with_timeout(timeout, conn.read(&mut self.buf[self.read_so_far..]))
+            self.prepare_for_read(need_additional_bytes);
+            let size = with_timeout(timeout, conn.read(&mut self.buf[self.filled..]))
                 .await
                 .context("error reading from peer")?;
             if size == 0 {
-                anyhow::bail!(
-                    "disconnected while reading, read so far: {}",
-                    self.read_so_far
-                )
+                anyhow::bail!("disconnected while reading, read so far: {}", self.filled)
             }
-            self.read_so_far += size;
+            self.filled += size;
         }
     }
 }

--- a/crates/librqbit/src/read_buf.rs
+++ b/crates/librqbit/src/read_buf.rs
@@ -1,0 +1,88 @@
+use std::time::Duration;
+
+use crate::peer_connection::with_timeout;
+use anyhow::Context;
+use buffers::ByteBuf;
+use peer_binary_protocol::{
+    Handshake, MessageBorrowed, MessageDeserializeError, PIECE_MESSAGE_DEFAULT_LEN,
+};
+use tokio::io::AsyncReadExt;
+
+pub struct ReadBuf {
+    buf: Vec<u8>,
+    read_so_far: usize,
+    last_size: usize,
+}
+
+impl ReadBuf {
+    pub fn new() -> Self {
+        Self {
+            buf: vec![0; PIECE_MESSAGE_DEFAULT_LEN * 2],
+            read_so_far: 0,
+            last_size: 0,
+        }
+    }
+
+    fn prepare_for_read(&mut self) {
+        if self.read_so_far > self.last_size {
+            self.buf.copy_within(self.last_size..self.read_so_far, 0);
+        }
+        self.read_so_far -= self.last_size;
+        self.last_size = 0;
+    }
+
+    // This MUST be run as the first operation on the buffer.
+    pub async fn read_handshake(
+        &mut self,
+        mut conn: impl AsyncReadExt + Unpin,
+        timeout: Duration,
+    ) -> anyhow::Result<Handshake<ByteBuf<'_>>> {
+        self.read_so_far = with_timeout(timeout, conn.read(&mut self.buf))
+            .await
+            .context("error reading handshake")?;
+        if self.read_so_far == 0 {
+            anyhow::bail!("bad handshake");
+        }
+        let (h, size) = Handshake::deserialize(&self.buf[..self.read_so_far])
+            .map_err(|e| anyhow::anyhow!("error deserializing handshake: {:?}", e))?;
+        self.last_size = size;
+        Ok(h)
+    }
+
+    pub async fn read_message(
+        &mut self,
+        mut conn: impl AsyncReadExt + Unpin,
+        timeout: Duration,
+        on_message: impl for<'a> FnOnce(MessageBorrowed<'a>) -> anyhow::Result<()>,
+    ) -> anyhow::Result<()> {
+        self.prepare_for_read();
+        loop {
+            let need_additional_bytes =
+                match MessageBorrowed::deserialize(&self.buf[..self.read_so_far]) {
+                    Err(MessageDeserializeError::NotEnoughData(d, _)) => d,
+                    Ok((msg, size)) => {
+                        self.last_size = size;
+                        // Rust's borrow checker can't do this early return. So we are using a callback instead.
+                        // return Ok(msg);
+                        on_message(msg)?;
+                        return Ok(());
+                    }
+                    Err(e) => return Err(e.into()),
+                };
+            if self.buf.len() < self.read_so_far + need_additional_bytes {
+                self.buf.reserve(need_additional_bytes);
+                self.buf.resize(self.buf.capacity(), 0);
+            }
+            let size = with_timeout(timeout, conn.read(&mut self.buf[self.read_so_far..]))
+                .await
+                .context("error reading from peer")?;
+            if size == 0 {
+                anyhow::bail!(
+                    "disconnected while reading, read so far: {}",
+                    self.read_so_far
+                )
+            }
+            self.read_so_far += size;
+        }
+    }
+}

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -27,20 +27,18 @@ use librqbit_core::{
     },
 };
 use parking_lot::RwLock;
-use peer_binary_protocol::{Handshake, PIECE_MESSAGE_DEFAULT_LEN};
+use peer_binary_protocol::Handshake;
 use reqwest::Url;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_with::serde_as;
-use tokio::{
-    io::AsyncReadExt,
-    net::{TcpListener, TcpStream},
-};
+use tokio::net::{TcpListener, TcpStream};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, error_span, info, trace, warn, Instrument};
 
 use crate::{
     dht_utils::{read_metainfo_from_peer_receiver, ReadMetainfoResult},
-    peer_connection::{with_timeout, PeerConnectionOptions},
+    peer_connection::PeerConnectionOptions,
+    read_buf::ReadBuf,
     spawn_utils::BlockingSpawner,
     torrent_state::{
         ManagedTorrentBuilder, ManagedTorrentHandle, ManagedTorrentState, TorrentStateLive,
@@ -371,9 +369,8 @@ async fn create_tcp_listener(
 pub(crate) struct CheckedIncomingConnection {
     pub addr: SocketAddr,
     pub stream: tokio::net::TcpStream,
-    pub read_buf: Vec<u8>,
+    pub read_buf: ReadBuf,
     pub handshake: Handshake<ByteString>,
-    pub read_so_far: usize,
 }
 
 impl Session {
@@ -515,16 +512,11 @@ impl Session {
             .read_write_timeout
             .unwrap_or_else(|| Duration::from_secs(10));
 
-        let mut read_buf = vec![0u8; PIECE_MESSAGE_DEFAULT_LEN * 2];
-        let mut read_so_far = with_timeout(rwtimeout, stream.read(&mut read_buf))
+        let mut read_buf = ReadBuf::new();
+        let h = read_buf
+            .read_handshake(&mut stream, rwtimeout)
             .await
             .context("error reading handshake")?;
-        if read_so_far == 0 {
-            anyhow::bail!("bad handshake");
-        }
-        let (h, size) = Handshake::deserialize(&read_buf[..read_so_far])
-            .map_err(|e| anyhow::anyhow!("error deserializing handshake: {:?}", e))?;
-
         trace!("received handshake from {addr}: {:?}", h);
 
         if h.peer_id == self.peer_id.0 {
@@ -545,11 +537,6 @@ impl Session {
 
             let handshake = h.clone_to_owned();
 
-            if read_so_far > size {
-                read_buf.copy_within(size..read_so_far, 0);
-            }
-            read_so_far -= size;
-
             return Ok((
                 live,
                 CheckedIncomingConnection {
@@ -557,7 +544,6 @@ impl Session {
                     stream,
                     handshake,
                     read_buf,
-                    read_so_far,
                 },
             ));
         }

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -11,7 +11,7 @@ use std::{
 
 use anyhow::{bail, Context};
 use bencode::{bencode_serialize_to_writer, BencodeDeserializer};
-use buffers::{ByteBufT, ByteString};
+use buffers::{ByteBuf, ByteBufT, ByteString};
 use clone_to_owned::CloneToOwned;
 use dht::{
     Dht, DhtBuilder, DhtConfig, Id20, PersistentDht, PersistentDhtConfig, RequestPeersStream,
@@ -22,7 +22,9 @@ use librqbit_core::{
     magnet::Magnet,
     peer_id::generate_peer_id,
     spawn_utils::spawn_with_cancel,
-    torrent_metainfo::{torrent_from_bytes, TorrentMetaV1Info, TorrentMetaV1Owned},
+    torrent_metainfo::{
+        torrent_from_bytes as bencode_torrent_from_bytes, TorrentMetaV1Info, TorrentMetaV1Owned,
+    },
 };
 use parking_lot::RwLock;
 use peer_binary_protocol::{Handshake, PIECE_MESSAGE_DEFAULT_LEN};
@@ -48,6 +50,14 @@ use crate::{
 pub const SUPPORTED_SCHEMES: [&str; 3] = ["http:", "https:", "magnet:"];
 
 pub type TorrentId = usize;
+
+fn torrent_from_bytes(bytes: &[u8]) -> anyhow::Result<TorrentMetaV1Owned> {
+    debug!(
+        "all fields in torrent: {:#?}",
+        bencode::dyn_from_bytes::<ByteBuf>(bytes)
+    );
+    bencode_torrent_from_bytes(bytes)
+}
 
 #[derive(Default)]
 pub struct SessionDatabase {

--- a/crates/librqbit/src/torrent_state/live/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/mod.rs
@@ -457,7 +457,6 @@ impl TorrentStateLive {
             r = requester => {r}
             r = peer_connection.manage_peer_incoming(
                 rx,
-                checked_peer.read_so_far,
                 checked_peer.read_buf,
                 checked_peer.handshake,
                 checked_peer.stream


### PR DESCRIPTION
Working with peer read buffer was clumsy, there were a bunch of assumptions that code users needed to hold, encapsulated it into a ReadBuf struct.