### PR TITLE
SOCKS5 proxy support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1346,6 +1346,7 @@ dependencies = [
  "size_format",
  "tempfile",
  "tokio",
+ "tokio-socks",
  "tokio-stream",
  "tokio-test",
  "tokio-util",
@@ -2145,6 +2146,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
+ "tokio-socks",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -2697,6 +2699,18 @@ checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
  "rustls",
  "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror",
  "tokio",
 ]
 

--- a/crates/librqbit/Cargo.toml
+++ b/crates/librqbit/Cargo.toml
@@ -42,7 +42,10 @@ anyhow = "1"
 itertools = "0.12"
 http = "1"
 regex = "1"
-reqwest = { version = "0.12", default-features = false, features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = [
+    "json",
+    "socks",
+] }
 urlencoding = "2"
 byteorder = "1"
 bincode = "1"
@@ -75,6 +78,7 @@ async-stream = "0.3.5"
 memmap2 = { version = "0.9.4" }
 lru = { version = "0.12.3", optional = true }
 mime_guess = { version = "2.0.5", default-features = false }
+tokio-socks = "0.5.2"
 
 [dev-dependencies]
 futures = { version = "0.3" }

--- a/crates/librqbit/src/lib.rs
+++ b/crates/librqbit/src/lib.rs
@@ -41,6 +41,7 @@ mod read_buf;
 mod session;
 mod spawn_utils;
 pub mod storage;
+mod stream_connect;
 mod torrent_state;
 pub mod tracing_subscriber_config_utils;
 mod type_aliases;

--- a/crates/librqbit/src/stream_connect.rs
+++ b/crates/librqbit/src/stream_connect.rs
@@ -1,0 +1,82 @@
+use std::net::SocketAddr;
+
+use anyhow::Context;
+
+#[derive(Debug, Clone)]
+pub(crate) struct SocksProxyConfig {
+    pub host: String,
+    pub port: u16,
+    pub username_password: Option<(String, String)>,
+}
+
+impl SocksProxyConfig {
+    pub fn parse(url: &str) -> anyhow::Result<Self> {
+        let url = ::url::Url::parse(url).context("invalid proxy URL")?;
+        if url.scheme() != "socks5" {
+            anyhow::bail!("proxy URL should have socks5 scheme");
+        }
+        let host = url.host_str().context("missing host")?;
+        let port = url.port().context("missing port")?;
+        let up = url
+            .password()
+            .map(|p| (url.username().to_owned(), p.to_owned()));
+        Ok(Self {
+            host: host.to_owned(),
+            port,
+            username_password: up,
+        })
+    }
+
+    async fn connect(
+        &self,
+        addr: SocketAddr,
+    ) -> anyhow::Result<impl tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin> {
+        let proxy_addr = (self.host.as_str(), self.port);
+
+        if let Some((username, password)) = self.username_password.as_ref() {
+            tokio_socks::tcp::Socks5Stream::connect_with_password(
+                proxy_addr,
+                addr,
+                username.as_str(),
+                password.as_str(),
+            )
+            .await
+            .context("error connecting to proxy")
+        } else {
+            tokio_socks::tcp::Socks5Stream::connect(proxy_addr, addr)
+                .await
+                .context("error connecting to proxy")
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct StreamConnector {
+    proxy_config: Option<SocksProxyConfig>,
+}
+
+impl From<Option<SocksProxyConfig>> for StreamConnector {
+    fn from(proxy_config: Option<SocksProxyConfig>) -> Self {
+        Self { proxy_config }
+    }
+}
+
+pub(crate) trait AsyncReadWrite:
+    tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin
+{
+}
+
+impl<T> AsyncReadWrite for T where T: tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin {}
+
+impl StreamConnector {
+    pub async fn connect(&self, addr: SocketAddr) -> anyhow::Result<Box<dyn AsyncReadWrite>> {
+        if let Some(proxy) = self.proxy_config.as_ref() {
+            return Ok(Box::new(proxy.connect(addr).await?));
+        }
+        Ok(Box::new(
+            tokio::net::TcpStream::connect(addr)
+                .await
+                .context("error connecting")?,
+        ))
+    }
+}

--- a/crates/librqbit/src/tests/e2e.rs
+++ b/crates/librqbit/src/tests/e2e.rs
@@ -74,6 +74,7 @@ async fn test_e2e() {
                         enable_upnp_port_forwarding: false,
                         default_storage_factory: None,
                         defer_writes_up_to: None,
+                        ..Default::default()
                     },
                 )
                 .await

--- a/crates/librqbit/src/torrent_state/live/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/mod.rs
@@ -382,6 +382,7 @@ impl TorrentStateLive {
             &handler,
             Some(options),
             self.meta.spawner,
+            self.meta.connector.clone(),
         );
         let requester = handler.task_peer_chunk_requester();
 
@@ -444,6 +445,7 @@ impl TorrentStateLive {
             &handler,
             Some(options),
             state.meta.spawner,
+            state.meta.connector.clone(),
         );
         let requester = handler.task_peer_chunk_requester();
 

--- a/crates/rqbit/src/main.rs
+++ b/crates/rqbit/src/main.rs
@@ -320,6 +320,7 @@ async fn async_main(opts: Opts) -> anyhow::Result<()> {
                 wrap(FilesystemStorageFactory::default()).boxed()
             }
         }),
+        socks_proxy: None,
     };
 
     let stats_printer = |session: Arc<Session>| async move {

--- a/crates/rqbit/src/main.rs
+++ b/crates/rqbit/src/main.rs
@@ -115,6 +115,13 @@ struct Opts {
     /// If you use it, you know what you are doing.
     #[arg(long)]
     experimental_mmap_storage: bool,
+
+    /// Provide a socks5 URL.
+    /// The format is socks5://[username:password]@host:port
+    ///
+    /// Alternatively, set this as an environment variable RQBIT_SOCKS_PROXY_URL
+    #[arg(long)]
+    socks_url: Option<String>,
 }
 
 #[derive(Parser)]
@@ -281,6 +288,10 @@ async fn async_main(opts: Opts) -> anyhow::Result<()> {
         Err(e) => warn!("failed increasing open file limit: {:#}", e),
     };
 
+    let socks_url = opts
+        .socks_url
+        .or_else(|| std::env::var("RQBIT_SOCKS_PROXY_URL").ok());
+
     let mut sopts = SessionOptions {
         disable_dht: opts.disable_dht,
         disable_dht_persistence: opts.disable_dht_persistence,
@@ -320,7 +331,7 @@ async fn async_main(opts: Opts) -> anyhow::Result<()> {
                 wrap(FilesystemStorageFactory::default()).boxed()
             }
         }),
-        socks_proxy: None,
+        socks_proxy_url: socks_url,
     };
 
     let stats_printer = |session: Arc<Session>| async move {


### PR DESCRIPTION
Addresses https://github.com/ikatson/rqbit/issues/81

Usage:

rqbit --socks-url 'socks5://localhost:1080' ...

OR with environment variable

RQBIT_SOCKS_PROXY_URL=socks5://localhost:1080 rqbit ...

if you need username and password, the URL should be like
socks5://user:password@host:port

