### PR TITLE
Add an HTTP endopoint to resolve magnet URL to bytes (address #177)

### DIFF
--- a/crates/bencode/src/lib.rs
+++ b/crates/bencode/src/lib.rs
@@ -1,4 +1,5 @@
 mod bencode_value;
+pub mod raw_value;
 mod serde_bencode_de;
 mod serde_bencode_ser;
 

--- a/crates/bencode/src/raw_value.rs
+++ b/crates/bencode/src/raw_value.rs
@@ -1,0 +1,28 @@
+use serde::Serialize;
+
+pub struct RawValue<T>(pub T);
+
+pub(crate) const TAG: &str = "::librqbit_bencode::RawValue";
+
+impl<T> Serialize for RawValue<T>
+where
+    T: AsRef<[u8]>,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        struct Wrapper<'a>(&'a [u8]);
+
+        impl<'a> Serialize for Wrapper<'a> {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                serializer.serialize_bytes(self.0)
+            }
+        }
+
+        serializer.serialize_newtype_struct(TAG, &Wrapper(self.0.as_ref()))
+    }
+}

--- a/crates/bencode/src/serde_bencode_ser.rs
+++ b/crates/bencode/src/serde_bencode_ser.rs
@@ -328,12 +328,18 @@ impl<'ser, W: std::io::Write> Serializer for &'ser mut BencodeSerializer<W> {
 
     fn serialize_newtype_struct<T>(
         self,
-        _name: &'static str,
-        _value: &T,
+        name: &'static str,
+        value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
         T: ?Sized + serde::Serialize,
     {
+        if name == crate::raw_value::TAG {
+            self.hack_no_bytestring_prefix = true;
+            value.serialize(&mut *self)?;
+            self.hack_no_bytestring_prefix = false;
+            return Ok(());
+        }
         Err(SerError::custom_with_ser(
             "bencode doesn't support newtype structs",
             self,

--- a/crates/librqbit/src/api.rs
+++ b/crates/librqbit/src/api.rs
@@ -191,6 +191,7 @@ impl Api {
                 only_files,
                 seen_peers,
                 output_folder,
+                ..
             }) => ApiAddTorrentResponse {
                 id: None,
                 output_folder: output_folder.to_string_lossy().into_owned(),

--- a/crates/librqbit/src/dht_utils.rs
+++ b/crates/librqbit/src/dht_utils.rs
@@ -16,6 +16,7 @@ use librqbit_core::hash_id::Id20;
 pub enum ReadMetainfoResult<Rx> {
     Found {
         info: TorrentMetaV1Info<ByteBufOwned>,
+        bytes: ByteBufOwned,
         rx: Rx,
         seen: HashSet<SocketAddr>,
     },
@@ -80,7 +81,7 @@ pub async fn read_metainfo_from_peer_receiver<A: Stream<Item = SocketAddr> + Unp
             },
             done = unordered.next(), if !unordered.is_empty() => {
                 match done {
-                    Some(Ok(info)) => return ReadMetainfoResult::Found { info, seen, rx: addrs },
+                    Some(Ok(info)) => return ReadMetainfoResult::Found { info: info.0, bytes: info.1, seen, rx: addrs },
                     Some(Err(e)) => {
                         debug!("{:#}", e);
                     },

--- a/crates/librqbit/src/dht_utils.rs
+++ b/crates/librqbit/src/dht_utils.rs
@@ -16,7 +16,7 @@ use librqbit_core::hash_id::Id20;
 pub enum ReadMetainfoResult<Rx> {
     Found {
         info: TorrentMetaV1Info<ByteBufOwned>,
-        bytes: ByteBufOwned,
+        info_bytes: ByteBufOwned,
         rx: Rx,
         seen: HashSet<SocketAddr>,
     },
@@ -81,7 +81,7 @@ pub async fn read_metainfo_from_peer_receiver<A: Stream<Item = SocketAddr> + Unp
             },
             done = unordered.next(), if !unordered.is_empty() => {
                 match done {
-                    Some(Ok(info)) => return ReadMetainfoResult::Found { info: info.0, bytes: info.1, seen, rx: addrs },
+                    Some(Ok((info, info_bytes))) => return ReadMetainfoResult::Found { info, info_bytes, seen, rx: addrs },
                     Some(Err(e)) => {
                         debug!("{:#}", e);
                     },

--- a/crates/librqbit/src/http_api.rs
+++ b/crates/librqbit/src/http_api.rs
@@ -205,13 +205,13 @@ impl HttpApi {
             let (info, content) = match added {
                 crate::AddTorrentResponse::AlreadyManaged(_, handle) => (
                     handle.info().info.clone(),
-                    handle.info().torrent_bytes.clone().0,
+                    handle.info().torrent_bytes.clone(),
                 ),
                 crate::AddTorrentResponse::ListOnly(ListOnlyResponse {
                     info,
                     torrent_bytes,
                     ..
-                }) => (info, torrent_bytes.0),
+                }) => (info, torrent_bytes),
                 crate::AddTorrentResponse::Added(_, _) => {
                     return Err(ApiError::new_from_text(
                         StatusCode::INTERNAL_SERVER_ERROR,
@@ -226,7 +226,7 @@ impl HttpApi {
             );
 
             if let Some(name) = info.name.as_ref() {
-                if let Ok(name) = std::str::from_utf8(&name) {
+                if let Ok(name) = std::str::from_utf8(name) {
                     if let Ok(h) =
                         HeaderValue::from_str(&format!("attachment; filename=\"{}.torrent\"", name))
                     {

--- a/crates/librqbit/src/peer_info_reader/mod.rs
+++ b/crates/librqbit/src/peer_info_reader/mod.rs
@@ -32,7 +32,7 @@ pub(crate) async fn read_metainfo_from_peer(
     peer_connection_options: Option<PeerConnectionOptions>,
     spawner: BlockingSpawner,
     connector: Arc<StreamConnector>,
-) -> anyhow::Result<TorrentAndBytes> {
+) -> anyhow::Result<TorrentAndInfoBytes> {
     let (result_tx, result_rx) = tokio::sync::oneshot::channel::<
         anyhow::Result<(TorrentMetaV1Info<ByteBufOwned>, ByteBufOwned)>,
     >();
@@ -136,13 +136,13 @@ impl HandlerLocked {
     }
 }
 
-pub type TorrentAndBytes = (TorrentMetaV1Info<ByteBufOwned>, ByteBufOwned);
+pub type TorrentAndInfoBytes = (TorrentMetaV1Info<ByteBufOwned>, ByteBufOwned);
 
 struct Handler {
     addr: SocketAddr,
     info_hash: Id20,
     writer_tx: UnboundedSender<WriterRequest>,
-    result_tx: Mutex<Option<tokio::sync::oneshot::Sender<anyhow::Result<TorrentAndBytes>>>>,
+    result_tx: Mutex<Option<tokio::sync::oneshot::Sender<anyhow::Result<TorrentAndInfoBytes>>>>,
     locked: RwLock<Option<HandlerLocked>>,
 }
 

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -940,9 +940,6 @@ impl Session {
     ) -> BoxFuture<'a, anyhow::Result<AddTorrentResponse>> {
         async move {
             // Magnet links are different in that we first need to discover the metadata.
-            let span = error_span!("add_torrent");
-            let _ = span.enter();
-
             let opts = opts.unwrap_or_default();
 
             let paused = opts.list_only || opts.paused;
@@ -1076,6 +1073,7 @@ impl Session {
 
             self.main_torrent_info(add_res, opts).await
         }
+        .instrument(error_span!("add_torrent"))
         .boxed()
     }
 

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -1461,15 +1461,6 @@ mod tests {
 
         let generated_torrent =
             torrent_file_from_info_bytes(parsed.info_bytes.as_ref(), &parsed_trackers).unwrap();
-        {
-            let mut f = std::fs::OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(true)
-                .open("/tmp/generated")
-                .unwrap();
-            f.write_all(&generated_torrent).unwrap();
-        }
         let generated_parsed =
             torrent_from_bytes_ext::<ByteBuf>(generated_torrent.as_ref()).unwrap();
         assert_eq!(parsed.meta.info_hash, generated_parsed.meta.info_hash);

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -1438,8 +1438,6 @@ impl tracker_comms::TorrentStatsProvider for PeerRxTorrentInfo {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Write;
-
     use buffers::ByteBuf;
     use itertools::Itertools;
     use librqbit_core::torrent_metainfo::{torrent_from_bytes_ext, TorrentMetaV1};

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -502,6 +502,15 @@ async fn create_tcp_listener(
     bail!("no free TCP ports in range {port_range:?}");
 }
 
+fn torrent_file_from_info_and_bytes(
+    info: &TorrentMetaV1Info<ByteBufOwned>,
+    info_hash: &Id20,
+    info_bytes: &[u8],
+    trackers: &[String],
+) -> Bytes {
+    todo!()
+}
+
 pub(crate) struct CheckedIncomingConnection {
     pub addr: SocketAddr,
     pub stream: tokio::net::TcpStream,
@@ -986,16 +995,22 @@ impl Session {
                     {
                         ReadMetainfoResult::Found {
                             info,
-                            bytes,
+                            info_bytes,
                             rx,
                             seen,
                         } => {
                             debug!(?info, "received result from DHT");
+                            let trackers = magnet.trackers.into_iter().unique().collect_vec();
                             InternalAddResult {
                                 info_hash,
+                                torrent_bytes: torrent_file_from_info_and_bytes(
+                                    &info,
+                                    &info_hash,
+                                    &info_bytes,
+                                    &trackers,
+                                ),
                                 info,
-                                torrent_bytes: Bytes::from(bytes.0),
-                                trackers: magnet.trackers.into_iter().unique().collect(),
+                                trackers,
                                 peer_rx: Some(rx),
                                 initial_peers: seen.into_iter().collect(),
                             }

--- a/crates/librqbit/src/torrent_state/mod.rs
+++ b/crates/librqbit/src/torrent_state/mod.rs
@@ -14,6 +14,7 @@ use std::time::Duration;
 use anyhow::bail;
 use anyhow::Context;
 use buffers::ByteBufOwned;
+use bytes::Bytes;
 use futures::future::BoxFuture;
 use futures::FutureExt;
 use librqbit_core::hash_id::Id20;
@@ -99,7 +100,7 @@ pub(crate) struct ManagedTorrentOptions {
 
 pub struct ManagedTorrentInfo {
     pub info: TorrentMetaV1Info<ByteBufOwned>,
-    pub torrent_bytes: ByteBufOwned,
+    pub torrent_bytes: Bytes,
     pub info_hash: Id20,
     pub(crate) spawner: BlockingSpawner,
     pub trackers: HashSet<String>,
@@ -502,7 +503,7 @@ pub(crate) struct ManagedTorrentBuilder {
     info: TorrentMetaV1Info<ByteBufOwned>,
     output_folder: PathBuf,
     info_hash: Id20,
-    torrent_bytes: ByteBufOwned,
+    torrent_bytes: Bytes,
     force_tracker_interval: Option<Duration>,
     peer_connect_timeout: Option<Duration>,
     peer_read_write_timeout: Option<Duration>,
@@ -520,7 +521,7 @@ impl ManagedTorrentBuilder {
     pub fn new(
         info: TorrentMetaV1Info<ByteBufOwned>,
         info_hash: Id20,
-        torrent_bytes: ByteBufOwned,
+        torrent_bytes: Bytes,
         output_folder: PathBuf,
         storage_factory: BoxStorageFactory,
     ) -> Self {

--- a/crates/librqbit/src/torrent_state/mod.rs
+++ b/crates/librqbit/src/torrent_state/mod.rs
@@ -99,6 +99,7 @@ pub(crate) struct ManagedTorrentOptions {
 
 pub struct ManagedTorrentInfo {
     pub info: TorrentMetaV1Info<ByteBufOwned>,
+    pub torrent_bytes: ByteBufOwned,
     pub info_hash: Id20,
     pub(crate) spawner: BlockingSpawner,
     pub trackers: HashSet<String>,
@@ -501,6 +502,7 @@ pub(crate) struct ManagedTorrentBuilder {
     info: TorrentMetaV1Info<ByteBufOwned>,
     output_folder: PathBuf,
     info_hash: Id20,
+    torrent_bytes: ByteBufOwned,
     force_tracker_interval: Option<Duration>,
     peer_connect_timeout: Option<Duration>,
     peer_read_write_timeout: Option<Duration>,
@@ -518,12 +520,14 @@ impl ManagedTorrentBuilder {
     pub fn new(
         info: TorrentMetaV1Info<ByteBufOwned>,
         info_hash: Id20,
+        torrent_bytes: ByteBufOwned,
         output_folder: PathBuf,
         storage_factory: BoxStorageFactory,
     ) -> Self {
         Self {
             info,
             info_hash,
+            torrent_bytes,
             spawner: None,
             force_tracker_interval: None,
             peer_connect_timeout: None,
@@ -608,6 +612,7 @@ impl ManagedTorrentBuilder {
             span,
             file_infos,
             info: self.info,
+            torrent_bytes: self.torrent_bytes,
             info_hash: self.info_hash,
             trackers: self.trackers.into_iter().collect(),
             spawner: self.spawner.unwrap_or_default(),


### PR DESCRIPTION
```curl -v --data-raw 'magnet:?...' http://localhost:3030/torrents/resolve_magnet > /tmp/file.torrent```