### PR TITLE
Bugfix: on 32 bit systems files > 4gb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ release-linux-current-target:
 	cargo build  --profile release-github --target=$(TARGET) --features=openssl-vendored
 
 @PHONY: release-linux
-release-linux: release-linux-x86_64 release-linux-aarch64 release-linux-armv6 release-linux-armv7
+release-linux: release-linux-x86_64 release-linux-aarch64 release-linux-armv6 release-linux-armv7 release-linux-armv7-musl
 
 @PHONY: release-linux-x86_64
 release-linux-x86_64:
@@ -103,6 +103,14 @@ release-linux-armv7:
 	TARGET_SNAKE_CASE=armv7_unknown_linux_gnueabihf \
 	TARGET_SNAKE_UPPER_CASE=ARMV7_UNKNOWN_LINUX_GNUEABIHF \
 	CROSS_COMPILE_PREFIX=armv7-linux-gnueabihf \
+	$(MAKE) release-linux-current-target
+
+@PHONY: release-linux-armv7-musl
+release-linux-armv7-musl:
+	TARGET=armv7-unknown-linux-musleabihf \
+	TARGET_SNAKE_CASE=armv7_unknown_linux_musleabihf \
+	TARGET_SNAKE_UPPER_CASE=ARMV7_UNKNOWN_LINUX_MUSLEABIHF \
+	CROSS_COMPILE_PREFIX=armv7-linux-musleabihf \
 	$(MAKE) release-linux-current-target
 
 

--- a/crates/librqbit/src/file_ops.rs
+++ b/crates/librqbit/src/file_ops.rs
@@ -385,7 +385,7 @@ impl<'a> FileOps<'a> {
             }
 
             let remaining_len = file_len - absolute_offset;
-            let to_write = std::cmp::min(buf.len(), remaining_len as usize);
+            let to_write = std::cmp::min(buf.len() as u64, remaining_len) as usize;
 
             let mut file_g = self.files[file_idx].file.lock();
             trace!(

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -828,7 +828,11 @@ impl Session {
 
                     let peer_rx = self.make_peer_rx(
                         info_hash,
-                        magnet.trackers.clone(),
+                        if opts.disable_trackers {
+                            Default::default()
+                        } else {
+                            magnet.trackers.clone()
+                        },
                         announce_port,
                         opts.force_tracker_interval,
                     )?;
@@ -897,7 +901,11 @@ impl Session {
                     } else {
                         self.make_peer_rx(
                             torrent.info_hash,
-                            trackers.clone(),
+                            if opts.disable_trackers {
+                                Default::default()
+                            } else {
+                                trackers.clone()
+                            },
                             announce_port,
                             opts.force_tracker_interval,
                         )?


### PR DESCRIPTION
There was a bugged narrowing conversion from u64 to usize, which on 32-bit systems caused a logical bug.

If you tried to download a large (> 4gb) file on a 32-bit system, this narrowing conversion would have written fewer bytes than needed, resulting in checksums never validating, and the torrent never fully completing, and being stuck in like 99.96%.