### PR TITLE
Add redirect for /web

### DIFF
--- a/crates/librqbit/src/http_api.rs
+++ b/crates/librqbit/src/http_api.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use axum::body::Bytes;
 use axum::extract::{Path, Query, State};
-use axum::response::IntoResponse;
+use axum::response::{IntoResponse, Redirect};
 use axum::routing::{get, post};
 use futures::future::BoxFuture;
 use futures::{FutureExt, TryStreamExt};
@@ -341,6 +341,7 @@ impl HttpApi {
                 );
 
             app = app.nest("/web/", webui_router);
+            app = app.route("/web", get(|| async { Redirect::permanent("/web/") }))
         }
 
         let cors_layer = {


### PR DESCRIPTION
Small one -  I typed http://localhost:3030/web   in browser (without training /).
Took me while before I realize my mistake - hope it can help some other distracted user.