### PR TITLE
Add content type to streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1317,6 +1317,7 @@ dependencies = [
  "librqbit-upnp",
  "lru",
  "memmap2",
+ "mime_guess",
  "openssl",
  "parking_lot",
  "rand",
@@ -1538,6 +1539,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -2821,6 +2832,15 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-bidi"

--- a/crates/librqbit/Cargo.toml
+++ b/crates/librqbit/Cargo.toml
@@ -74,6 +74,7 @@ rlimit = "0.10.1"
 async-stream = "0.3.5"
 memmap2 = { version = "0.9.4" }
 lru = { version = "0.12.3", optional = true }
+mime_guess = { version = "2.0.5", default-features = false}
 
 [dev-dependencies]
 futures = { version = "0.3" }

--- a/crates/librqbit/src/api.rs
+++ b/crates/librqbit/src/api.rs
@@ -331,23 +331,18 @@ fn torrent_file_mime_type(
     info: &TorrentMetaV1Info<ByteBufOwned>,
     file_idx: usize,
 ) -> Result<&'static str> {
-    let file_name = info
-        .iter_filenames_and_lengths()?
-        .enumerate()
-        .find_map(|(idx, (f, _))| {
-            if idx == file_idx {
-                f.iter_components()
-                    .last()
-                    .and_then(|r| r.ok())
-                    .and_then(|s| mime_guess::from_path(s).first_raw())
-            } else {
-                None
-            }
-        });
-    file_name.ok_or_else(|| {
-        ApiError::new_from_text(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "cannot determine mime type for file",
-        )
-    })
+    info.iter_filenames_and_lengths()?
+        .nth(file_idx)
+        .and_then(|(f, _)| {
+            f.iter_components()
+                .last()
+                .and_then(|r| r.ok())
+                .and_then(|s| mime_guess::from_path(s).first_raw())
+        })
+        .ok_or_else(|| {
+            ApiError::new_from_text(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "cannot determine mime type for file",
+            )
+        })
 }

--- a/crates/librqbit/src/http_api.rs
+++ b/crates/librqbit/src/http_api.rs
@@ -206,12 +206,12 @@ impl HttpApi {
                         ))
                         .context("bug")?,
                     );
-                } else {
-                    output_headers.insert(
-                        http::header::CONTENT_LENGTH,
-                        HeaderValue::from_str(&format!("{}", stream.len())).context("bug")?,
-                    );
                 }
+            } else {
+                output_headers.insert(
+                    http::header::CONTENT_LENGTH,
+                    HeaderValue::from_str(&format!("{}", stream.len())).context("bug")?,
+                );
             }
 
             let s = tokio_util::io::ReaderStream::new(stream);

--- a/crates/librqbit/src/http_api.rs
+++ b/crates/librqbit/src/http_api.rs
@@ -167,6 +167,13 @@ impl HttpApi {
             let mut output_headers = HeaderMap::new();
             output_headers.insert("Accept-Ranges", HeaderValue::from_static("bytes"));
 
+            if let Ok(mime) = state.torrent_file_mime_type(idx, file_id) {
+                output_headers.insert(
+                    http::header::CONTENT_TYPE,
+                    HeaderValue::from_str(mime).context("bug - invalid MIME")?,
+                );
+            }
+
             let range_header = headers.get(http::header::RANGE);
             trace!(torrent_id=idx, file_id=file_id, range=?range_header, "request for HTTP stream");
 

--- a/crates/librqbit/webui/src/components/FileListInput.tsx
+++ b/crates/librqbit/webui/src/components/FileListInput.tsx
@@ -158,8 +158,7 @@ const FileTreeComponent: React.FC<{
   const fileLink = (file: TorrentFileForCheckbox) => {
     if (
       allowStream &&
-      torrentId != null &&
-      /\.(mp4|mkv|avi)$/.test(file.filename)
+      torrentId != null
     ) {
       return API.getTorrentStreamUrl(torrentId, file.id, file.filename);
     }

--- a/crates/librqbit/webui/src/components/forms/FormCheckbox.tsx
+++ b/crates/librqbit/webui/src/components/forms/FormCheckbox.tsx
@@ -39,6 +39,7 @@ export const FormCheckbox: React.FC<{
         {labelLink ? (
           <a
             href={labelLink}
+            target="_blank"
             className="text-blue-600 dark:text-blue-500 hover:underline"
           >
             {label}


### PR DESCRIPTION
This change is motivated by need to stream/open/download other files from torrent than mp4/mkv/avi.
Usecase is mainly if rqbit is running on other computer (like nas server) - so I can see what is in other files, download them to notebook etc.  Ad there are other media files, which streams nicely in browser - mp3 ....

Changes:
- add content-type header to stream - helps with handling the file in browser
- change slightly when content-length is send - always when there is not  content-range
- in UI - add link to all files in torrent and add target to link to open in new tab

Note: for some reason  files `crates/librqbit/webui/dist`, where checked in to repo, but they are also in .gitignore - I guess they are result of your release build process - so I did not included them.