### PR TITLE
fix: can not add base32 encoded magnet url

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,6 +619,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1364,6 +1370,7 @@ name = "librqbit-core"
 version = "3.8.0"
 dependencies = [
  "anyhow",
+ "data-encoding",
  "directories",
  "hex 0.4.3",
  "itertools",

--- a/crates/librqbit_core/Cargo.toml
+++ b/crates/librqbit_core/Cargo.toml
@@ -25,6 +25,8 @@ clone_to_owned = { path = "../clone_to_owned", package = "librqbit-clone-to-owne
 itertools = "0.12"
 directories = "5"
 tokio-util = "0.7.10"
+data-encoding = "2.6.0"
+
 
 [dev-dependencies]
 serde_json = "1"


### PR DESCRIPTION
fix issue #150 

also check base32 encoded size and decoded to info hash
