### PR TITLE
Remove sha1 extra features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1406,8 +1406,6 @@ name = "librqbit-sha1-wrapper"
 version = "2.2.1"
 dependencies = [
  "crypto-hash",
- "openssl",
- "sha1",
 ]
 
 [[package]]

--- a/crates/bencode/Cargo.toml
+++ b/crates/bencode/Cargo.toml
@@ -10,12 +10,6 @@ readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[features]
-default = ["sha1-system"]
-sha1-system = ["sha1w/sha1-system"]
-sha1-openssl = ["sha1w/sha1-openssl"]
-sha1-rust = ["sha1w/sha1-rust"]
-
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 buffers = { path = "../buffers", package = "librqbit-buffers", version = "2.2.1" }

--- a/crates/dht/Cargo.toml
+++ b/crates/dht/Cargo.toml
@@ -10,12 +10,6 @@ readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[features]
-default = ["sha1-system"]
-sha1-system = ["bencode/sha1-system", "librqbit-core/sha1-system"]
-sha1-openssl = ["bencode/sha1-openssl", "librqbit-core/sha1-openssl"]
-sha1-rust = ["bencode/sha1-rust", "librqbit-core/sha1-rust"]
-
 [dependencies]
 tokio = {version = "1", features = ["macros", "rt-multi-thread", "net", "sync"]}
 tokio-stream = {version = "0.1", features = ["sync"]}

--- a/crates/librqbit/Cargo.toml
+++ b/crates/librqbit/Cargo.toml
@@ -12,12 +12,9 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["sha1-system", "default-tls"]
+default = ["default-tls"]
 webui = []
 timed_existence = []
-sha1-system = ["sha1w/sha1-system"]
-sha1-openssl = ["sha1w/sha1-openssl"]
-sha1-rust = ["sha1w/sha1-rust"]
 default-tls = ["reqwest/default-tls"]
 rust-tls = ["reqwest/rustls-tls"]
 

--- a/crates/librqbit/src/file_ops.rs
+++ b/crates/librqbit/src/file_ops.rs
@@ -16,7 +16,7 @@ use librqbit_core::{
 };
 use parking_lot::Mutex;
 use peer_binary_protocol::Piece;
-use sha1w::ISha1;
+use sha1w::{ISha1, Sha1};
 use tracing::{debug, trace, warn};
 
 use crate::type_aliases::{PeerHandle, BF};
@@ -54,14 +54,14 @@ pub fn update_hash_from_file<Sha1: ISha1>(
     Ok(())
 }
 
-pub(crate) struct FileOps<'a, Sha1> {
+pub(crate) struct FileOps<'a> {
     torrent: &'a TorrentMetaV1Info<ByteBufOwned>,
     files: &'a [Arc<Mutex<File>>],
     lengths: &'a Lengths,
     phantom_data: PhantomData<Sha1>,
 }
 
-impl<'a, Sha1Impl: ISha1> FileOps<'a, Sha1Impl> {
+impl<'a> FileOps<'a> {
     pub fn new(
         torrent: &'a TorrentMetaV1Info<ByteBufOwned>,
         files: &'a [Arc<Mutex<File>>],
@@ -136,7 +136,7 @@ impl<'a, Sha1Impl: ISha1> FileOps<'a, Sha1Impl> {
         let mut read_buffer = vec![0u8; 65536];
 
         for piece_info in self.lengths.iter_piece_infos() {
-            let mut computed_hash = Sha1Impl::new();
+            let mut computed_hash = Sha1::new();
             let mut piece_remaining = piece_info.len as usize;
             let mut some_files_broken = false;
             let mut at_least_one_file_required = current_file.full_file_required;
@@ -242,7 +242,7 @@ impl<'a, Sha1Impl: ISha1> FileOps<'a, Sha1Impl> {
         piece_index: ValidPieceIndex,
         last_received_chunk: &ChunkInfo,
     ) -> anyhow::Result<bool> {
-        let mut h = Sha1Impl::new();
+        let mut h = Sha1::new();
         let piece_length = self.lengths.piece_length(piece_index);
         let mut absolute_offset = self.lengths.piece_offset(piece_index);
         let mut buf = vec![0u8; std::cmp::min(65536, piece_length as usize)];

--- a/crates/librqbit/src/torrent_state/initializing.rs
+++ b/crates/librqbit/src/torrent_state/initializing.rs
@@ -8,7 +8,6 @@ use anyhow::Context;
 
 use parking_lot::Mutex;
 
-use sha1w::Sha1;
 use size_format::SizeFormatterBinary as SF;
 use tracing::{debug, info, warn};
 
@@ -81,7 +80,7 @@ impl TorrentStateInitializing {
 
         info!("Doing initial checksum validation, this might take a while...");
         let initial_check_results = self.meta.spawner.spawn_block_in_place(|| {
-            FileOps::<Sha1>::new(&self.meta.info, &files, &self.meta.lengths)
+            FileOps::new(&self.meta.info, &files, &self.meta.lengths)
                 .initial_check(self.only_files.as_deref(), &self.checked_bytes)
         })?;
 

--- a/crates/librqbit/src/torrent_state/live/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/mod.rs
@@ -72,7 +72,6 @@ use parking_lot::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use peer_binary_protocol::{
     extended::handshake::ExtendedHandshake, Handshake, Message, MessageOwned, Piece, Request,
 };
-use sha1w::Sha1;
 use tokio::{
     sync::{
         mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
@@ -492,7 +491,7 @@ impl TorrentStateLive {
     pub fn peer_id(&self) -> Id20 {
         self.meta.peer_id
     }
-    pub(crate) fn file_ops(&self) -> FileOps<'_, Sha1> {
+    pub(crate) fn file_ops(&self) -> FileOps<'_> {
         FileOps::new(&self.meta.info, &self.files, &self.lengths)
     }
     pub fn initially_needed(&self) -> u64 {

--- a/crates/librqbit_core/Cargo.toml
+++ b/crates/librqbit_core/Cargo.toml
@@ -10,12 +10,6 @@ readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[features]
-default = ["sha1-system"]
-sha1-system = ["bencode/sha1-system"]
-sha1-openssl = ["bencode/sha1-openssl"]
-sha1-rust = ["bencode/sha1-rust"]
-
 [dependencies]
 tracing = "0.1.40"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }

--- a/crates/peer_binary_protocol/Cargo.toml
+++ b/crates/peer_binary_protocol/Cargo.toml
@@ -10,12 +10,6 @@ readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[features]
-default = ["sha1-system"]
-sha1-system = ["bencode/sha1-system", "librqbit-core/sha1-system"]
-sha1-openssl = ["bencode/sha1-openssl", "librqbit-core/sha1-openssl"]
-sha1-rust = ["bencode/sha1-rust", "librqbit-core/sha1-rust"]
-
 [dependencies]
 serde = {version = "1", features = ["derive"]}
 bincode = "1"

--- a/crates/rqbit/Cargo.toml
+++ b/crates/rqbit/Cargo.toml
@@ -12,14 +12,11 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["sha1-system", "default-tls", "webui"]
+default = ["default-tls", "webui"]
 openssl-vendored = ["openssl/vendored"]
 tokio-console = ["console-subscriber", "tokio/tracing"]
 webui = ["librqbit/webui"]
 timed_existence = ["librqbit/timed_existence"]
-sha1-system = ["librqbit/sha1-system"]
-sha1-openssl = ["librqbit/sha1-openssl"]
-sha1-rust = ["librqbit/sha1-rust"]
 default-tls = ["librqbit/default-tls"]
 rust-tls = ["librqbit/rust-tls"]
 

--- a/crates/sha1w/Cargo.toml
+++ b/crates/sha1w/Cargo.toml
@@ -11,4 +11,4 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-crypto-hash = {version="0.3", optional=true}
+crypto-hash = "0.3"

--- a/crates/sha1w/Cargo.toml
+++ b/crates/sha1w/Cargo.toml
@@ -10,15 +10,5 @@ readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[features]
-default = ["sha1-system"]
-sha1-system = ["crypto-hash"]
-sha1-openssl = ["openssl"]
-sha1-rust = ["sha1"]
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-openssl = {version="0.10", optional=true}
 crypto-hash = {version="0.3", optional=true}
-sha1 = {version = "0.10", optional=true}

--- a/crates/sha1w/src/lib.rs
+++ b/crates/sha1w/src/lib.rs
@@ -5,13 +5,6 @@
 // openssl is 2-3x faster than rust's sha1.
 // system library is the best choice probably (it's the default anyway).
 
-#[cfg(feature = "sha1-openssl")]
-pub type Sha1 = Sha1Openssl;
-
-#[cfg(feature = "sha1-rust")]
-pub type Sha1 = Sha1Rust;
-
-#[cfg(feature = "sha1-system")]
 pub type Sha1 = Sha1System;
 
 pub trait ISha1 {
@@ -20,60 +13,10 @@ pub trait ISha1 {
     fn finish(self) -> [u8; 20];
 }
 
-#[cfg(feature = "sha1-rust")]
-pub struct Sha1Rust {
-    inner: sha1::Sha1,
-}
-
-#[cfg(feature = "sha1-rust")]
-impl ISha1 for Sha1Rust {
-    fn new() -> Self {
-        Sha1Rust {
-            inner: sha1::Sha1::default(),
-        }
-    }
-
-    fn update(&mut self, buf: &[u8]) {
-        use sha1::Digest;
-        sha1::Sha1::update(&mut self.inner, buf)
-    }
-
-    fn finish(self) -> [u8; 20] {
-        use sha1::Digest;
-        let mut output = [0u8; 20];
-        sha1::Sha1::finalize_into(self.inner, (&mut output[..]).into());
-        output
-    }
-}
-
-#[cfg(feature = "sha1-openssl")]
-pub struct Sha1Openssl {
-    inner: openssl::sha::Sha1,
-}
-
-#[cfg(feature = "sha1-openssl")]
-impl ISha1 for Sha1Openssl {
-    fn new() -> Self {
-        Self {
-            inner: openssl::sha::Sha1::new(),
-        }
-    }
-
-    fn update(&mut self, buf: &[u8]) {
-        self.inner.update(buf)
-    }
-
-    fn finish(self) -> [u8; 20] {
-        self.inner.finish()
-    }
-}
-
-#[cfg(feature = "sha1-system")]
 pub struct Sha1System {
     inner: crypto_hash::Hasher,
 }
 
-#[cfg(feature = "sha1-system")]
 impl ISha1 for Sha1System {
     fn new() -> Self {
         Self {


### PR DESCRIPTION
We used to have 3 implementations of sha1, now we don't need the other 2. This simplifies stuff.