### PR TITLE
Use bytes crate for zerocopy and memory re-use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1363,6 +1363,7 @@ name = "librqbit-bencode"
 version = "2.2.3"
 dependencies = [
  "anyhow",
+ "bytes",
  "librqbit-buffers",
  "librqbit-clone-to-owned",
  "librqbit-sha1-wrapper",
@@ -1373,6 +1374,7 @@ dependencies = [
 name = "librqbit-buffers"
 version = "3.0.1"
 dependencies = [
+ "bytes",
  "librqbit-clone-to-owned",
  "serde",
 ]
@@ -1380,12 +1382,16 @@ dependencies = [
 [[package]]
 name = "librqbit-clone-to-owned"
 version = "2.2.1"
+dependencies = [
+ "bytes",
+]
 
 [[package]]
 name = "librqbit-core"
 version = "3.9.0"
 dependencies = [
  "anyhow",
+ "bytes",
  "data-encoding",
  "directories",
  "hex 0.4.3",
@@ -1409,6 +1415,7 @@ version = "5.0.4"
 dependencies = [
  "anyhow",
  "backoff",
+ "bytes",
  "chrono",
  "dashmap",
  "futures",
@@ -1437,6 +1444,7 @@ dependencies = [
  "bincode",
  "bitvec",
  "byteorder",
+ "bytes",
  "librqbit-bencode",
  "librqbit-buffers",
  "librqbit-clone-to-owned",

--- a/crates/bencode/Cargo.toml
+++ b/crates/bencode/Cargo.toml
@@ -16,3 +16,4 @@ buffers = { path = "../buffers", package = "librqbit-buffers", version = "3.0.1"
 clone_to_owned = { path = "../clone_to_owned", package = "librqbit-clone-to-owned", version = "2.2.1" }
 anyhow = "1"
 sha1w = { path = "../sha1w", default-features = false, package = "librqbit-sha1-wrapper", version = "3.0.0" }
+bytes = "1.7.1"

--- a/crates/bencode/src/bencode_value.rs
+++ b/crates/bencode/src/bencode_value.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, marker::PhantomData};
 
 use buffers::{ByteBuf, ByteBufOwned};
+use bytes::Bytes;
 use clone_to_owned::CloneToOwned;
 use serde::Deserializer;
 
@@ -122,12 +123,12 @@ where
 {
     type Target = BencodeValue<<BufT as CloneToOwned>::Target>;
 
-    fn clone_to_owned(&self) -> Self::Target {
+    fn clone_to_owned(&self, within_buffer: Option<&Bytes>) -> Self::Target {
         match self {
-            BencodeValue::Bytes(b) => BencodeValue::Bytes(b.clone_to_owned()),
+            BencodeValue::Bytes(b) => BencodeValue::Bytes(b.clone_to_owned(within_buffer)),
             BencodeValue::Integer(i) => BencodeValue::Integer(*i),
-            BencodeValue::List(l) => BencodeValue::List(l.clone_to_owned()),
-            BencodeValue::Dict(d) => BencodeValue::Dict(d.clone_to_owned()),
+            BencodeValue::List(l) => BencodeValue::List(l.clone_to_owned(within_buffer)),
+            BencodeValue::Dict(d) => BencodeValue::Dict(d.clone_to_owned(within_buffer)),
         }
     }
 }

--- a/crates/buffers/Cargo.toml
+++ b/crates/buffers/Cargo.toml
@@ -12,3 +12,4 @@ readme = "README.md"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 clone_to_owned = { path = "../clone_to_owned", package = "librqbit-clone-to-owned", version = "2.2.1" }
+bytes = "1"

--- a/crates/buffers/src/lib.rs
+++ b/crates/buffers/src/lib.rs
@@ -101,6 +101,9 @@ impl<'a> CloneToOwned for ByteBuf<'a> {
 
             if needle >= haystack && needle_end <= haystack_end {
                 return ByteBufOwned(within_buffer.slice_ref(self.0.as_ref()));
+            } else {
+                #[cfg(debug_assertions)]
+                panic!("bug: broken buffers! not inside within_buffer");
             }
         }
 

--- a/crates/buffers/src/lib.rs
+++ b/crates/buffers/src/lib.rs
@@ -162,6 +162,12 @@ impl From<Vec<u8>> for ByteBufOwned {
     }
 }
 
+impl From<Bytes> for ByteBufOwned {
+    fn from(b: Bytes) -> Self {
+        Self(b)
+    }
+}
+
 impl<'a> serde::ser::Serialize for ByteBuf<'a> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/crates/clone_to_owned/Cargo.toml
+++ b/crates/clone_to_owned/Cargo.toml
@@ -10,3 +10,4 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bytes = "1.7.1"

--- a/crates/clone_to_owned/src/lib.rs
+++ b/crates/clone_to_owned/src/lib.rs
@@ -6,12 +6,13 @@
 // This lets us express types like TorrentMetaInfo<&[u8]> for zero-copy metadata about a bencode buffer in memory,
 // but to have one-line conversion for it into TorrentMetaInfo<Vec<u8>> so that we can store it later somewhere.
 
+use bytes::Bytes;
 use std::collections::HashMap;
 
 pub trait CloneToOwned {
     type Target;
 
-    fn clone_to_owned(&self) -> Self::Target;
+    fn clone_to_owned(&self, within_buffer: Option<&Bytes>) -> Self::Target;
 }
 
 impl<T> CloneToOwned for Option<T>
@@ -20,8 +21,8 @@ where
 {
     type Target = Option<<T as CloneToOwned>::Target>;
 
-    fn clone_to_owned(&self) -> Self::Target {
-        self.as_ref().map(|i| i.clone_to_owned())
+    fn clone_to_owned(&self, within_buffer: Option<&Bytes>) -> Self::Target {
+        self.as_ref().map(|i| i.clone_to_owned(within_buffer))
     }
 }
 
@@ -31,15 +32,17 @@ where
 {
     type Target = Vec<<T as CloneToOwned>::Target>;
 
-    fn clone_to_owned(&self) -> Self::Target {
-        self.iter().map(|i| i.clone_to_owned()).collect()
+    fn clone_to_owned(&self, within_buffer: Option<&Bytes>) -> Self::Target {
+        self.iter()
+            .map(|i| i.clone_to_owned(within_buffer))
+            .collect()
     }
 }
 
 impl CloneToOwned for u8 {
     type Target = u8;
 
-    fn clone_to_owned(&self) -> Self::Target {
+    fn clone_to_owned(&self, _within_buffer: Option<&Bytes>) -> Self::Target {
         *self
     }
 }
@@ -47,7 +50,7 @@ impl CloneToOwned for u8 {
 impl CloneToOwned for u32 {
     type Target = u32;
 
-    fn clone_to_owned(&self) -> Self::Target {
+    fn clone_to_owned(&self, _within_buffer: Option<&Bytes>) -> Self::Target {
         *self
     }
 }
@@ -60,10 +63,13 @@ where
 {
     type Target = HashMap<<K as CloneToOwned>::Target, <V as CloneToOwned>::Target>;
 
-    fn clone_to_owned(&self) -> Self::Target {
+    fn clone_to_owned(&self, within_buffer: Option<&Bytes>) -> Self::Target {
         let mut result = HashMap::with_capacity(self.capacity());
         for (k, v) in self {
-            result.insert(k.clone_to_owned(), v.clone_to_owned());
+            result.insert(
+                k.clone_to_owned(within_buffer),
+                v.clone_to_owned(within_buffer),
+            );
         }
         result
     }

--- a/crates/dht/Cargo.toml
+++ b/crates/dht/Cargo.toml
@@ -35,6 +35,7 @@ clone_to_owned = { path = "../clone_to_owned", package = "librqbit-clone-to-owne
 librqbit-core = { path = "../librqbit_core", version = "3.9.0" }
 chrono = { version = "0.4.31", features = ["serde"] }
 tokio-util = "0.7.10"
+bytes = "1.7.1"
 
 [dev-dependencies]
 tracing-subscriber = "0.3"

--- a/crates/dht/src/bprotocol.rs
+++ b/crates/dht/src/bprotocol.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use bencode::{ByteBuf, ByteBufOwned};
+use bytes::Bytes;
 use clone_to_owned::CloneToOwned;
 use librqbit_core::hash_id::Id20;
 use serde::{
@@ -73,10 +74,10 @@ where
 {
     type Target = ErrorDescription<<BufT as CloneToOwned>::Target>;
 
-    fn clone_to_owned(&self) -> Self::Target {
+    fn clone_to_owned(&self, within_buffer: Option<&Bytes>) -> Self::Target {
         ErrorDescription {
             code: self.code,
-            description: self.description.clone_to_owned(),
+            description: self.description.clone_to_owned(within_buffer),
         }
     }
 }

--- a/crates/librqbit/src/peer_connection.rs
+++ b/crates/librqbit/src/peer_connection.rs
@@ -382,7 +382,7 @@ impl<H: PeerConnectionHandler> PeerConnection<H> {
                 trace!("received: {:?}", &message);
 
                 if let Message::Extended(ExtendedMessage::Handshake(h)) = &message {
-                    *extended_handshake_ref.write() = Some(h.clone_to_owned());
+                    *extended_handshake_ref.write() = Some(h.clone_to_owned(None));
                     self.handler.on_extended_handshake(h)?;
                     trace!("remembered extended handshake for future serializing");
                 } else {

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -121,7 +121,11 @@ impl SessionDatabase {
                                 .map(|u| u.to_string())
                                 .collect(),
                             info_hash: torrent.info_hash().as_string(),
-                            torrent_bytes: torrent.info.torrent_bytes.clone(),
+                            // TODO: this could take up too much space / time / resources to write on interval.
+                            // Store this outside the JSON file
+                            //
+                            // torrent_bytes: torrent.info.torrent_bytes.clone(),
+                            torrent_bytes: Bytes::new(),
                             info: torrent.info().info.clone(),
                             only_files: torrent.only_files().clone(),
                             is_paused: torrent

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -752,7 +752,7 @@ impl Session {
                 }
             };
 
-            let handshake = h.clone_to_owned();
+            let handshake = h.clone_to_owned(None);
 
             return Ok((
                 live,
@@ -1047,7 +1047,7 @@ impl Session {
                         ),
                         AddTorrent::TorrentInfo(t) => {
                             // TODO: this is lossy, as we don't store the bytes.
-                            (*t, ByteBufOwned(Vec::new().into_boxed_slice()))
+                            (*t, ByteBufOwned(Default::default()))
                         }
                     };
 
@@ -1081,7 +1081,7 @@ impl Session {
                     InternalAddResult {
                         info_hash: torrent.info_hash,
                         info: torrent.info,
-                        torrent_bytes: Bytes::from(bytes.0),
+                        torrent_bytes: bytes.0,
                         trackers,
                         peer_rx,
                         initial_peers: opts

--- a/crates/librqbit/src/torrent_state/live/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/mod.rs
@@ -779,7 +779,7 @@ impl<'a> PeerConnectionHandler for &'a PeerHandler {
                     .context("on_download_request")?;
             }
             Message::Bitfield(b) => self
-                .on_bitfield(b.clone_to_owned())
+                .on_bitfield(b.clone_to_owned(None))
                 .context("on_bitfield")?,
             Message::Choke => self.on_i_am_choked(),
             Message::Unchoke => self.on_i_am_unchoked(),
@@ -1127,7 +1127,7 @@ impl PeerHandler {
         }
         self.state
             .peers
-            .update_bitfield_from_vec(self.addr, bitfield.0);
+            .update_bitfield_from_vec(self.addr, bitfield.0.to_vec().into_boxed_slice());
         self.on_bitfield_notify.notify_waiters();
         Ok(())
     }
@@ -1480,7 +1480,7 @@ impl PeerHandler {
             let state = self.state.clone();
             let addr = self.addr;
             let counters = self.counters.clone();
-            let piece = piece.clone_to_owned();
+            let piece = piece.clone_to_owned(None);
             let tx = self.tx.clone();
 
             let span = tracing::error_span!("deferred_write");

--- a/crates/librqbit_core/Cargo.toml
+++ b/crates/librqbit_core/Cargo.toml
@@ -26,6 +26,7 @@ itertools = "0.12"
 directories = "5"
 tokio-util = "0.7.10"
 data-encoding = "2.6.0"
+bytes = "1.7.1"
 
 
 [dev-dependencies]

--- a/crates/librqbit_core/src/torrent_metainfo.rs
+++ b/crates/librqbit_core/src/torrent_metainfo.rs
@@ -1,11 +1,11 @@
-use std::{iter::once, path::PathBuf};
-
 use anyhow::Context;
 use bencode::BencodeDeserializer;
 use buffers::{ByteBuf, ByteBufOwned};
+use bytes::Bytes;
 use clone_to_owned::CloneToOwned;
 use itertools::Either;
 use serde::{Deserialize, Serialize};
+use std::{iter::once, path::PathBuf};
 
 use crate::{hash_id::Id20, lengths::Lengths};
 
@@ -274,10 +274,10 @@ where
 {
     type Target = TorrentMetaV1File<<BufType as CloneToOwned>::Target>;
 
-    fn clone_to_owned(&self) -> Self::Target {
+    fn clone_to_owned(&self, within_buffer: Option<&Bytes>) -> Self::Target {
         TorrentMetaV1File {
             length: self.length,
-            path: self.path.clone_to_owned(),
+            path: self.path.clone_to_owned(within_buffer),
         }
     }
 }
@@ -288,14 +288,14 @@ where
 {
     type Target = TorrentMetaV1Info<<BufType as CloneToOwned>::Target>;
 
-    fn clone_to_owned(&self) -> Self::Target {
+    fn clone_to_owned(&self, within_buffer: Option<&Bytes>) -> Self::Target {
         TorrentMetaV1Info {
-            name: self.name.clone_to_owned(),
-            pieces: self.pieces.clone_to_owned(),
+            name: self.name.clone_to_owned(within_buffer),
+            pieces: self.pieces.clone_to_owned(within_buffer),
             piece_length: self.piece_length,
             length: self.length,
-            md5sum: self.md5sum.clone_to_owned(),
-            files: self.files.clone_to_owned(),
+            md5sum: self.md5sum.clone_to_owned(within_buffer),
+            files: self.files.clone_to_owned(within_buffer),
         }
     }
 }
@@ -306,16 +306,16 @@ where
 {
     type Target = TorrentMetaV1<<BufType as CloneToOwned>::Target>;
 
-    fn clone_to_owned(&self) -> Self::Target {
+    fn clone_to_owned(&self, within_buffer: Option<&Bytes>) -> Self::Target {
         TorrentMetaV1 {
-            announce: self.announce.clone_to_owned(),
-            announce_list: self.announce_list.clone_to_owned(),
-            info: self.info.clone_to_owned(),
-            comment: self.comment.clone_to_owned(),
-            created_by: self.created_by.clone_to_owned(),
-            encoding: self.encoding.clone_to_owned(),
-            publisher: self.publisher.clone_to_owned(),
-            publisher_url: self.publisher_url.clone_to_owned(),
+            announce: self.announce.clone_to_owned(within_buffer),
+            announce_list: self.announce_list.clone_to_owned(within_buffer),
+            info: self.info.clone_to_owned(within_buffer),
+            comment: self.comment.clone_to_owned(within_buffer),
+            created_by: self.created_by.clone_to_owned(within_buffer),
+            encoding: self.encoding.clone_to_owned(within_buffer),
+            publisher: self.publisher.clone_to_owned(within_buffer),
+            publisher_url: self.publisher_url.clone_to_owned(within_buffer),
             creation_date: self.creation_date,
             info_hash: self.info_hash,
         }

--- a/crates/peer_binary_protocol/Cargo.toml
+++ b/crates/peer_binary_protocol/Cargo.toml
@@ -20,3 +20,4 @@ clone_to_owned = { path = "../clone_to_owned", package = "librqbit-clone-to-owne
 librqbit-core = { path = "../librqbit_core", version = "3.9.0" }
 bitvec = "1"
 anyhow = "1"
+bytes = "1.7.1"

--- a/crates/peer_binary_protocol/src/extended/handshake.rs
+++ b/crates/peer_binary_protocol/src/extended/handshake.rs
@@ -6,6 +6,7 @@ use std::{
 use buffers::ByteBuf;
 use byteorder::ByteOrder;
 use byteorder::BE;
+use bytes::Bytes;
 use clone_to_owned::CloneToOwned;
 use serde::{Deserialize, Deserializer, Serialize};
 
@@ -75,14 +76,14 @@ where
 {
     type Target = ExtendedHandshake<<ByteBuf as CloneToOwned>::Target>;
 
-    fn clone_to_owned(&self) -> Self::Target {
+    fn clone_to_owned(&self, within_buffer: Option<&Bytes>) -> Self::Target {
         ExtendedHandshake {
-            m: self.m.clone_to_owned(),
+            m: self.m.clone_to_owned(within_buffer),
             p: self.p,
-            v: self.v.clone_to_owned(),
+            v: self.v.clone_to_owned(within_buffer),
             yourip: self.yourip,
-            ipv6: self.ipv6.clone_to_owned(),
-            ipv4: self.ipv4.clone_to_owned(),
+            ipv6: self.ipv6.clone_to_owned(within_buffer),
+            ipv4: self.ipv4.clone_to_owned(within_buffer),
             reqq: self.reqq,
             metadata_size: self.metadata_size,
             complete_ago: self.complete_ago,

--- a/crates/peer_binary_protocol/src/extended/mod.rs
+++ b/crates/peer_binary_protocol/src/extended/mod.rs
@@ -1,6 +1,7 @@
 use bencode::bencode_serialize_to_writer;
 use bencode::from_bytes;
 use bencode::BencodeValue;
+use bytes::Bytes;
 use clone_to_owned::CloneToOwned;
 use serde::{Deserialize, Serialize};
 
@@ -27,11 +28,15 @@ where
 {
     type Target = ExtendedMessage<<ByteBuf as CloneToOwned>::Target>;
 
-    fn clone_to_owned(&self) -> Self::Target {
+    fn clone_to_owned(&self, within_buffer: Option<&Bytes>) -> Self::Target {
         match self {
-            ExtendedMessage::Handshake(h) => ExtendedMessage::Handshake(h.clone_to_owned()),
-            ExtendedMessage::Dyn(u, d) => ExtendedMessage::Dyn(*u, d.clone_to_owned()),
-            ExtendedMessage::UtMetadata(m) => ExtendedMessage::UtMetadata(m.clone_to_owned()),
+            ExtendedMessage::Handshake(h) => {
+                ExtendedMessage::Handshake(h.clone_to_owned(within_buffer))
+            }
+            ExtendedMessage::Dyn(u, d) => ExtendedMessage::Dyn(*u, d.clone_to_owned(within_buffer)),
+            ExtendedMessage::UtMetadata(m) => {
+                ExtendedMessage::UtMetadata(m.clone_to_owned(within_buffer))
+            }
         }
     }
 }

--- a/crates/peer_binary_protocol/src/extended/ut_metadata.rs
+++ b/crates/peer_binary_protocol/src/extended/ut_metadata.rs
@@ -1,10 +1,10 @@
-use std::io::Write;
-
 use bencode::bencode_serialize_to_writer;
 use bencode::BencodeDeserializer;
+use bytes::Bytes;
 use clone_to_owned::CloneToOwned;
 use serde::Deserialize;
 use serde::Serialize;
+use std::io::Write;
 
 use crate::MessageDeserializeError;
 
@@ -22,7 +22,7 @@ pub enum UtMetadata<ByteBuf> {
 impl<ByteBuf: CloneToOwned> CloneToOwned for UtMetadata<ByteBuf> {
     type Target = UtMetadata<<ByteBuf as CloneToOwned>::Target>;
 
-    fn clone_to_owned(&self) -> Self::Target {
+    fn clone_to_owned(&self, within_buffer: Option<&Bytes>) -> Self::Target {
         match self {
             UtMetadata::Request(req) => UtMetadata::Request(*req),
             UtMetadata::Data {
@@ -32,7 +32,7 @@ impl<ByteBuf: CloneToOwned> CloneToOwned for UtMetadata<ByteBuf> {
             } => UtMetadata::Data {
                 piece: *piece,
                 total_size: *total_size,
-                data: data.clone_to_owned(),
+                data: data.clone_to_owned(within_buffer),
             },
             UtMetadata::Reject(piece) => UtMetadata::Reject(*piece),
         }


### PR DESCRIPTION
There's a lot of references into torrent metadata everywhere, and this lets us have just one Bytes instance for the whole thing, while all strings and other blobs just reference into it.