### PR TITLE
Update leaky_bucket version - current version have issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,13 +1262,13 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "leaky-bucket"
-version = "1.0.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb491abd89e9794d50f93c8db610a29509123e3fbbc9c8c67a528e9391cd853"
+checksum = "0a396bb213c2d09ed6c5495fd082c991b6ab39c9daf4fff59e6727f85c73e4c5"
 dependencies = [
  "parking_lot",
+ "pin-project-lite",
  "tokio",
- "tracing",
 ]
 
 [[package]]

--- a/crates/dht/Cargo.toml
+++ b/crates/dht/Cargo.toml
@@ -19,7 +19,7 @@ tokio = { version = "1", features = [
 ] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 serde = { version = "1", features = ["derive"] }
-leaky-bucket = "1"
+leaky-bucket = "1.1"
 serde_json = "1"
 hex = "0.4"
 bencode = { path = "../bencode", default-features = false, package = "librqbit-bencode", version = "2.2.2" }


### PR DESCRIPTION
Version 1.0  has some race condition,  it sometimes panics (when new torrent is added  - see below), version 1.1 seems to be stable for now (also there is crate leaky_bucket_light as alternative, if problems remains).

```
thread 'tokio-runtime-worker' panicked at /home/ivan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/leaky-bucket-1.0.1/src/linked_list.rs:385:13:
assertion `left == right` failed
  left: Some(0x7eac7402bef0)
 right: Some(0x7eac10051cb0)
stack backtrace:
   0: rust_begin_unwind
             at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/std/src/panicking.rs:652:5
   1: core::panicking::panic_fmt
             at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/core/src/panicking.rs:72:14
   2: core::panicking::assert_failed_inner
             at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/core/src/panicking.rs:408:17
   3: core::panicking::assert_failed
             at /rustc/051478957371ee0084a7c0913941d2a8c4757bb9/library/core/src/panicking.rs:363:5
   4: leaky_bucket::linked_list::LinkedList<T>::remove
             at /home/ivan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/leaky-bucket-1.0.1/src/linked_list.rs:385:13
   5: leaky_bucket::AcquireState::release_remaining
             at /home/ivan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/leaky-bucket-1.0.1/src/lib.rs:923:13
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
Aborted (core dumped)
```