### PR TITLE
Playlist ordering and  mime

### DIFF
--- a/crates/librqbit/src/http_api.rs
+++ b/crates/librqbit/src/http_api.rs
@@ -183,6 +183,7 @@ impl HttpApi {
                         "application/vnd.apple.mpegurl; charset=utf-8",
                     )]
                 } else {
+                    // apple mime does not work with VLC on linux
                     [("Content-Type", "text/plain; charset=utf-8")]
                 },
                 body,

--- a/crates/librqbit/src/http_api.rs
+++ b/crates/librqbit/src/http_api.rs
@@ -152,7 +152,7 @@ impl HttpApi {
                     }
                 })
                 .collect::<Vec<_>>();
-            playlist_items.sort();
+            playlist_items.sort_by(|left, right| left.1.cmp(&right.1));
             Ok(playlist_items)
         }
 
@@ -177,10 +177,14 @@ impl HttpApi {
                 })
                 .join("\r\n");
             (
-                [(
-                    "Content-Type",
-                    "application/vnd.apple.mpegurl; charset=utf-8",
-                )],
+                if cfg!(any(target_os = "macos", target_os = "ios")) {
+                    [(
+                        "Content-Type",
+                        "application/vnd.apple.mpegurl; charset=utf-8",
+                    )]
+                } else {
+                    [("Content-Type", "text/plain; charset=utf-8")]
+                },
                 body,
             )
         }


### PR DESCRIPTION
Thanks for #172 - definitely better code organization,  just couple of edits from my linux perspective:
- torrent PL should be sorted by filename, torrent file id ordering is often not "natural"
- apple MIME is not working well with VLC on linux - so leaving it for apple platforms,  simple text/plain works on linux fine.

