### PR TITLE
Sort playlist and fix playlist URL copy

### DIFF
--- a/crates/librqbit/webui/src/http-api.ts
+++ b/crates/librqbit/webui/src/http-api.ts
@@ -152,6 +152,6 @@ export const API: RqbitAPI & { getVersion: () => Promise<string> } = {
     return url;
   },
   getPlaylistUrl: (index: number) => {
-    return apiUrl + `/torrents/${index}/playlist`;
+    return (apiUrl || window.origin)  + `/torrents/${index}/playlist`;
   },
 };


### PR DESCRIPTION
Thanks for merging #167 and fixing UI in #169.  Couple additions:

Playlist should be sorted  and  copied playlist URL should be always absolute (which was not the case, when Web was served from localhost:3030 - then apiUrl is "").