### PR TITLE
Fix playlist content type issues

### DIFF
--- a/crates/librqbit/src/http_api.rs
+++ b/crates/librqbit/src/http_api.rs
@@ -177,15 +177,13 @@ impl HttpApi {
                 })
                 .join("\r\n");
             (
-                if cfg!(any(target_os = "macos", target_os = "ios")) {
-                    [(
-                        "Content-Type",
-                        "application/vnd.apple.mpegurl; charset=utf-8",
-                    )]
-                } else {
-                    // apple mime does not work with VLC on linux
-                    [("Content-Type", "text/plain; charset=utf-8")]
-                },
+                [
+                    ("Content-Type", "application/mpegurl; charset=utf-8"),
+                    (
+                        "Content-Disposition",
+                        "attachment; filename=\"rqbit-playlist.m3u8\"",
+                    ),
+                ],
                 body,
             )
         }

--- a/crates/librqbit/webui/src/api-types.ts
+++ b/crates/librqbit/webui/src/api-types.ts
@@ -94,7 +94,7 @@ export interface ErrorDetails {
   path?: string;
   status?: number;
   statusText?: string;
-  text: string;
+  text: string | React.ReactNode;
 }
 
 export type Duration = number;

--- a/crates/librqbit/webui/src/components/buttons/TorrentActions.tsx
+++ b/crates/librqbit/webui/src/components/buttons/TorrentActions.tsx
@@ -11,6 +11,7 @@ import {
   FaClipboardList,
 } from "react-icons/fa";
 import { useErrorStore } from "../../stores/errorStore";
+import { ErrorComponent } from "../ErrorComponent";
 
 export const TorrentActions: React.FC<{
   id: number;
@@ -45,7 +46,7 @@ export const TorrentActions: React.FC<{
             text: `Error starting torrent id=${id}`,
             details: e,
           });
-        }
+        },
       )
       .finally(() => setDisabled(false));
   };
@@ -62,7 +63,7 @@ export const TorrentActions: React.FC<{
             text: `Error pausing torrent id=${id}`,
             details: e,
           });
-        }
+        },
       )
       .finally(() => setDisabled(false));
   };
@@ -88,9 +89,21 @@ export const TorrentActions: React.FC<{
     try {
       await navigator.clipboard.writeText(playlistUrl);
     } catch (e) {
-      setCloseableError({
-        text: "Error",
-        details: { text: `Error copying playlist URL to clipboard: ${e}` },
+      setAlert({
+        text: "Copy playlist URL",
+        details: {
+          text: (
+            <>
+              <p>
+                Copy{" "}
+                <a href={playlistUrl} className="text-blue-500">
+                  playlist URL
+                </a>{" "}
+                to clipboard and paste into e.g. VLC to play.
+              </p>
+            </>
+          ),
+        },
       });
       return;
     }
@@ -98,7 +111,7 @@ export const TorrentActions: React.FC<{
     setAlert({
       text: "Copied",
       details: {
-        text: `Playlist URL copied to clipboard. Paste into e.g. VLC to play.`,
+        text: "Playlist URL copied to clipboard. Paste into e.g. VLC to play.",
       },
     });
   };


### PR DESCRIPTION
- change content-type to be audio/mpegurl. Validated it works in VLC, even for nested playlists.
- copying to clipboard doesn't work if rqbit is not under HTTPS and not localhost - made this nicer in UI
- added content-disposition header so that it downloads with .m3u suffix