### PR TITLE
Other way to handle blocking in streaming.rs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .DS_Store
+/.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,0 @@
-{
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "[javascript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  },
-  "[rust]": {
-    "editor.defaultFormatter": "rust-lang.rust-analyzer"
-  }
-}

--- a/crates/librqbit/src/http_api.rs
+++ b/crates/librqbit/src/http_api.rs
@@ -170,7 +170,7 @@ impl HttpApi {
             let range_header = headers.get(http::header::RANGE);
             trace!(torrent_id=idx, file_id=file_id, range=?range_header, "request for HTTP stream");
 
-            if let Some(range) = headers.get(http::header::RANGE) {
+            if let Some(range) = range_header {
                 let offset: Option<u64> = range
                     .to_str()
                     .ok()

--- a/crates/librqbit/src/tests/e2e_stream.rs
+++ b/crates/librqbit/src/tests/e2e_stream.rs
@@ -101,6 +101,8 @@ async fn e2e_stream() -> anyhow::Result<()> {
     let mut buf = Vec::<u8>::with_capacity(8192);
     stream.read_to_end(&mut buf).await?;
 
+    assert_eq!(buf.len(), orig_content.len(), "sizes differ");
+
     if buf != orig_content {
         panic!("contents differ")
     }

--- a/crates/librqbit/src/tests/e2e_stream.rs
+++ b/crates/librqbit/src/tests/e2e_stream.rs
@@ -1,6 +1,7 @@
 use std::{net::SocketAddr, time::Duration};
 
 use anyhow::Context;
+use tempfile::TempDir;
 use tokio::{io::AsyncReadExt, time::timeout};
 use tracing::info;
 
@@ -22,7 +23,7 @@ async fn e2e_stream() -> anyhow::Result<()> {
     let orig_content = std::fs::read(files.path().join("0.data")).unwrap();
 
     let server_session = Session::new_with_opts(
-        "/does-not-matter".into(),
+        files.path().into(),
         crate::SessionOptions {
             disable_dht: true,
             persistence: false,
@@ -63,8 +64,10 @@ async fn e2e_stream() -> anyhow::Result<()> {
         server_session.tcp_listen_port().unwrap(),
     );
 
+    let client_dir = TempDir::with_prefix("test_e2e_stream_client")?;
+
     let client_session = Session::new_with_opts(
-        "/does-not-matter".into(),
+        client_dir.path().into(),
         crate::SessionOptions {
             disable_dht: true,
             persistence: false,

--- a/crates/librqbit/src/torrent_state/streaming.rs
+++ b/crates/librqbit/src/torrent_state/streaming.rs
@@ -17,7 +17,7 @@ use futures::Future;
 use librqbit_core::lengths::{CurrentPiece, Lengths, ValidPieceIndex};
 use tokio::{
     io::{AsyncRead, AsyncSeek},
-    task::{block_in_place, spawn_blocking, JoinHandle},
+    task::{spawn_blocking, JoinHandle},
 };
 use tracing::{debug, error, trace};
 


### PR DESCRIPTION
Hi,

this relates to #153 .

`block_in_place` - I've tried here - it's relatively straightforward -  https://github.com/ikatson/rqbit/compare/main...izderadicka:naive_streaming_fix  

I also found a problem on e2e_streaming test - at least on my linux - it tried to create directory  in root /does-not-matter, which failed due to permissions..

Here I tried approach with `spawn_blocking` - which I feel is more "appropriate".  With blocking in event loop I think there can be problems if tokio runs in current thread executor.   On the other hand I understand that reading from local file would be fairly quick (taking into account Linux kernel's  fs caches etc.).  So it might not be faster, as some additional allocation is involved, when task should run in different thread - this might be still bit optimized - here is first rough attempt.

 