### PR TITLE
Fix resilience to bogus peers

### DIFF
--- a/crates/librqbit/src/file_ops.rs
+++ b/crates/librqbit/src/file_ops.rs
@@ -283,7 +283,7 @@ impl<'a, Sha1Impl: ISha1> FileOps<'a, Sha1Impl> {
             piece_remaining_bytes -= to_read_in_file;
 
             if piece_remaining_bytes == 0 {
-                return Ok(true);
+                break;
             }
 
             absolute_offset = 0;

--- a/crates/librqbit/src/tests/e2e.rs
+++ b/crates/librqbit/src/tests/e2e.rs
@@ -105,6 +105,7 @@ async fn test_e2e() {
                                 }
                                 Ok(true)
                             }
+                            crate::ManagedTorrentState::Error(e) => bail!("error: {e:?}"),
                             _ => bail!("broken state"),
                         })
                         .unwrap();

--- a/crates/librqbit/src/tests/test_util.rs
+++ b/crates/librqbit/src/tests/test_util.rs
@@ -63,4 +63,11 @@ impl TestPeerMetadata {
         }
         0f64
     }
+
+    pub fn bad_data_probability(&self) -> f64 {
+        if self.server_id % 2 == 0 {
+            return 0.05f64;
+        }
+        0f64
+    }
 }

--- a/crates/librqbit/src/torrent_state/live/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/mod.rs
@@ -1397,11 +1397,15 @@ impl PeerHandler {
                         self.state.maybe_transmit_haves(chunk_info.piece_index);
                     }
                     false => {
-                        warn!("checksum for piece={} did not validate", index,);
+                        warn!(
+                            "checksum for piece={} did not validate. disconecting peer.",
+                            index
+                        );
                         self.state
                             .lock_write("mark_piece_broken")
                             .get_chunks_mut()?
                             .mark_piece_broken_if_not_have(chunk_info.piece_index);
+                        anyhow::bail!("i am probably a bogus peer. dying.")
                     }
                 };
                 Ok::<_, anyhow::Error>(())

--- a/crates/librqbit_core/src/lengths.rs
+++ b/crates/librqbit_core/src/lengths.rs
@@ -25,9 +25,15 @@ pub struct PieceInfo {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ChunkInfo {
     pub piece_index: ValidPieceIndex,
+
+    // Index of chunk within the piece.
     pub chunk_index: u32,
+
+    // Absolute chunk index if the first chunk of the first piece was 0.
     pub absolute_index: u32,
     pub size: u32,
+
+    // Offset of chunk in bytes within the piece.
     pub offset: u32,
 }
 


### PR DESCRIPTION
This fixes checksumming in case peers send bad data.

The code turned out to be broken all the time, and checksums weren't checked.
Took me a day to debug this, the culprit was an early return in file_ops.rs.

Updated e2e test also to simulate bad peers.