### PR TITLE
Fix a bug in stealing code

### DIFF
--- a/crates/librqbit/src/torrent_state/live/peers/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/peers/mod.rs
@@ -142,7 +142,6 @@ impl PeerStates {
                         begin: req.offset,
                         length: req.size,
                     })));
-                live.inflight_requests.remove(&req);
             }
         });
     }

--- a/crates/rqbit/src/main.rs
+++ b/crates/rqbit/src/main.rs
@@ -321,8 +321,8 @@ async fn async_main(opts: Opts) -> anyhow::Result<()> {
                             up_speed.mbps(),
                             SF::new(live_stats.snapshot.uploaded_bytes),
                             eta,
-                            peer_stats.live + peer_stats.connecting,
-                            peer_stats.queued,
+                            peer_stats.live,
+                            peer_stats.queued + peer_stats.connecting,
                             peer_stats.dead,
                         );
                     }


### PR DESCRIPTION
This caused live peers to drop when they got stolen from, which caused them to disconnect too frequently.

Also fixed reporting the "live" number in command line.

Found it while investigating https://github.com/ikatson/rqbit/issues/125