### PR TITLE
Better queueing for multi-file torrents

### DIFF
--- a/crates/librqbit/src/chunk_tracker.rs
+++ b/crates/librqbit/src/chunk_tracker.rs
@@ -182,7 +182,7 @@ impl ChunkTracker {
         hns
     }
 
-    pub fn iter_queued_pieces<'a>(
+    pub(crate) fn iter_queued_pieces<'a>(
         &'a self,
         file_priorities: &'a FilePriorities,
         opened_files: &'a OpenedFiles,

--- a/crates/librqbit/src/chunk_tracker.rs
+++ b/crates/librqbit/src/chunk_tracker.rs
@@ -190,6 +190,7 @@ impl ChunkTracker {
         file_priorities
             .iter()
             .filter_map(|p| opened_files.get(*p))
+            .filter(|f| !f.approx_is_finished())
             .flat_map(|f| f.iter_piece_priorities())
             .filter(|id| self.queue_pieces[*id])
     }

--- a/crates/librqbit/src/opened_file.rs
+++ b/crates/librqbit/src/opened_file.rs
@@ -31,6 +31,20 @@ pub(crate) fn dummy_file() -> anyhow::Result<std::fs::File> {
         .with_context(|| format!("error opening {}", DEVNULL))
 }
 
+// Iterate file pieces in the following order: first, last, everything else from start to end.
+fn iter_piece_priorities(range: std::ops::Range<usize>) -> impl Iterator<Item = usize> {
+    // First and last of each file first, then the rest of pieces in that file.
+    let r = range;
+    use std::iter::once;
+
+    let first = once(r.start);
+    let last = once(r.start + r.len().overflowing_sub(1).0); // it's ok if it repeats, doesn't matter
+    let mid = r.clone().skip(1).take(r.len().overflowing_sub(2).0);
+
+    // The take(r.len()) is to not yield start/end pieces in case of 0 and 1 lengths.
+    first.chain(last).chain(mid).take(r.len())
+}
+
 impl OpenedFile {
     pub fn new(
         f: File,
@@ -93,5 +107,25 @@ impl OpenedFile {
         let size = lengths.size_of_piece_in_file(piece_id, self.offset_in_torrent, self.len);
         self.have.fetch_add(size, Ordering::Relaxed);
         size
+    }
+
+    pub fn iter_piece_priorities(&self) -> impl Iterator<Item = usize> {
+        iter_piece_priorities(self.piece_range_usize())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::opened_file::iter_piece_priorities;
+
+    #[test]
+    fn test_iter_piece_priorities() {
+        let it = |r: std::ops::Range<usize>| -> Vec<usize> { iter_piece_priorities(r).collect() };
+        assert_eq!(it(0..0), Vec::<usize>::new());
+
+        assert_eq!(it(0..1), vec![0]);
+        assert_eq!(it(0..2), vec![0, 1]);
+        assert_eq!(it(0..3), vec![0, 2, 1]);
+        assert_eq!(it(0..4), vec![0, 3, 1, 2]);
     }
 }

--- a/crates/librqbit/src/opened_file.rs
+++ b/crates/librqbit/src/opened_file.rs
@@ -109,6 +109,10 @@ impl OpenedFile {
         size
     }
 
+    pub fn approx_is_finished(&self) -> bool {
+        self.have.load(Ordering::Relaxed) == self.len
+    }
+
     pub fn iter_piece_priorities(&self) -> impl Iterator<Item = usize> {
         iter_piece_priorities(self.piece_range_usize())
     }

--- a/crates/librqbit/src/torrent_state/live/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/mod.rs
@@ -219,7 +219,12 @@ impl TorrentStateLive {
         reopen_necessary_files_for_write(&paused.chunk_tracker, &paused.files)?;
 
         // TODO: make it configurable
-        let file_priorities = (0..paused.files.len()).collect();
+        let file_priorities = {
+            let mut pri = (0..paused.files.len()).collect::<Vec<usize>>();
+            // sort by filename, cause many torrents have random sort order.
+            pri.sort_unstable_by_key(|id| paused.files.get(*id).map(|op| op.filename.as_path()));
+            pri
+        };
 
         let state = Arc::new(TorrentStateLive {
             meta: paused.info.clone(),

--- a/crates/librqbit/src/type_aliases.rs
+++ b/crates/librqbit/src/type_aliases.rs
@@ -9,3 +9,4 @@ pub type BF = bitvec::boxed::BitBox<u8, bitvec::order::Msb0>;
 pub type PeerHandle = SocketAddr;
 pub type PeerStream = BoxStream<'static, SocketAddr>;
 pub(crate) type OpenedFiles = Vec<OpenedFile>;
+pub(crate) type FilePriorities = Vec<usize>;

--- a/crates/rqbit/src/main.rs
+++ b/crates/rqbit/src/main.rs
@@ -35,7 +35,7 @@ struct Opts {
     log_file: Option<String>,
 
     /// The value for RUST_LOG in the log file
-    #[arg(long = "log-file-rust-log", default_value = "librqbit=trace,info")]
+    #[arg(long = "log-file-rust-log", default_value = "librqbit=debug,info")]
     log_file_rust_log: String,
 
     /// The interval to poll trackers, e.g. 30s.


### PR DESCRIPTION
Previously, rqbit prioritized first and last pieces of the whole torrent.
Now it does so per selected file.

Also files are now downoaded in sorted lexicographic order, not in torrent-specified order.