### PR TITLE
Mark dead code explicitly

### DIFF
--- a/crates/librqbit/src/api_error.rs
+++ b/crates/librqbit/src/api_error.rs
@@ -155,6 +155,7 @@ impl IntoResponse for ApiError {
 
 pub trait ApiErrorExt<T> {
     fn with_error_status_code(self, s: StatusCode) -> Result<T, ApiError>;
+    #[allow(dead_code)]
     fn with_plaintext_error(self, value: bool) -> Result<T, ApiError>;
 }
 

--- a/crates/librqbit/src/dht_utils.rs
+++ b/crates/librqbit/src/dht_utils.rs
@@ -19,6 +19,7 @@ pub enum ReadMetainfoResult<Rx> {
         seen: HashSet<SocketAddr>,
     },
     ChannelClosed {
+        #[allow(dead_code)]
         seen: HashSet<SocketAddr>,
     },
 }

--- a/crates/librqbit/src/torrent_state/live/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/mod.rs
@@ -150,7 +150,9 @@ impl TorrentStateLocked {
 
 #[derive(Default)]
 pub struct TorrentStateOptions {
+    #[allow(dead_code)]
     pub peer_connect_timeout: Option<Duration>,
+    #[allow(dead_code)]
     pub peer_read_write_timeout: Option<Duration>,
 }
 

--- a/crates/tracker_comms/src/tracker_comms_http.rs
+++ b/crates/tracker_comms/src/tracker_comms_http.rs
@@ -149,13 +149,18 @@ fn parse_compact_peers(b: &[u8]) -> Vec<SocketAddrV4> {
 
 #[derive(Deserialize, Debug)]
 pub struct TrackerResponse<'a> {
+    #[allow(dead_code)]
     #[serde(rename = "warning message", borrow)]
     pub warning_message: Option<ByteBuf<'a>>,
+    #[allow(dead_code)]
     pub complete: u64,
     pub interval: u64,
+    #[allow(dead_code)]
     #[serde(rename = "min interval")]
     pub min_interval: Option<u64>,
+    #[allow(dead_code)]
     pub tracker_id: Option<ByteBuf<'a>>,
+    #[allow(dead_code)]
     pub incomplete: u64,
     pub peers: Peers,
 }

--- a/crates/tracker_comms/src/tracker_comms_udp.rs
+++ b/crates/tracker_comms/src/tracker_comms_udp.rs
@@ -75,7 +75,9 @@ impl Request {
 #[derive(Debug)]
 pub struct AnnounceResponse {
     pub interval: u32,
+    #[allow(dead_code)]
     pub leechers: u32,
+    #[allow(dead_code)]
     pub seeders: u32,
     pub addrs: Vec<SocketAddrV4>,
 }


### PR DESCRIPTION
The warnings were annoying -  put there explicit annotation to get rid of them.