### PR TITLE
Fix for #66

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -1867,7 +1867,7 @@ dependencies = [
 
 [[package]]
 name = "librqbit"
-version = "5.4.0"
+version = "5.4.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -1936,7 +1936,7 @@ version = "2.2.1"
 
 [[package]]
 name = "librqbit-core"
-version = "3.4.0"
+version = "3.5.0"
 dependencies = [
  "anyhow",
  "directories",
@@ -3022,7 +3022,7 @@ dependencies = [
 
 [[package]]
 name = "rqbit-desktop"
-version = "5.4.0"
+version = "5.4.1"
 dependencies = [
  "anyhow",
  "base64 0.21.5",


### PR DESCRIPTION
In https://github.com/ikatson/rqbit/issues/66 from a posted stacktrace it became clear that setting previously_requested_pieces may panic.

I found a place where it was not initialized - in "on_have" callback.

I wanted to fix that + make it less error-prone, however noticed that previously_requested_pieces isn't used at all anyway, because its use was removed during one of the recent refactorings.

As things seem to be working fine without it, just removed it to simplify code.