### PR TITLE
Remove info hash hacks and misc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1350,6 +1350,7 @@ dependencies = [
  "librqbit-bencode",
  "librqbit-buffers",
  "librqbit-clone-to-owned",
+ "librqbit-sha1-wrapper",
  "parking_lot",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1324,6 +1324,7 @@ dependencies = [
  "librqbit-buffers",
  "librqbit-clone-to-owned",
  "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2234,9 +2235,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,6 +1313,7 @@ dependencies = [
  "librqbit-buffers",
  "librqbit-clone-to-owned",
  "serde",
+ "serde_bytes",
  "serde_json",
 ]
 
@@ -1342,6 +1343,7 @@ dependencies = [
  "librqbit-sha1-wrapper",
  "parking_lot",
  "serde",
+ "serde_bytes",
  "serde_json",
  "tokio",
  "tokio-util",
@@ -2208,6 +2210,15 @@ dependencies = [
  "serde",
  "thiserror",
  "xml-rs",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,17 +96,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
-name = "async-recursion"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30c5ef0ede93efbf733c1a727f3b6b5a1060bbedd5600183e66f6e4be4af0ec5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1436,7 +1425,6 @@ name = "librqbit-upnp"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-recursion",
  "futures",
  "network-interface",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1323,7 +1323,6 @@ dependencies = [
  "anyhow",
  "librqbit-buffers",
  "librqbit-clone-to-owned",
- "librqbit-sha1-wrapper",
  "serde",
 ]
 

--- a/crates/bencode/Cargo.toml
+++ b/crates/bencode/Cargo.toml
@@ -15,6 +15,7 @@ serde = {version = "1", features=["derive"]}
 buffers = {path = "../buffers", package="librqbit-buffers", version = "2.2.1"}
 clone_to_owned = {path = "../clone_to_owned", package="librqbit-clone-to-owned", version = "2.2.1"}
 anyhow = "1"
+serde_bytes = "0.11.14"
 
 [dev-dependencies]
 serde_json = "1.0.115"

--- a/crates/bencode/Cargo.toml
+++ b/crates/bencode/Cargo.toml
@@ -15,3 +15,6 @@ serde = {version = "1", features=["derive"]}
 buffers = {path = "../buffers", package="librqbit-buffers", version = "2.2.1"}
 clone_to_owned = {path = "../clone_to_owned", package="librqbit-clone-to-owned", version = "2.2.1"}
 anyhow = "1"
+
+[dev-dependencies]
+serde_json = "1.0.115"

--- a/crates/bencode/Cargo.toml
+++ b/crates/bencode/Cargo.toml
@@ -10,15 +10,8 @@ readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[features]
-default = ["sha1-system"]
-sha1-system = ["sha1w/sha1-system"]
-sha1-openssl = ["sha1w/sha1-openssl"]
-sha1-rust = ["sha1w/sha1-rust"]
-
 [dependencies]
 serde = {version = "1", features=["derive"]}
 buffers = {path = "../buffers", package="librqbit-buffers", version = "2.2.1"}
 clone_to_owned = {path = "../clone_to_owned", package="librqbit-clone-to-owned", version = "2.2.1"}
 anyhow = "1"
-sha1w = {path="../sha1w", default-features=false, package="librqbit-sha1-wrapper", version="2.2.1"}

--- a/crates/bencode/src/bencode_value.rs
+++ b/crates/bencode/src/bencode_value.rs
@@ -96,7 +96,7 @@ where
 // A dynamic value when we don't know exactly what we are deserializing.
 // Useful for debugging.
 
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Clone)]
 pub enum BencodeValue<BufT: std::hash::Hash + Eq> {
     Bytes(BufT),
     Integer(i64),

--- a/crates/bencode/src/bencode_value.rs
+++ b/crates/bencode/src/bencode_value.rs
@@ -1,19 +1,19 @@
 use std::{collections::HashMap, marker::PhantomData};
 
-use buffers::{ByteBuf, ByteString};
+use buffers::{ByteBuf, ByteBufT, ByteString};
 use clone_to_owned::CloneToOwned;
 use serde::Deserializer;
 
-use crate::serde_bencode_de::from_bytes;
+use super::*;
 
-pub fn dyn_from_bytes<'de, BufT>(buf: &'de [u8]) -> anyhow::Result<BencodeValue<BufT>>
+pub fn dyn_from_bytes<'a, BufT>(buf: &'a [u8]) -> anyhow::Result<BencodeValue<BufT>>
 where
-    BufT: From<&'de [u8]> + std::hash::Hash + Eq,
+    BufT: BencodeValueBufConstraint + From<&'a [u8]>,
 {
     from_bytes(buf)
 }
 
-impl<BufT: serde::Serialize + Eq + std::hash::Hash> serde::Serialize for BencodeValue<BufT> {
+impl<BufT: serde::Serialize + BencodeValueBufConstraint> serde::Serialize for BencodeValue<BufT> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -29,7 +29,7 @@ impl<BufT: serde::Serialize + Eq + std::hash::Hash> serde::Serialize for Bencode
 
 impl<'de, BufT> serde::de::Deserialize<'de> for BencodeValue<BufT>
 where
-    BufT: From<&'de [u8]> + std::hash::Hash + Eq,
+    BufT: BencodeValueBufConstraint + From<&'de [u8]>,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -41,7 +41,7 @@ where
 
         impl<'de, BufT> serde::de::Visitor<'de> for Visitor<BufT>
         where
-            BufT: From<&'de [u8]> + std::hash::Hash + Eq,
+            BufT: BencodeValueBufConstraint + From<&'de [u8]>,
         {
             type Value = BencodeValue<BufT>;
 
@@ -56,6 +56,13 @@ where
                 Ok(BencodeValue::Integer(v))
             }
 
+            fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(BencodeValue::Bytes(BufT::from(v)))
+            }
+
             fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
             where
                 A: serde::de::SeqAccess<'de>,
@@ -65,13 +72,6 @@ where
                     v.push(value);
                 }
                 Ok(BencodeValue::List(v))
-            }
-
-            fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                Ok(BencodeValue::Bytes(BufT::from(v)))
             }
 
             fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
@@ -93,18 +93,32 @@ where
     }
 }
 
-// A dynamic value when we don't know exactly what we are deserializing.
-// Useful for debugging.
+pub trait BencodeValueBufConstraint: std::hash::Hash + Eq + ByteBufT {}
 
+impl<T> BencodeValueBufConstraint for T where T: std::hash::Hash + Eq + ByteBufT {}
+
+/// A dynamic value when we don't know exactly what we are deserializing.
+/// Useful for debugging.
 #[derive(PartialEq, Eq, Clone)]
-pub enum BencodeValue<BufT: std::hash::Hash + Eq> {
+pub enum BencodeValue<BufT: BencodeValueBufConstraint> {
     Bytes(BufT),
     Integer(i64),
     List(Vec<BencodeValue<BufT>>),
     Dict(HashMap<BufT, BencodeValue<BufT>>),
 }
 
-impl<BufT: std::fmt::Debug + std::hash::Hash + Eq> std::fmt::Debug for BencodeValue<BufT> {
+impl<BufT> BencodeValue<BufT>
+where
+    BufT: BencodeValueBufConstraint + serde::Serialize,
+{
+    pub fn to_bytes(&self) -> Result<Vec<u8>, SerError> {
+        let mut bytes = vec![];
+        bencode_serialize_to_writer(self, &mut bytes)?;
+        Ok(bytes)
+    }
+}
+
+impl<BufT: std::fmt::Debug + BencodeValueBufConstraint> std::fmt::Debug for BencodeValue<BufT> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             BencodeValue::Bytes(b) => std::fmt::Debug::fmt(b, f),
@@ -117,8 +131,8 @@ impl<BufT: std::fmt::Debug + std::hash::Hash + Eq> std::fmt::Debug for BencodeVa
 
 impl<BufT> CloneToOwned for BencodeValue<BufT>
 where
-    BufT: CloneToOwned + std::hash::Hash + Eq,
-    <BufT as CloneToOwned>::Target: Eq + std::hash::Hash,
+    BufT: CloneToOwned + BencodeValueBufConstraint,
+    <BufT as CloneToOwned>::Target: BencodeValueBufConstraint,
 {
     type Target = BencodeValue<<BufT as CloneToOwned>::Target>;
 
@@ -160,20 +174,21 @@ mod tests {
 
     #[test]
     fn test_serialize_torrent_dyn() {
-        let mut buf = Vec::new();
+        let mut file_buf = Vec::new();
         let filename = "../librqbit/resources/ubuntu-21.04-desktop-amd64.iso.torrent";
         std::fs::File::open(filename)
             .unwrap()
-            .read_to_end(&mut buf)
+            .read_to_end(&mut file_buf)
             .unwrap();
 
-        let torrent: BencodeValueBorrowed = from_bytes(&buf).unwrap();
+        let torrent: BencodeValueBorrowed = from_bytes(&file_buf).unwrap();
 
-        let mut buf = Vec::<u8>::new();
-        bencode_serialize_to_writer(&torrent, &mut buf).unwrap();
+        let mut ser_buf = Vec::<u8>::new();
+        bencode_serialize_to_writer(&torrent, &mut ser_buf).unwrap();
 
-        let new_torrent = from_bytes(&buf).unwrap();
+        let new_torrent = from_bytes(&ser_buf).unwrap();
         assert_eq!(torrent, new_torrent);
+        assert_eq!(ser_buf, file_buf);
     }
 
     #[test]
@@ -191,5 +206,25 @@ mod tests {
         let mut buf = Vec::<u8>::new();
         bencode_serialize_to_writer(&test, &mut buf).unwrap();
         assert_eq!(&buf, b"d2:f1i100ee");
+    }
+
+    #[test]
+    fn test_dict_ordering() -> anyhow::Result<()> {
+        let hash_map = HashMap::from_iter((0..1000).map(|x| {
+            (
+                ByteString::from(x.to_string().into_bytes()),
+                BencodeValue::Integer(x),
+            )
+        }));
+        dbg!(&hash_map);
+        let orig = BencodeValue::Dict(hash_map);
+        dbg!(&orig);
+        let first_buf: ByteString = orig.to_bytes()?.into();
+        dbg!(&first_buf);
+        let first_deser = from_bytes(&first_buf)?;
+        assert_eq!(orig, first_deser);
+        let second_buf = first_deser.to_bytes()?.into();
+        assert_eq!(first_buf, second_buf);
+        Ok(())
     }
 }

--- a/crates/bencode/src/lib.rs
+++ b/crates/bencode/src/lib.rs
@@ -1,9 +1,18 @@
 mod bencode_value;
+mod raw_value;
 mod serde_bencode_de;
 mod serde_bencode_ser;
 
 pub use bencode_value::*;
+pub use raw_value::*;
 pub use serde_bencode_de::*;
 pub use serde_bencode_ser::*;
+
+use std::collections::BTreeMap;
+use std::fmt::Formatter;
+
+use serde::de::{DeserializeOwned, Error as _, Visitor};
+use serde::ser::{Impossible, SerializeStruct};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 pub use buffers::{ByteBuf, ByteString};

--- a/crates/bencode/src/lib.rs
+++ b/crates/bencode/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::used_underscore_binding)]
+
 mod bencode_value;
 mod raw_value;
 mod serde_bencode_de;

--- a/crates/bencode/src/lib.rs
+++ b/crates/bencode/src/lib.rs
@@ -5,6 +5,8 @@ mod raw_value;
 mod serde_bencode_de;
 mod serde_bencode_ser;
 
+pub use buffers::{ByteBuf, ByteString};
+
 pub use bencode_value::*;
 pub use raw_value::*;
 pub use serde_bencode_de::*;
@@ -12,9 +14,32 @@ pub use serde_bencode_ser::*;
 
 use std::collections::BTreeMap;
 use std::fmt::Formatter;
+use std::marker::PhantomData;
 
-use serde::de::{DeserializeOwned, Error as _, Visitor};
-use serde::ser::{Impossible, SerializeStruct};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{
+    de::{
+        value::BorrowedBytesDeserializer,
+        MapAccess,
+        DeserializeOwned,
+        Error as _,
+        Visitor
+    },
+    ser::{Impossible, SerializeStruct, Error as _},
+    Deserialize,
+    Deserializer,
+    Serialize,
+    Serializer
+};
 
-pub use buffers::{ByteBuf, ByteString};
+use clone_to_owned::CloneToOwned;
+
+fn escape_bytes(bytes: &[u8]) -> String {
+    String::from_utf8(
+        bytes
+            .iter()
+            .copied()
+            .flat_map(std::ascii::escape_default)
+            .collect(),
+    )
+    .unwrap()
+}

--- a/crates/bencode/src/lib.rs
+++ b/crates/bencode/src/lib.rs
@@ -18,7 +18,7 @@ use std::marker::PhantomData;
 
 use serde::{
     de::{value::BorrowedBytesDeserializer, DeserializeOwned, Error as _, MapAccess, Visitor},
-    ser::{Impossible},
+    ser::Impossible,
     Deserialize, Deserializer, Serialize, Serializer,
 };
 

--- a/crates/bencode/src/lib.rs
+++ b/crates/bencode/src/lib.rs
@@ -17,18 +17,9 @@ use std::fmt::Formatter;
 use std::marker::PhantomData;
 
 use serde::{
-    de::{
-        value::BorrowedBytesDeserializer,
-        MapAccess,
-        DeserializeOwned,
-        Error as _,
-        Visitor
-    },
-    ser::{Impossible, SerializeStruct, Error as _},
-    Deserialize,
-    Deserializer,
-    Serialize,
-    Serializer
+    de::{value::BorrowedBytesDeserializer, DeserializeOwned, Error as _, MapAccess, Visitor},
+    ser::{Impossible},
+    Deserialize, Deserializer, Serialize, Serializer,
 };
 
 use clone_to_owned::CloneToOwned;

--- a/crates/bencode/src/raw_value.rs
+++ b/crates/bencode/src/raw_value.rs
@@ -5,7 +5,7 @@ use serde::ser::Error;
 pub struct RawValue<T>(pub T);
 
 // This can't go in RawValue because it doesn't depend on T.
-pub(crate) const TOKEN: &str = "$librq_bencode::private::RawValue";
+pub(crate) const TOKEN: &str = "$librqbit_bencode::private::RawValue";
 
 impl<T> Serialize for RawValue<T>
 where

--- a/crates/bencode/src/raw_value.rs
+++ b/crates/bencode/src/raw_value.rs
@@ -1,0 +1,260 @@
+use super::*;
+use serde::ser::Error;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RawValue<T>(pub T);
+
+// This can't go in RawValue because it doesn't depend on T.
+pub(crate) const TOKEN: &str = "$librq_bencode::private::RawValue";
+
+impl<T> Serialize for RawValue<T>
+where
+    T: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut s = serializer.serialize_struct(TOKEN, 1)?;
+        s.serialize_field(TOKEN, &self.0)?;
+        s.end()
+    }
+}
+
+impl<'de, T> Deserialize<'de> for RawValue<T>
+where
+    T: From<&'de [u8]>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct V;
+        impl<'de> Visitor<'de> for V {
+            type Value = &'de [u8];
+
+            fn expecting(&self, _formatter: &mut Formatter) -> std::fmt::Result {
+                todo!()
+            }
+
+            fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(v)
+            }
+        }
+        deserializer
+            .deserialize_newtype_struct(TOKEN, V)
+            .map(|x| RawValue(x.into()))
+    }
+}
+
+impl<T> std::ops::Deref for RawValue<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+pub(crate) struct SerializeRawValue<'ser, W: std::io::Write> {
+    pub(crate) ser: &'ser mut BencodeSerializer<W>,
+}
+
+impl<'ser, W: std::io::Write> serde::ser::SerializeStruct for SerializeRawValue<'ser, W> {
+    type Ok = ();
+    type Error = SerError;
+
+    fn serialize_field<T: ?Sized>(
+        &mut self,
+        key: &'static str,
+        value: &T,
+    ) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        assert_eq!(key, TOKEN);
+        value.serialize(RawValueSerializer(self.ser))
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+}
+
+pub(crate) struct RawValueSerializer<'ser, W: std::io::Write>(&'ser mut BencodeSerializer<W>);
+
+impl<'ser, W: std::io::Write> RawValueSerializer<'ser, W> {
+    fn expected_err<T>() -> Result<T, SerError> {
+        Err(SerError::custom("expected RawValue"))
+    }
+}
+
+impl<'ser, W: std::io::Write> Serializer for RawValueSerializer<'ser, W> {
+    type Ok = ();
+    type Error = SerError;
+    type SerializeSeq = Impossible<(), SerError>;
+    type SerializeTuple = Impossible<(), SerError>;
+    type SerializeTupleStruct = Impossible<(), SerError>;
+    type SerializeTupleVariant = Impossible<(), SerError>;
+    type SerializeMap = Impossible<(), SerError>;
+    type SerializeStruct = Impossible<(), SerError>;
+    type SerializeStructVariant = Impossible<(), SerError>;
+
+    fn serialize_bool(self, _v: bool) -> Result<Self::Ok, Self::Error> {
+        Self::expected_err()
+    }
+
+    fn serialize_i8(self, _v: i8) -> Result<Self::Ok, Self::Error> {
+        Self::expected_err()
+    }
+
+    fn serialize_i16(self, _v: i16) -> Result<Self::Ok, Self::Error> {
+        Self::expected_err()
+    }
+
+    fn serialize_i32(self, _v: i32) -> Result<Self::Ok, Self::Error> {
+        Self::expected_err()
+    }
+
+    fn serialize_i64(self, _v: i64) -> Result<Self::Ok, Self::Error> {
+        Self::expected_err()
+    }
+
+    fn serialize_u8(self, _v: u8) -> Result<Self::Ok, Self::Error> {
+        Self::expected_err()
+    }
+
+    fn serialize_u16(self, _v: u16) -> Result<Self::Ok, Self::Error> {
+        Self::expected_err()
+    }
+
+    fn serialize_u32(self, _v: u32) -> Result<Self::Ok, Self::Error> {
+        Self::expected_err()
+    }
+
+    fn serialize_u64(self, _v: u64) -> Result<Self::Ok, Self::Error> {
+        Self::expected_err()
+    }
+
+    fn serialize_f32(self, _v: f32) -> Result<Self::Ok, Self::Error> {
+        Self::expected_err()
+    }
+
+    fn serialize_f64(self, _v: f64) -> Result<Self::Ok, Self::Error> {
+        Self::expected_err()
+    }
+
+    fn serialize_char(self, _v: char) -> Result<Self::Ok, Self::Error> {
+        Self::expected_err()
+    }
+
+    fn serialize_str(self, _v: &str) -> Result<Self::Ok, Self::Error> {
+        Self::expected_err()
+    }
+
+    fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        self.0.write_raw(v)
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        Self::expected_err()
+    }
+
+    fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        Self::expected_err()
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Self::expected_err()
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        Self::expected_err()
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        Self::expected_err()
+    }
+
+    fn serialize_newtype_struct<T: ?Sized>(
+        self,
+        _name: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        Self::expected_err()
+    }
+
+    fn serialize_newtype_variant<T: ?Sized>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        Self::expected_err()
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        Self::expected_err()
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        Self::expected_err()
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        Self::expected_err()
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        Self::expected_err()
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        Self::expected_err()
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        Self::expected_err()
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        Self::expected_err()
+    }
+}

--- a/crates/bencode/src/serde_bencode_de.rs
+++ b/crates/bencode/src/serde_bencode_de.rs
@@ -1,5 +1,7 @@
+use crate::{bencode_serialize_to_writer, BencodeValue, BencodeValueOwned};
 use buffers::ByteBuf;
-use serde::de::Error as DeError;
+use serde::de::{DeserializeOwned, Error as DeError};
+use serde::Deserialize;
 use sha1w::{ISha1, Sha1};
 
 pub struct BencodeDeserializer<'de> {
@@ -564,4 +566,13 @@ impl<'a, 'de> serde::de::SeqAccess<'de> for SeqAccess<'a, 'de> {
         }
         Ok(Some(seed.deserialize(&mut *self.de)?))
     }
+}
+
+pub fn from_value<'a, T>(value: BencodeValueOwned) -> anyhow::Result<T>
+where
+    T: DeserializeOwned,
+{
+    let mut bytes = vec![];
+    bencode_serialize_to_writer(value, &mut bytes)?;
+    from_bytes(&bytes)
 }

--- a/crates/bencode/src/serde_bencode_de.rs
+++ b/crates/bencode/src/serde_bencode_de.rs
@@ -27,7 +27,7 @@ impl<'de> BencodeDeserializer<'de> {
     pub fn into_remaining(self) -> &'de [u8] {
         self.raw_buf
     }
-    
+
     fn parse_integer(&mut self) -> Result<i64, Error> {
         match self.buf().iter().copied().position(|e| e == b'e') {
             Some(end) => {
@@ -63,14 +63,7 @@ impl<'de> BencodeDeserializer<'de> {
                         format!(
                             "could not get byte range {:?}, data in the buffer: {:?}",
                             slice_index,
-                            String::from_utf8(
-                                self.buf()
-                                    .iter()
-                                    .copied()
-                                    .flat_map(std::ascii::escape_default)
-                                    .collect()
-                            )
-                            .unwrap()
+                            escape_bytes(self.buf())
                         ),
                         self,
                     )

--- a/crates/bencode/src/serde_bencode_de.rs
+++ b/crates/bencode/src/serde_bencode_de.rs
@@ -1,8 +1,8 @@
-use crate::{bencode_serialize_to_writer, BencodeValue, BencodeValueOwned};
-use buffers::ByteBuf;
 use serde::de::{DeserializeOwned, Error as DeError};
-use serde::Deserialize;
-use sha1w::{ISha1, Sha1};
+
+use buffers::ByteBuf;
+
+use crate::{bencode_serialize_to_writer, BencodeValueOwned};
 
 pub struct BencodeDeserializer<'de> {
     buf: &'de [u8],
@@ -533,7 +533,6 @@ impl<'a, 'de> serde::de::MapAccess<'de> for MapAccess<'a, 'de> {
     where
         V: serde::de::DeserializeSeed<'de>,
     {
-        let buf_before = self.de.buf;
         let value = seed.deserialize(&mut *self.de)?;
         self.de.field_context.pop();
         Ok(value)
@@ -555,7 +554,7 @@ impl<'a, 'de> serde::de::SeqAccess<'de> for SeqAccess<'a, 'de> {
     }
 }
 
-pub fn from_value<'a, T>(value: BencodeValueOwned) -> anyhow::Result<T>
+pub fn from_value<T>(value: BencodeValueOwned) -> anyhow::Result<T>
 where
     T: DeserializeOwned,
 {

--- a/crates/bencode/src/serde_bencode_de.rs
+++ b/crates/bencode/src/serde_bencode_de.rs
@@ -436,16 +436,16 @@ impl<'de, 'a> serde::de::Deserializer<'de> for &'a mut BencodeDeserializer<'de> 
 
     fn deserialize_newtype_struct<V>(
         self,
-        _name: &'static str,
-        _visitor: V,
+        name: &'static str,
+        visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        if _name == TOKEN {
+        if name == TOKEN {
             self.start_raw();
             self.deserialize_any(serde::de::IgnoredAny)?;
-            _visitor.visit_borrowed_bytes(self.end_raw())
+            visitor.visit_borrowed_bytes(self.end_raw())
         } else {
             Err(Error::new_from_kind(ErrorKind::NotSupported("newtype structs")).set_context(self))
         }

--- a/crates/bencode/src/serde_bencode_ser.rs
+++ b/crates/bencode/src/serde_bencode_ser.rs
@@ -487,10 +487,10 @@ impl<'ser, W: std::io::Write> Serializer for &'ser mut BencodeSerializer<W> {
 
     fn serialize_struct(
         self,
-        _name: &'static str,
+        name: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStruct, Self::Error> {
-        if _name == TOKEN {
+        if name == TOKEN {
             return Ok(SerializeStructCompound::RawValue(SerializeRawValue {
                 ser: self,
             }));

--- a/crates/bencode/src/serde_bencode_ser.rs
+++ b/crates/bencode/src/serde_bencode_ser.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 
 use serde::{Serialize, Serializer};
 
+use crate::{dyn_from_bytes, BencodeValueOwned};
 use buffers::ByteString;
 
 #[derive(Debug)]
@@ -488,4 +489,10 @@ pub fn bencode_serialize_to_writer<T: Serialize, W: std::io::Write>(
     let mut serializer = BencodeSerializer::new(writer);
     value.serialize(&mut serializer)?;
     Ok(())
+}
+
+pub fn serialize_to_value(value: impl Serialize) -> anyhow::Result<BencodeValueOwned> {
+    let mut bytes = vec![];
+    bencode_serialize_to_writer(value, &mut bytes)?;
+    dyn_from_bytes(&bytes)
 }

--- a/crates/buffers/src/lib.rs
+++ b/crates/buffers/src/lib.rs
@@ -4,6 +4,8 @@
 // Not useful outside of librqbit.
 
 use serde::{Deserialize, Deserializer};
+use serde::de::SeqAccess;
+use serde::de::value::SeqAccessDeserializer;
 
 use clone_to_owned::CloneToOwned;
 
@@ -188,6 +190,10 @@ impl<'de> serde::de::Deserialize<'de> for ByteString {
                 E: serde::de::Error,
             {
                 Ok(v.to_owned())
+            }
+
+            fn visit_seq<A>(self, seq: A) -> Result<Self::Value, A::Error> where A: SeqAccess<'de> {
+                Self::Value::deserialize(SeqAccessDeserializer::new(seq))
             }
         }
         Ok(ByteString(deserializer.deserialize_byte_buf(Visitor {})?))

--- a/crates/clone_to_owned/src/lib.rs
+++ b/crates/clone_to_owned/src/lib.rs
@@ -9,7 +9,7 @@
 use std::collections::HashMap;
 
 pub trait CloneToOwned {
-    type Target;
+    type Target: 'static;
 
     fn clone_to_owned(&self) -> Self::Target;
 }

--- a/crates/dht/Cargo.toml
+++ b/crates/dht/Cargo.toml
@@ -10,12 +10,6 @@ readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[features]
-default = ["sha1-system"]
-sha1-system = ["bencode/sha1-system", "librqbit-core/sha1-system"]
-sha1-openssl = ["bencode/sha1-openssl", "librqbit-core/sha1-openssl"]
-sha1-rust = ["bencode/sha1-rust", "librqbit-core/sha1-rust"]
-
 [dependencies]
 tokio = {version = "1", features = ["macros", "rt-multi-thread", "net", "sync"]}
 tokio-stream = {version = "0.1", features = ["sync"]}

--- a/crates/dht/examples/dht.rs
+++ b/crates/dht/examples/dht.rs
@@ -12,7 +12,9 @@ async fn main() -> anyhow::Result<()> {
         .nth(1)
         .expect("first argument should be a magnet link");
     let magnet = Magnet::parse(&magnet).unwrap();
-    let info_hash = magnet.as_id20().context("Supplied magnet link didn't contain a BTv1 infohash")?;
+    let info_hash = magnet
+        .as_id20()
+        .context("Supplied magnet link didn't contain a BTv1 infohash")?;
 
     tracing_subscriber::fmt::init();
 

--- a/crates/dht/src/bprotocol.rs
+++ b/crates/dht/src/bprotocol.rs
@@ -583,6 +583,7 @@ mod tests {
         let mut f = std::fs::OpenOptions::new()
             .create(true)
             .write(true)
+            .truncate(true)
             .open(full)
             .unwrap();
         f.write_all(data).unwrap()

--- a/crates/librqbit/src/create_torrent_file.rs
+++ b/crates/librqbit/src/create_torrent_file.rs
@@ -175,7 +175,7 @@ pub async fn create_torrent<'a>(
     options: CreateTorrentOptions<'a>,
 ) -> anyhow::Result<CreateTorrentResult> {
     let info = create_torrent_raw(path, options).await?;
-    let info = bencode::serialize_to_value(info)?;
+    let info = Some(bencode::RawValue( bencode::to_bytes(info)?.into()));
     Ok(CreateTorrentResult {
         meta: TorrentMetaV1Owned {
             announce: None,

--- a/crates/librqbit/src/create_torrent_file.rs
+++ b/crates/librqbit/src/create_torrent_file.rs
@@ -160,7 +160,7 @@ impl CreateTorrentResult {
     }
 
     pub fn info_hash(&self) -> Id20 {
-        self.meta.v1_info_hash()
+        self.meta.v1_hash_info().expect("info to be present")
     }
 
     pub fn as_bytes(&self) -> anyhow::Result<Vec<u8>> {
@@ -175,7 +175,7 @@ pub async fn create_torrent<'a>(
     options: CreateTorrentOptions<'a>,
 ) -> anyhow::Result<CreateTorrentResult> {
     let info = create_torrent_raw(path, options).await?;
-    let info = Some(bencode::RawValue( bencode::to_bytes(info)?.into()));
+    let info = Some(bencode::RawValue(bencode::to_bytes(info)?.into()));
     Ok(CreateTorrentResult {
         meta: TorrentMetaV1Owned {
             announce: None,
@@ -214,6 +214,6 @@ mod tests {
         let bytes = torrent.as_bytes().unwrap();
 
         let deserialized = torrent_from_bytes::<ByteBuf>(&bytes).unwrap();
-        assert_eq!(torrent.info_hash(), deserialized.v1_info_hash());
+        assert_eq!(Some(torrent.info_hash()), deserialized.v1_hash_info());
     }
 }

--- a/crates/librqbit/src/create_torrent_file.rs
+++ b/crates/librqbit/src/create_torrent_file.rs
@@ -8,6 +8,7 @@ use bencode::bencode_serialize_to_writer;
 use buffers::ByteString;
 use librqbit_core::torrent_metainfo::{TorrentMetaV1File, TorrentMetaV1Info, TorrentMetaV1Owned};
 use librqbit_core::Id20;
+use serde::Serialize;
 use sha1w::{ISha1, Sha1};
 
 use crate::spawn_utils::BlockingSpawner;
@@ -197,12 +198,13 @@ pub async fn create_torrent<'a>(
     options: CreateTorrentOptions<'a>,
 ) -> anyhow::Result<CreateTorrentResult> {
     let info = create_torrent_raw(path, options).await?;
+    let info_value = bencode::serialize_to_value(&info)?;
     let info_hash = compute_info_hash(&info).context("error computing info hash")?;
     Ok(CreateTorrentResult {
         meta: TorrentMetaV1Owned {
             announce: None,
             announce_list: Vec::new(),
-            info,
+            info: info_value,
             comment: None,
             created_by: None,
             encoding: Some(b"utf-8"[..].into()),

--- a/crates/librqbit/src/create_torrent_file.rs
+++ b/crates/librqbit/src/create_torrent_file.rs
@@ -175,7 +175,7 @@ pub async fn create_torrent<'a>(
     options: CreateTorrentOptions<'a>,
 ) -> anyhow::Result<CreateTorrentResult> {
     let info = create_torrent_raw(path, options).await?;
-    let info = Some(bencode::RawValue(bencode::to_bytes(info)?.into()));
+    let info = Some(bencode::RawValue::new(bencode::to_bytes(info)?.into()));
     Ok(CreateTorrentResult {
         meta: TorrentMetaV1Owned {
             announce: None,

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -720,10 +720,11 @@ impl Session {
                 .into_iter()
                 .map(|t| ByteString(t.into_bytes()))
                 .collect();
-            let info = TorrentMetaV1Owned {
+            let info_value = bencode::serialize_to_value(storrent.info)?;
+            let meta_info = TorrentMetaV1Owned {
                 announce: trackers.first().cloned(),
                 announce_list: vec![trackers],
-                info: storrent.info,
+                info: info_value,
                 comment: None,
                 created_by: None,
                 encoding: None,
@@ -737,7 +738,7 @@ impl Session {
                 async move {
                     session
                         .add_torrent(
-                            AddTorrent::TorrentInfo(Box::new(info)),
+                            AddTorrent::TorrentInfo(Box::new(meta_info)),
                             Some(AddTorrentOptions {
                                 paused: storrent.is_paused,
                                 output_folder: Some(
@@ -902,7 +903,7 @@ impl Session {
 
                     (
                         torrent.info_hash,
-                        torrent.info,
+                        bencode::from_value(torrent.info)?,
                         trackers,
                         peer_rx,
                         opts.initial_peers

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -688,7 +688,7 @@ impl Session {
                 .into_iter()
                 .map(|t| ByteString(t.into_bytes()))
                 .collect();
-            let info = Some(bencode::RawValue(storrent.info));
+            let info = Some(bencode::RawValue::new(storrent.info));
             let meta_info = TorrentMetaV1Owned {
                 announce: trackers.first().cloned(),
                 announce_list: vec![trackers],

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -4,7 +4,6 @@ use std::{
     io::{BufReader, BufWriter, Read},
     net::SocketAddr,
     path::PathBuf,
-    str::FromStr,
     sync::Arc,
     time::Duration,
 };

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -731,7 +731,6 @@ impl Session {
                 publisher: None,
                 publisher_url: None,
                 creation_date: None,
-                info_hash: Id20::from_str(&storrent.info_hash)?,
             };
             futures.push({
                 let session = self.clone();
@@ -894,7 +893,7 @@ impl Session {
                         None
                     } else {
                         self.make_peer_rx(
-                            torrent.info_hash,
+                            torrent.v1_info_hash(),
                             trackers.clone(),
                             announce_port,
                             opts.force_tracker_interval,
@@ -902,7 +901,7 @@ impl Session {
                     };
 
                     (
-                        torrent.info_hash,
+                        torrent.v1_info_hash(),
                         bencode::from_value(torrent.info)?,
                         trackers,
                         peer_rx,

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -688,7 +688,7 @@ impl Session {
                 .into_iter()
                 .map(|t| ByteString(t.into_bytes()))
                 .collect();
-            let info=Some(bencode::RawValue(storrent.info));
+            let info = Some(bencode::RawValue(storrent.info));
             let meta_info = TorrentMetaV1Owned {
                 announce: trackers.first().cloned(),
                 announce_list: vec![trackers],
@@ -861,7 +861,7 @@ impl Session {
                         None
                     } else {
                         self.make_peer_rx(
-                            torrent.v1_info_hash(),
+                            torrent.v1_hash_info().unwrap(),
                             trackers.clone(),
                             announce_port,
                             opts.force_tracker_interval,
@@ -869,7 +869,7 @@ impl Session {
                     };
 
                     (
-                        torrent.v1_info_hash(),
+                        torrent.v1_hash_info().unwrap(),
                         bencode::from_bytes(&torrent.info.ok_or(anyhow!("missing info"))?)?,
                         trackers,
                         peer_rx,

--- a/crates/librqbit/src/torrent_state/initializing.rs
+++ b/crates/librqbit/src/torrent_state/initializing.rs
@@ -58,6 +58,7 @@ impl TorrentStateInitializing {
                         .create(true)
                         .read(true)
                         .write(true)
+                        .truncate(false)
                         .open(&full_path)
                         .with_context(|| {
                             format!("error opening {full_path:?} in read/write mode")

--- a/crates/librqbit/src/torrent_state/mod.rs
+++ b/crates/librqbit/src/torrent_state/mod.rs
@@ -78,6 +78,7 @@ pub(crate) struct ManagedTorrentOptions {
 }
 
 pub struct ManagedTorrentInfo {
+    pub info_bytes: ByteString,
     pub info: TorrentMetaV1Info<ByteString>,
     pub info_hash: Id20,
     pub out_dir: PathBuf,
@@ -488,6 +489,7 @@ impl ManagedTorrentBuilder {
         let lengths = Lengths::from_torrent(&self.info)?;
         let info = Arc::new(ManagedTorrentInfo {
             span,
+            info_bytes: bencode::to_bytes(&self.info)?.into(),
             info: self.info,
             info_hash: self.info_hash,
             out_dir: self.output_folder,

--- a/crates/librqbit_core/Cargo.toml
+++ b/crates/librqbit_core/Cargo.toml
@@ -10,12 +10,6 @@ readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[features]
-default = ["sha1-system"]
-sha1-system = ["bencode/sha1-system"]
-sha1-openssl = ["bencode/sha1-openssl"]
-sha1-rust = ["bencode/sha1-rust"]
-
 [dependencies]
 tracing = "0.1.40"
 tokio = {version = "1", features = ["rt-multi-thread", "macros", "time"]}

--- a/crates/librqbit_core/Cargo.toml
+++ b/crates/librqbit_core/Cargo.toml
@@ -31,6 +31,7 @@ clone_to_owned = {path="../clone_to_owned", package="librqbit-clone-to-owned", v
 itertools = "0.12"
 directories = "5"
 tokio-util = "0.7.10"
+sha1w = {path="../sha1w", default-features=false, package="librqbit-sha1-wrapper", version="2.2.1"}
 
 [dev-dependencies]
 serde_json = "1"

--- a/crates/librqbit_core/Cargo.toml
+++ b/crates/librqbit_core/Cargo.toml
@@ -26,6 +26,7 @@ itertools = "0.12"
 directories = "5"
 tokio-util = "0.7.10"
 sha1w = {path="../sha1w", default-features=false, package="librqbit-sha1-wrapper", version="2.2.1"}
+serde_bytes = "0.11.14"
 
 [dev-dependencies]
 serde_json = "1"

--- a/crates/librqbit_core/src/hash_id.rs
+++ b/crates/librqbit_core/src/hash_id.rs
@@ -69,8 +69,8 @@ impl<const N: usize> FromStr for Id<N> {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut out = [0u8; N];
-        if s.len() != N*2 {
-            anyhow::bail!("expected a hex string of length {}", N*2)
+        if s.len() != N * 2 {
+            anyhow::bail!("expected a hex string of length {}", N * 2)
         };
         hex::decode_to_slice(s, &mut out)?;
         Ok(Id(out))
@@ -97,8 +97,9 @@ impl<'de, const N: usize> Deserialize<'de> for Id<N> {
             type Value = Id<N>;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-                formatter.write_str("a byte array of length ")
-                         .and_then(|_| formatter.write_fmt(format_args!("{}", N)))
+                formatter
+                    .write_str("a byte array of length ")
+                    .and_then(|_| formatter.write_fmt(format_args!("{}", N)))
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
@@ -135,7 +136,7 @@ impl<'de, const N: usize> Deserialize<'de> for Id<N> {
             }
         }
 
-        deserializer.deserialize_any(IdVisitor{})
+        deserializer.deserialize_any(IdVisitor {})
     }
 }
 
@@ -165,8 +166,8 @@ pub type Id32 = Id<32>;
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
     use super::*;
+    use std::str::FromStr;
 
     #[test]
     fn test_set_bit_range() {
@@ -183,5 +184,4 @@ mod tests {
         let str = "06f04cc728bef957a658876ef807f0514e4d715392969998efef584d2c3e435e";
         let _ih = Id32::from_str(str).unwrap();
     }
-
 }

--- a/crates/librqbit_core/src/torrent_metainfo.rs
+++ b/crates/librqbit_core/src/torrent_metainfo.rs
@@ -22,9 +22,11 @@ pub fn torrent_from_bytes<'de, ByteBuf: Deserialize<'de>>(
     Ok(t)
 }
 
+type RawInfo = bencode::RawValue<ByteString>;
+
 /// A parsed .torrent file.
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TorrentMetaV1<BufType> {
+pub struct TorrentMetaV1<BufType>  {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub announce: Option<BufType>,
     #[serde(
@@ -33,7 +35,7 @@ pub struct TorrentMetaV1<BufType> {
         skip_serializing_if = "Vec::is_empty"
     )]
     pub announce_list: Vec<Vec<BufType>>,
-    pub info: RawInfo,
+    pub info: Option<RawInfo>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub comment: Option<BufType>,
     #[serde(rename = "created by", skip_serializing_if = "Option::is_none")]
@@ -63,8 +65,6 @@ impl<BufType> TorrentMetaV1<BufType> {
         Id20::new(h.finish())
     }
 }
-
-type RawInfo = bencode::BencodeValueOwned;
 
 /// Main torrent information, shared by .torrent files and magnet link contents.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -264,7 +264,7 @@ where
         TorrentMetaV1 {
             announce: self.announce.clone_to_owned(),
             announce_list: self.announce_list.clone_to_owned(),
-            info: self.info.clone_to_owned(),
+            info: self.info.clone(),
             comment: self.comment.clone_to_owned(),
             created_by: self.created_by.clone_to_owned(),
             encoding: self.encoding.clone_to_owned(),
@@ -336,6 +336,6 @@ mod tests {
         let deserialized =
             RawInfo::deserialize(&mut BencodeDeserializer::new_from_buf(&writer)).unwrap();
 
-        assert_eq!(torrent, deserialized);
+        assert_eq!(torrent, Some(deserialized));
     }
 }

--- a/crates/librqbit_core/src/torrent_metainfo.rs
+++ b/crates/librqbit_core/src/torrent_metainfo.rs
@@ -8,7 +8,7 @@ use itertools::Either;
 use serde::{Deserialize, Serialize};
 
 use crate::hash_id::Id20;
-use sha1w::{ISha1, Sha1};
+use sha1w::ISha1;
 
 pub type TorrentMetaV1Borrowed<'a> = TorrentMetaV1<ByteBuf<'a>>;
 pub type TorrentMetaV1Owned = TorrentMetaV1<ByteString>;
@@ -18,7 +18,7 @@ pub fn torrent_from_bytes<'de, ByteBuf: Deserialize<'de>>(
     buf: &'de [u8],
 ) -> anyhow::Result<TorrentMetaV1<ByteBuf>> {
     let mut de = BencodeDeserializer::new_from_buf(buf);
-    let mut t = TorrentMetaV1::deserialize(&mut de)?;
+    let t = TorrentMetaV1::deserialize(&mut de)?;
     Ok(t)
 }
 

--- a/crates/librqbit_core/src/torrent_metainfo.rs
+++ b/crates/librqbit_core/src/torrent_metainfo.rs
@@ -334,10 +334,8 @@ mod tests {
         let torrent = torrent_from_bytes::<ByteString>(&buf).unwrap().info;
         let mut writer = Vec::new();
         bencode::bencode_serialize_to_writer(&torrent, &mut writer).unwrap();
-        let deserialized = RawInfo::deserialize(
-            &mut BencodeDeserializer::new_from_buf(&writer),
-        )
-        .unwrap();
+        let deserialized =
+            RawInfo::deserialize(&mut BencodeDeserializer::new_from_buf(&writer)).unwrap();
 
         assert_eq!(torrent, deserialized);
     }

--- a/crates/librqbit_core/src/torrent_metainfo.rs
+++ b/crates/librqbit_core/src/torrent_metainfo.rs
@@ -5,17 +5,17 @@ use itertools::Either;
 use serde::{Deserialize, Serialize};
 
 use bencode::BencodeDeserializer;
-use buffers::{ByteBuf, ByteBufT, ByteString};
+use buffers::{ByteBuf, ByteString};
 use clone_to_owned::CloneToOwned;
 use sha1w::ISha1;
 
 use crate::hash_id::Id20;
 
-pub type TorrentMetaV1Borrowed<'a> = TorrentMetaV1<ByteBuf<'a>>;
-pub type TorrentMetaV1Owned = TorrentMetaV1<ByteString>;
+pub type TorrentMetaV1Borrowed<'a> = TorrentMetaV1<'a, ByteBuf<'a>>;
+pub type TorrentMetaV1Owned = TorrentMetaV1<'static, ByteString>;
 
 /// Parse torrent metainfo from bytes.
-pub fn torrent_from_bytes<'de, ByteBuf: Deserialize<'de> + ByteBufT>(
+pub fn torrent_from_bytes<'de, ByteBuf: Deserialize<'de>+TorrentMetaV1BufTypeConstraints<'de>>(
     buf: &'de [u8],
 ) -> anyhow::Result<TorrentMetaV1<ByteBuf>> {
     let mut de = BencodeDeserializer::new_from_buf(buf);
@@ -24,17 +24,17 @@ pub fn torrent_from_bytes<'de, ByteBuf: Deserialize<'de> + ByteBufT>(
 }
 
 /// Info as pristine bytes.
-type RawInfo<BufType> = bencode::RawValue<BufType>;
+type RawInfo<'a, BufType> = bencode::RawValue<'a, BufType>;
 
 /// Constraints on embedded raw info. Ensures the buffer type supports visiting by bytes during
 /// deserialization. Vec<u8> expects a sequence.
-pub trait TorrentMetaV1BufTypeConstraints: ByteBufT {}
+pub trait TorrentMetaV1BufTypeConstraints<'a>: AsRef<[u8]>+serde_bytes::Deserialize<'a> {}
 
-impl<T: ByteBufT> TorrentMetaV1BufTypeConstraints for T {}
+impl<'a, T: AsRef<[u8]>+serde_bytes::Deserialize<'a>> TorrentMetaV1BufTypeConstraints<'a> for T {}
 
 /// A parsed .torrent file.
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TorrentMetaV1<BufType: TorrentMetaV1BufTypeConstraints> {
+pub struct TorrentMetaV1<'a, BufType: TorrentMetaV1BufTypeConstraints<'a>> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub announce: Option<BufType>,
     #[serde(
@@ -45,7 +45,8 @@ pub struct TorrentMetaV1<BufType: TorrentMetaV1BufTypeConstraints> {
     pub announce_list: Vec<Vec<BufType>>,
     /// Unmodified bytes corresponding to the info value. Used for computing infohash and
     /// communicated to peers via the metadata extension.
-    pub info: Option<RawInfo<BufType>>,
+    #[serde(borrow = "'a")]
+    pub info: Option<RawInfo<'a, BufType>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub comment: Option<BufType>,
     #[serde(rename = "created by", skip_serializing_if = "Option::is_none")]
@@ -60,7 +61,7 @@ pub struct TorrentMetaV1<BufType: TorrentMetaV1BufTypeConstraints> {
     pub creation_date: Option<usize>,
 }
 
-impl<BufType: TorrentMetaV1BufTypeConstraints> TorrentMetaV1<BufType> {
+impl<'a, BufType: TorrentMetaV1BufTypeConstraints<'a>> TorrentMetaV1<'a, BufType> {
     pub fn iter_announce(&self) -> impl Iterator<Item = &BufType> {
         if self.announce_list.iter().flatten().next().is_some() {
             return itertools::Either::Left(self.announce_list.iter().flatten());
@@ -69,12 +70,12 @@ impl<BufType: TorrentMetaV1BufTypeConstraints> TorrentMetaV1<BufType> {
     }
 }
 
-impl<BufType: TorrentMetaV1BufTypeConstraints> TorrentMetaV1<BufType> {
+impl<'a, BufType: TorrentMetaV1BufTypeConstraints<'a>> TorrentMetaV1<'a, BufType> {
     /// v1 called out, because v2 is a thing, and migration is a PITA.
     pub fn v1_hash_info(&self) -> Option<Id20> {
         self.info.as_ref().map(|bytes| {
             let mut h = sha1w::Sha1::new();
-            h.update(bytes.as_slice());
+            h.update(bytes.as_ref());
             Id20::new(h.finish())
         })
     }
@@ -268,12 +269,12 @@ where
     }
 }
 
-impl<ByteBuf: TorrentMetaV1BufTypeConstraints> CloneToOwned for TorrentMetaV1<ByteBuf>
+impl<'a, ByteBuf: TorrentMetaV1BufTypeConstraints<'a>> CloneToOwned for TorrentMetaV1<'a, ByteBuf>
 where
     ByteBuf: CloneToOwned,
-    <ByteBuf as CloneToOwned>::Target: TorrentMetaV1BufTypeConstraints,
+    <ByteBuf as CloneToOwned>::Target: TorrentMetaV1BufTypeConstraints<'static>,
 {
-    type Target = TorrentMetaV1<<ByteBuf as CloneToOwned>::Target>;
+    type Target = TorrentMetaV1<'static, <ByteBuf as CloneToOwned>::Target>;
 
     fn clone_to_owned(&self) -> Self::Target {
         TorrentMetaV1 {

--- a/crates/peer_binary_protocol/Cargo.toml
+++ b/crates/peer_binary_protocol/Cargo.toml
@@ -10,12 +10,6 @@ readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[features]
-default = ["sha1-system"]
-sha1-system = ["bencode/sha1-system", "librqbit-core/sha1-system"]
-sha1-openssl = ["bencode/sha1-openssl", "librqbit-core/sha1-openssl"]
-sha1-rust = ["bencode/sha1-rust", "librqbit-core/sha1-rust"]
-
 [dependencies]
 serde = {version = "1", features = ["derive"]}
 bincode = "1"

--- a/crates/peer_binary_protocol/src/extended/mod.rs
+++ b/crates/peer_binary_protocol/src/extended/mod.rs
@@ -1,6 +1,6 @@
-use bencode::bencode_serialize_to_writer;
 use bencode::from_bytes;
 use bencode::BencodeValue;
+use bencode::{bencode_serialize_to_writer, BencodeValueBufConstraint};
 use clone_to_owned::CloneToOwned;
 use serde::{Deserialize, Serialize};
 
@@ -14,7 +14,7 @@ pub mod ut_metadata;
 use super::MY_EXTENDED_UT_METADATA;
 
 #[derive(Debug)]
-pub enum ExtendedMessage<ByteBuf: std::hash::Hash + Eq> {
+pub enum ExtendedMessage<ByteBuf: BencodeValueBufConstraint> {
     Handshake(ExtendedHandshake<ByteBuf>),
     UtMetadata(UtMetadata<ByteBuf>),
     Dyn(u8, BencodeValue<ByteBuf>),
@@ -22,8 +22,8 @@ pub enum ExtendedMessage<ByteBuf: std::hash::Hash + Eq> {
 
 impl<ByteBuf> CloneToOwned for ExtendedMessage<ByteBuf>
 where
-    ByteBuf: CloneToOwned + std::hash::Hash + Eq,
-    <ByteBuf as CloneToOwned>::Target: std::hash::Hash + Eq,
+    ByteBuf: CloneToOwned + BencodeValueBufConstraint,
+    <ByteBuf as CloneToOwned>::Target: BencodeValueBufConstraint,
 {
     type Target = ExtendedMessage<<ByteBuf as CloneToOwned>::Target>;
 
@@ -36,7 +36,7 @@ where
     }
 }
 
-impl<'a, ByteBuf: 'a + std::hash::Hash + Eq + Serialize> ExtendedMessage<ByteBuf> {
+impl<'a, ByteBuf: 'a + BencodeValueBufConstraint + Serialize> ExtendedMessage<ByteBuf> {
     pub fn serialize(
         &self,
         out: &mut Vec<u8>,

--- a/crates/peer_binary_protocol/src/lib.rs
+++ b/crates/peer_binary_protocol/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod extended;
 
+use bencode::BencodeValueBufConstraint;
 use bincode::Options;
 use buffers::{ByteBuf, ByteString};
 use byteorder::{ByteOrder, BE};
@@ -168,7 +169,7 @@ impl From<anyhow::Error> for MessageDeserializeError {
 }
 
 #[derive(Debug)]
-pub enum Message<ByteBuf: std::hash::Hash + Eq> {
+pub enum Message<ByteBuf: BencodeValueBufConstraint> {
     Request(Request),
     Cancel(Request),
     Bitfield(ByteBuf),
@@ -194,8 +195,8 @@ pub struct Bitfield<'a> {
 
 impl<ByteBuf> CloneToOwned for Message<ByteBuf>
 where
-    ByteBuf: CloneToOwned + std::hash::Hash + Eq,
-    <ByteBuf as CloneToOwned>::Target: std::hash::Hash + Eq,
+    ByteBuf: CloneToOwned + BencodeValueBufConstraint,
+    <ByteBuf as CloneToOwned>::Target: BencodeValueBufConstraint,
 {
     type Target = Message<<ByteBuf as CloneToOwned>::Target>;
 
@@ -239,7 +240,7 @@ impl<'a> std::fmt::Debug for Bitfield<'a> {
 
 impl<ByteBuf> Message<ByteBuf>
 where
-    ByteBuf: AsRef<[u8]> + std::hash::Hash + Eq + Serialize,
+    ByteBuf: AsRef<[u8]> + BencodeValueBufConstraint + Serialize,
 {
     pub fn len_prefix_and_msg_id(&self) -> (u32, u8) {
         match self {

--- a/crates/peer_binary_protocol/src/lib.rs
+++ b/crates/peer_binary_protocol/src/lib.rs
@@ -644,6 +644,7 @@ mod tests {
                 let mut f = std::fs::OpenOptions::new()
                     .create(true)
                     .write(true)
+                    .truncate(true)
                     .open("/tmp/test_deserialize_serialize_extended_is_same")
                     .unwrap();
                 f.write_all(&write_buf).unwrap();

--- a/crates/sha1w/src/lib.rs
+++ b/crates/sha1w/src/lib.rs
@@ -18,6 +18,9 @@ pub trait ISha1 {
     fn new() -> Self;
     fn update(&mut self, buf: &[u8]);
     fn finish(self) -> [u8; 20];
+    fn write(&mut self) -> Sha1Writer<Self> {
+        Sha1Writer(self)
+    }
 }
 
 #[cfg(feature = "sha1-rust")]
@@ -92,5 +95,23 @@ impl ISha1 for Sha1System {
         let mut result_arr = [0u8; 20];
         result_arr.copy_from_slice(&result);
         result_arr
+    }
+}
+
+pub struct Sha1Writer<'a, T>(&'a mut T)
+where
+    T: ISha1 + ?Sized;
+
+impl<T> std::io::Write for Sha1Writer<'_, T>
+where
+    T: ISha1,
+{
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.update(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
     }
 }

--- a/crates/upnp/Cargo.toml
+++ b/crates/upnp/Cargo.toml
@@ -20,7 +20,6 @@ serde-xml-rs = "0.6.0"
 tokio = {version = "1", features = ["macros"]}
 futures = "0.3"
 url = "2"
-async-recursion = "1"
 network-interface = { git = 'https://github.com/ikatson/network-interface', branch = "compile-on-freebsd" }
 
 [dev-dependencies]

--- a/raw value notes
+++ b/raw value notes
@@ -1,0 +1,28 @@
+create serializer
+call value.serialize(serializer)
+calls serializer.serialize_struct(TOKEN, len) consuming the serializer
+sees the token and returns serialize struct implementor
+calls serialize_field on the struct serializer, passing the value which must implement Serialize
+calls value.serialize but passes a custom serializer that writes the value directly to the buffer
+
+dude's version
+
+create serializer
+call value.serialize(serializer)
+calls serializer.serialize_newtype_struct(TOKEN, value wrapped in RawSerializer) consuming the serializer
+sees the token and calls value.serialize with a serializer that writes directly to the buffer
+
+deserializer for Bencode:
+
+RawValue.deserialize
+BencodeDeserializer.deserialize_newtype_struct
+Creates wrapper deserializer that remembers buffer start. Throws away a value, then calls the RawValue.deserialize visitor with the bytes that were skipped
+
+deserialize for JSON
+
+RawValue.deserialize
+BencodeDeserializer.deserialize_newtype_struct
+sees nothing and calls visit_newtype_struct
+calls deserializer.deserialize_bytes
+json sees a sequence and calls visit_seq
+RawValue wraps the given seq access in SeqAccessDeserializer and tries to get the wrapped value to deserialize on it. for &[u8] this fails since it needs allocation.


### PR DESCRIPTION
I ran into this same problem in my client https://github.com/anacrolix/torrent, there I solved by implementing the equivalent of a deserializer into bytes (essentially just type checks the bencode) (https://github.com/anacrolix/torrent/blob/master/metainfo/metainfo.go#L16). I don't quite know enough Rust, but I think you either want to (in the same way as my implementation) store the info bytes directly in a metainfo so you can hash them at will (and do a subsequent deserialize if you want to turn them into an info you can work with), or as I've done here, I've stored info as a BencodeValue, which can be deterministically turned into bytes for hashing, or deserialized further into an Info. I did notice you use HashMap for BencodeValue::Dict. That shouldn't allow serializing back into a different order, but I couldn't trigger that behaviour with the unit test. I'm not sure how to best trigger this behaviour in Rust. The solution would be to have an ordered mapping type, or have Dict use Vec internally and expose some kind of mapping interface? BitTorrent does specify that dict keys must be ordered like memcmp (but not in the original BEP 3), so client support is flakey, and that's why you want to deserialize info into something that retains the original ordering, at least if you intend to generate infohashes.

Moving the infohashing out of bencode moved the sha1w dep to librqbit_core. I didn't retain the features, I assume they aren't in use (except on the main bin perhaps?), but if it was I can put them back in mapping features to core instead.

There's no way to deserialize from BencodeValue to a Rust type. I'm not well versed in serde, would that require a custom deserializer? Instead I serialized back into bytes then ran the bytes deserializer. It should still be correct, unless the Dict nondeterministic ordering strikes. At least for infohashing, there's no intermediate allocation as it can serialize straight into the hasher.

How does one deserialize into bytes with serde? If it was possible to have `info: ByteBuf` in the metainfo that could be optimal for hashing after deserializing. With the BencodeValue route I went, I had to use BencodeValueOwned: I couldn't work out the trait and lifetime requirements to have it be BencodeValue<ByteBuf>. Do you know why that might be? Perhaps knowing whether BencodeValue or a raw ByteBuf type could be used in metainfo to avoid allocations could decide the best choice?

I tried to add a std::io::Write for any ISha1, but Rust didn't like that, so I made a helper type then noticed you had a private one in a function somewhere that was identical.

I have been toying with the idea of a Rust implementation of my torrent client for a while, but there's a few rough spots in my knowledge of Rust. If it works for you'll I'll make some more contributions like this if you have the capacity for it.