### PR TITLE
Add .desktop file configured for torrents

### DIFF
--- a/resources/rqbit-desktop.desktop
+++ b/resources/rqbit-desktop.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Categories=Network;FileTransfer;P2P
+Comment=rqbit torrent client
+Exec=rqbit-desktop %U
+Icon=rqbit-desktop
+Name=rqbit-desktop
+Terminal=false
+Type=Application
+MimeType=application/x-bittorrent;x-scheme-handler/magnet;


### PR DESCRIPTION
The tauri generated .desktop file is not configured for any file types or protocols, with this file rqbit-desktop is going to be suggested for opening magnet links and .torrent files.

However, I noticed commandline arguments are currently not understood by rqbit-desktop, and opening two files results in two rqbit-desktop instances.