### PR TITLE
Playlis for playable media

### DIFF
--- a/crates/librqbit/src/http_api.rs
+++ b/crates/librqbit/src/http_api.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use axum::body::Bytes;
-use axum::extract::{Path, Query, Request, State};
+use axum::extract::{Path, Query, State};
 use axum::response::{IntoResponse, Redirect};
 use axum::routing::{get, post};
 use futures::future::BoxFuture;
@@ -148,8 +148,7 @@ impl HttpApi {
                 .into_iter()
                 .enumerate()
                 .filter_map(|(file_idx, f)| {
-                    let file_name = f.name;
-                    let is_playable = mime_guess::from_path(&file_name)
+                    let is_playable = mime_guess::from_path(&f.name)
                         .first()
                         .map(|mime| {
                             mime.type_() == mime_guess::mime::VIDEO
@@ -157,6 +156,7 @@ impl HttpApi {
                         })
                         .unwrap_or(false);
                     if is_playable {
+                        let file_name = urlencoding::encode(&f.name);
                         Some(format!(
                             "http://{host}/torrents/{idx}/stream/{file_idx}/{file_name}"
                         ))

--- a/crates/librqbit/webui/src/components/buttons/TorrentActions.tsx
+++ b/crates/librqbit/webui/src/components/buttons/TorrentActions.tsx
@@ -3,7 +3,7 @@ import { TorrentStats } from "../../api-types";
 import { APIContext, RefreshTorrentStatsContext } from "../../context";
 import { IconButton } from "./IconButton";
 import { DeleteTorrentModal } from "../modal/DeleteTorrentModal";
-import { FaCog, FaPause, FaPlay, FaTrash } from "react-icons/fa";
+import { FaCog, FaPause, FaPlay, FaTrash, FaClipboardList } from "react-icons/fa";
 import { useErrorStore } from "../../stores/errorStore";
 
 export const TorrentActions: React.FC<{
@@ -93,6 +93,11 @@ export const TorrentActions: React.FC<{
       )}
       <IconButton onClick={startDeleting} disabled={disabled}>
         <FaTrash className="hover:text-red-500" />
+      </IconButton>
+      <IconButton onClick={() => {alert("Open this playlist link in external player like VLC")}}>
+      <a target="_blank" href={"/torrents/"+id+"/playlist"}>
+        <FaClipboardList className="hover:text-green-500"/>
+      </a>
       </IconButton>
       <DeleteTorrentModal id={id} show={deleting} onHide={cancelDeleting} />
     </div>


### PR DESCRIPTION
Rationale behind this PR:

Many torrents contains several playable files (series, albums ...). 
Good players like VLC has posibility to open a playlist - combined with streaming capability of rqbit this enables to play whole content of a torrent in the player (just by open playlist link in the player).

This is a minimal implementation, that works with VLC, couple more things I thought about:
- MIME type of playlist - the only official MIME is registered by Apple for HLS - this is not exactly this case as as text/plain works with VLC, so  I did not explore further - this  article is good source for m3u playlist "standard" - https://en.wikipedia.org/wiki/M3U#Internet_media_types
- ordering of files - now using the ordering provided by the program, not sure if reodering could be useful.
- UI icon - now on whole torrent - but I though also on possibility to have it on directory level. Current implementation was easiest to implement. But possibility to have playlist for  just particular directory sounds interesting.
