### PR TITLE
More robust deletion of files and folders (fixes #140)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ webui-build: webui-deps
 
 @PHONY: devserver
 devserver:
-	echo -n '' > /tmp/rqbit-log && cargo run --release -- \
+	echo -n '' > /tmp/rqbit-log && cargo run -- \
 		--log-file /tmp/rqbit-log \
 		--log-file-rust-log=debug,librqbit=trace \
 		server start /tmp/scratch/

--- a/crates/librqbit/examples/custom_storage.rs
+++ b/crates/librqbit/examples/custom_storage.rs
@@ -19,7 +19,7 @@ struct CustomStorage {
 impl StorageFactory for CustomStorageFactory {
     type Storage = CustomStorage;
 
-    fn init_storage(&self, _info: &librqbit::ManagedTorrentInfo) -> anyhow::Result<Self::Storage> {
+    fn create(&self, _info: &librqbit::ManagedTorrentInfo) -> anyhow::Result<Self::Storage> {
         Ok(CustomStorage::default())
     }
 
@@ -46,6 +46,14 @@ impl TorrentStorage for CustomStorage {
     }
 
     fn take(&self) -> anyhow::Result<Box<dyn TorrentStorage>> {
+        anyhow::bail!("not implemented")
+    }
+
+    fn remove_directory_if_empty(&self, _path: &std::path::Path) -> anyhow::Result<()> {
+        anyhow::bail!("not implemented")
+    }
+
+    fn init(&mut self, _meta: &librqbit::ManagedTorrentInfo) -> anyhow::Result<()> {
         anyhow::bail!("not implemented")
     }
 }

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -4,7 +4,7 @@ use std::{
     collections::{HashMap, HashSet},
     io::{BufReader, BufWriter, Read},
     net::SocketAddr,
-    path::PathBuf,
+    path::{Path, PathBuf},
     str::FromStr,
     sync::Arc,
     time::Duration,
@@ -16,11 +16,14 @@ use crate::{
     peer_connection::PeerConnectionOptions,
     read_buf::ReadBuf,
     spawn_utils::BlockingSpawner,
-    storage::{filesystem::FilesystemStorageFactory, BoxStorageFactory, StorageFactoryExt},
+    storage::{
+        filesystem::FilesystemStorageFactory, BoxStorageFactory, StorageFactoryExt, TorrentStorage,
+    },
     torrent_state::{
         ManagedTorrentBuilder, ManagedTorrentHandle, ManagedTorrentState, TorrentStateLive,
     },
     type_aliases::{DiskWorkQueueSender, PeerStream},
+    ManagedTorrentInfo,
 };
 use anyhow::{bail, Context};
 use bencode::{bencode_serialize_to_writer, BencodeDeserializer};
@@ -1136,31 +1139,44 @@ impl Session {
             .remove(&id)
             .with_context(|| format!("torrent with id {} did not exist", id))?;
 
-        let paused = removed
-            .with_state_mut(|s| {
-                let paused = match s.take() {
-                    ManagedTorrentState::Paused(p) => p,
-                    ManagedTorrentState::Live(l) => l.pause()?,
-                    _ => return Ok(None),
-                };
-                Ok::<_, anyhow::Error>(Some(paused))
-            })
-            .context("error pausing torrent");
+        if let Err(e) = removed.pause() {
+            debug!("error pausing torrent before deletion: {e:?}")
+        }
 
-        match (paused, delete_files) {
+        let storage = removed
+            .with_state_mut(|s| match s.take() {
+                ManagedTorrentState::Initializing(p) => p.files.take().ok(),
+                ManagedTorrentState::Paused(p) => Some(p.files),
+                ManagedTorrentState::Live(l) => l
+                    .pause()
+                    .inspect_err(|e| warn!("error pausing torrent: {e:?}"))
+                    .ok()
+                    .map(|p| p.files),
+                _ => None,
+            })
+            .map(Ok)
+            .unwrap_or_else(|| removed.storage_factory.create(removed.info()));
+
+        match (storage, delete_files) {
             (Err(e), true) => return Err(e).context("torrent deleted, but could not delete files"),
-            (Err(e), false) => {
-                warn!(error=?e, "error deleting torrent cleanly");
-            }
-            (Ok(Some(paused)), true) => {
-                for (id, fi) in removed.info().file_infos.iter().enumerate() {
-                    if let Err(e) = paused.files.remove_file(id, &fi.relative_filename) {
-                        warn!(?fi.relative_filename, error=?e, "could not delete file");
+            (Ok(storage), true) => {
+                debug!("will delete files");
+                remove_files_and_dirs(removed.info(), &storage);
+                if removed.info().options.output_folder != self.output_folder {
+                    if let Err(e) = storage.remove_directory_if_empty(Path::new("")) {
+                        warn!(
+                            "error removing {:?}: {e:?}",
+                            removed.info().options.output_folder
+                        )
                     }
                 }
             }
-            _ => {}
+            (_, false) => {
+                debug!("not deleting files")
+            }
         };
+
+        info!(id, "deleted torrent");
         Ok(())
     }
 
@@ -1217,6 +1233,37 @@ impl Session {
 
     pub fn tcp_listen_port(&self) -> Option<u16> {
         self.tcp_listen_port
+    }
+}
+
+fn remove_files_and_dirs(info: &ManagedTorrentInfo, files: &dyn TorrentStorage) {
+    let mut all_dirs = HashSet::new();
+    for (id, fi) in info.file_infos.iter().enumerate() {
+        let mut fname = &*fi.relative_filename;
+        if let Err(e) = files.remove_file(id, fname) {
+            warn!(?fi.relative_filename, error=?e, "could not delete file");
+        } else {
+            debug!(?fi.relative_filename, "deleted the file")
+        }
+        while let Some(parent) = fname.parent() {
+            if parent != Path::new("") {
+                all_dirs.insert(parent);
+            }
+            fname = parent;
+        }
+    }
+
+    let all_dirs = {
+        let mut v = all_dirs.into_iter().collect::<Vec<_>>();
+        v.sort_unstable_by_key(|p| std::cmp::Reverse(p.as_os_str().len()));
+        v
+    };
+    for dir in all_dirs {
+        if let Err(e) = files.remove_directory_if_empty(dir) {
+            warn!("error removing {dir:?}: {e:?}");
+        } else {
+            debug!("removed {dir:?}")
+        }
     }
 }
 

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -1149,7 +1149,11 @@ impl Session {
                 ManagedTorrentState::Paused(p) => Some(p.files),
                 ManagedTorrentState::Live(l) => l
                     .pause()
-                    .inspect_err(|e| warn!("error pausing torrent: {e:?}"))
+                    // inspect_err not available in 1.75
+                    .map_err(|e| {
+                        warn!("error pausing torrent: {e:?}");
+                        e
+                    })
                     .ok()
                     .map(|p| p.files),
                 _ => None,

--- a/crates/librqbit/src/storage/examples/inmemory.rs
+++ b/crates/librqbit/src/storage/examples/inmemory.rs
@@ -25,7 +25,7 @@ pub struct InMemoryExampleStorageFactory {}
 impl StorageFactory for InMemoryExampleStorageFactory {
     type Storage = InMemoryExampleStorage;
 
-    fn init_storage(
+    fn create(
         &self,
         info: &crate::torrent_state::ManagedTorrentInfo,
     ) -> anyhow::Result<InMemoryExampleStorage> {
@@ -109,5 +109,13 @@ impl TorrentStorage for InMemoryExampleStorage {
             map: RwLock::new(map),
             file_infos: self.file_infos.clone(),
         }))
+    }
+
+    fn init(&mut self, _meta: &crate::ManagedTorrentInfo) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn remove_directory_if_empty(&self, _path: &Path) -> anyhow::Result<()> {
+        Ok(())
     }
 }

--- a/crates/librqbit/src/storage/examples/mmap.rs
+++ b/crates/librqbit/src/storage/examples/mmap.rs
@@ -18,7 +18,7 @@ pub struct MmapStorage {
 impl StorageFactory for MmapStorageFactory {
     type Storage = MmapStorage;
 
-    fn init_storage(&self, info: &ManagedTorrentInfo) -> anyhow::Result<Self::Storage> {
+    fn create(&self, info: &ManagedTorrentInfo) -> anyhow::Result<Self::Storage> {
         Ok(MmapStorage {
             mmap: RwLock::new(
                 MmapOptions::new()
@@ -61,5 +61,13 @@ impl TorrentStorage for MmapStorage {
 
     fn take(&self) -> anyhow::Result<Box<dyn TorrentStorage>> {
         anyhow::bail!("not implemented")
+    }
+
+    fn init(&mut self, _meta: &ManagedTorrentInfo) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn remove_directory_if_empty(&self, _path: &std::path::Path) -> anyhow::Result<()> {
+        Ok(())
     }
 }

--- a/crates/librqbit/src/torrent_state/mod.rs
+++ b/crates/librqbit/src/torrent_state/mod.rs
@@ -275,7 +275,7 @@ impl ManagedTorrent {
                     error_span!(parent: span.clone(), "initialize_and_start"),
                     token.clone(),
                     async move {
-                        match init.check(&t.storage_factory).await {
+                        match init.check().await {
                             Ok(paused) => {
                                 let mut g = t.locked.write();
                                 if let ManagedTorrentState::Initializing(_) = &g.state {
@@ -325,6 +325,7 @@ impl ManagedTorrent {
                 let initializing = Arc::new(TorrentStateInitializing::new(
                     self.info.clone(),
                     g.only_files.clone(),
+                    self.storage_factory.create_and_init(self.info())?,
                 ));
                 g.state = ManagedTorrentState::Initializing(initializing.clone());
                 self.state_change_notify.notify_waiters();
@@ -616,6 +617,7 @@ impl ManagedTorrentBuilder {
         let initializing = Arc::new(TorrentStateInitializing::new(
             info.clone(),
             self.only_files.clone(),
+            self.storage_factory.create_and_init(&info)?,
         ));
         Ok(Arc::new(ManagedTorrent {
             locked: RwLock::new(ManagedTorrentLocked {


### PR DESCRIPTION
This required some refactoring, so that storage operations are available without initialization succeding.

Empty folders should be deleted properly now.