### PR TITLE
Add build steps of desktop application to README.md

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -1,7 +1,33 @@
-# Tauri + React + Typescript
+# rqbit GUI Application
 
-This template should help get you started developing with Tauri, React and Typescript in Vite.
+This is a thin tauri wrapper for the web ui of rqbit.
 
 ## Recommended IDE Setup
 
 - [VS Code](https://code.visualstudio.com/) + [Tauri](https://marketplace.visualstudio.com/items?itemName=tauri-apps.tauri-vscode) + [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer)
+
+## Dependencies
+
+* Tauri CLI.
+
+```
+cargo install tauri-cli
+```
+
+* Nodejs and NPM
+
+## How to build GUI
+
+* Go to `rqbit/crates/librqbit/webui`
+  
+  ```
+  npm install
+  npm run build
+  ```
+  
+* Go to `rqbit/desktop`
+  
+  ```
+  npm install
+  cargo tauri dev
+  ```


### PR DESCRIPTION
Added details on how to build the desktop app for rqbit manually to the sub directory's README.md file. There is some value to have the build details present along with the code and it's config. 