### PR TITLE
Make the announce info field optional

### DIFF
--- a/crates/librqbit/src/create_torrent_file.rs
+++ b/crates/librqbit/src/create_torrent_file.rs
@@ -200,7 +200,7 @@ pub async fn create_torrent<'a>(
     let info_hash = compute_info_hash(&info).context("error computing info hash")?;
     Ok(CreateTorrentResult {
         meta: TorrentMetaV1Owned {
-            announce: b""[..].into(),
+            announce: None,
             announce_list: Vec::new(),
             info,
             comment: None,

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -721,10 +721,7 @@ impl Session {
                 .map(|t| ByteString(t.into_bytes()))
                 .collect();
             let info = TorrentMetaV1Owned {
-                announce: trackers
-                    .first()
-                    .cloned()
-                    .unwrap_or_else(|| ByteString(b"http://retracker.local/announce".to_vec())),
+                announce: trackers.first().cloned(),
                 announce_list: vec![trackers],
                 info: storrent.info,
                 comment: None,

--- a/crates/librqbit_core/src/torrent_metainfo.rs
+++ b/crates/librqbit_core/src/torrent_metainfo.rs
@@ -29,7 +29,8 @@ pub fn torrent_from_bytes<'de, ByteBuf: Deserialize<'de>>(
 /// A parsed .torrent file.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct TorrentMetaV1<BufType> {
-    pub announce: BufType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub announce: Option<BufType>,
     #[serde(
         rename = "announce-list",
         default = "Vec::new",
@@ -59,7 +60,7 @@ impl<BufType> TorrentMetaV1<BufType> {
         if self.announce_list.iter().flatten().next().is_some() {
             return itertools::Either::Left(self.announce_list.iter().flatten());
         }
-        itertools::Either::Right(once(&self.announce))
+        itertools::Either::Right(self.announce.iter())
     }
 }
 


### PR DESCRIPTION
BEP 3 makes it seem like announce isn't optional, but in practice it is. This relaxes the constraint and makes a whole bunch of torrents that it borked on work.

I wasn't sure about the fallback with http://retracker.local/announce, I'm guessing that's not necessary if announce can now be optional.

I noticed Either is imported, but referred to in that part of the code with its full path. I left it alone, I think it's more readable knowing it's from itertools.