### PR TITLE
Other fixes found by e2e test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
+name = "async-backtrace"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcb391558246d27a13f195c1e3a53eda422270fdd452bd57a5aa9c1da1bb198"
+dependencies = [
+ "async-backtrace-attributes",
+ "dashmap",
+ "futures",
+ "loom",
+ "once_cell",
+ "pin-project-lite",
+ "rustc-hash 1.1.0",
+ "static_assertions",
+]
+
+[[package]]
+name = "async-backtrace-attributes"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "affbba0d438add06462a0371997575927bc05052f7ec486e7a4ca405c956c3d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.74",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -964,6 +991,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc16584ff22b460a382b7feec54b23d2908d858152e5739a120b949293bd74e"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustversion",
+ "windows",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1467,6 +1507,7 @@ name = "librqbit"
 version = "7.0.0-beta.0"
 dependencies = [
  "anyhow",
+ "async-backtrace",
  "async-stream",
  "async-trait",
  "axum 0.7.5",
@@ -1688,6 +1729,19 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
+name = "loom"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "lru"
@@ -2203,7 +2257,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.0.0",
  "rustls",
  "socket2",
  "thiserror",
@@ -2220,7 +2274,7 @@ dependencies = [
  "bytes",
  "rand",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.0.0",
  "rustls",
  "slab",
  "thiserror",
@@ -2483,6 +2537,12 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
@@ -2561,6 +2621,12 @@ checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
 dependencies = [
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -2991,6 +3057,12 @@ dependencies = [
  "url",
  "urlencoding",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stringprep"
@@ -3695,6 +3767,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.5",
+]
 
 [[package]]
 name = "windows-core"

--- a/crates/librqbit/Cargo.toml
+++ b/crates/librqbit/Cargo.toml
@@ -22,6 +22,7 @@ storage_middleware = ["lru"]
 storage_examples = []
 tracing-subscriber-utils = ["tracing-subscriber"]
 postgres = ["sqlx"]
+async-bt = ["async-backtrace"]
 
 [dependencies]
 sqlx = { version = "0.7", features = [
@@ -88,7 +89,7 @@ lru = { version = "0.12.3", optional = true }
 mime_guess = { version = "2.0.5", default-features = false }
 tokio-socks = "0.5.2"
 async-trait = "0.1.81"
-async-backtrace = "0.2"
+async-backtrace = { version = "0.2", optional = true }
 
 [build-dependencies]
 anyhow = "1"

--- a/crates/librqbit/Cargo.toml
+++ b/crates/librqbit/Cargo.toml
@@ -88,6 +88,7 @@ lru = { version = "0.12.3", optional = true }
 mime_guess = { version = "2.0.5", default-features = false }
 tokio-socks = "0.5.2"
 async-trait = "0.1.81"
+async-backtrace = "0.2"
 
 [build-dependencies]
 anyhow = "1"

--- a/crates/librqbit/src/chunk_tracker.rs
+++ b/crates/librqbit/src/chunk_tracker.rs
@@ -222,25 +222,6 @@ impl ChunkTracker {
         self.have[id.get() as usize]
     }
 
-    // None if wrong chunk
-    // true if did something
-    // false if didn't do anything
-    pub fn mark_chunk_request_cancelled(
-        &mut self,
-        index: ValidPieceIndex,
-        _chunk: u32,
-    ) -> Option<bool> {
-        if *self.have.get(index.get() as usize)? {
-            return Some(false);
-        }
-        // This will trigger the requesters to re-check each chunk in this piece.
-        let chunk_range = self.lengths.chunk_range(index);
-        if !self.chunk_status.get(chunk_range)?.all() {
-            self.queue_pieces.set(index.get() as usize, true);
-        }
-        Some(true)
-    }
-
     pub fn mark_piece_broken_if_not_have(&mut self, index: ValidPieceIndex) {
         if self
             .have

--- a/crates/librqbit/src/lib.rs
+++ b/crates/librqbit/src/lib.rs
@@ -25,6 +25,19 @@
 
 #![warn(clippy::cast_possible_truncation)]
 
+macro_rules! aframe {
+    ($e:expr) => {{
+        #[cfg(feature = "async-bt")]
+        {
+            async_backtrace::frame!($e)
+        }
+        #[cfg(not(feature = "async-bt"))]
+        {
+            $e
+        }
+    }};
+}
+
 pub mod api;
 mod api_error;
 mod chunk_tracker;

--- a/crates/librqbit/src/peer_connection.rs
+++ b/crates/librqbit/src/peer_connection.rs
@@ -199,7 +199,7 @@ impl<H: PeerConnectionHandler> PeerConnection<H> {
             .await
             .context("error reading handshake")?;
         let h_supports_extended = h.supports_extended();
-        trace!(
+        debug!(
             "connected: id={:?}",
             try_decode_peer_id(Id20::new(h.peer_id))
         );

--- a/crates/librqbit/src/storage/filesystem/mmap.rs
+++ b/crates/librqbit/src/storage/filesystem/mmap.rs
@@ -102,9 +102,10 @@ impl TorrentStorage for MmapFilesystemStorage {
         let mut mmaps = Vec::new();
         for (idx, file) in self.fs.opened_files.iter().enumerate() {
             let fg = file.file.write();
+            let fg = fg.as_ref().context("file is None")?;
             fg.set_len(meta.file_infos[idx].len)
                 .context("mmap storage: error setting length")?;
-            let mmap = unsafe { MmapOptions::new().map_mut(&*fg) }.context("error mapping file")?;
+            let mmap = unsafe { MmapOptions::new().map_mut(fg) }.context("error mapping file")?;
             mmaps.push(RwLock::new(mmap));
         }
 

--- a/crates/librqbit/src/storage/filesystem/opened_file.rs
+++ b/crates/librqbit/src/storage/filesystem/opened_file.rs
@@ -1,37 +1,22 @@
 use std::fs::File;
 
-use anyhow::Context;
 use parking_lot::RwLock;
 
 #[derive(Debug)]
 pub(crate) struct OpenedFile {
-    pub file: RwLock<File>,
-}
-
-pub(crate) fn dummy_file() -> anyhow::Result<std::fs::File> {
-    #[cfg(target_os = "windows")]
-    const DEVNULL: &str = "NUL";
-    #[cfg(not(target_os = "windows"))]
-    const DEVNULL: &str = "/dev/null";
-
-    std::fs::OpenOptions::new()
-        .read(true)
-        .open(DEVNULL)
-        .with_context(|| format!("error opening {}", DEVNULL))
+    pub file: RwLock<Option<File>>,
 }
 
 impl OpenedFile {
     pub fn new(f: File) -> Self {
         Self {
-            file: RwLock::new(f),
+            file: RwLock::new(Some(f)),
         }
     }
 
-    pub fn take(&self) -> anyhow::Result<File> {
+    pub fn take(&self) -> anyhow::Result<Option<File>> {
         let mut f = self.file.write();
-        let dummy = dummy_file()?;
-        let f = std::mem::replace(&mut *f, dummy);
-        Ok(f)
+        Ok(f.take())
     }
 
     pub fn take_clone(&self) -> anyhow::Result<Self> {

--- a/crates/librqbit/src/tests/e2e.rs
+++ b/crates/librqbit/src/tests/e2e.rs
@@ -41,14 +41,17 @@ async fn test_e2e_download() {
     .await
     .unwrap();
 
-    let num_servers = 128;
+    let num_servers = std::env::var("E2E_NUM_SERVERS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(128u8);
 
     let torrent_file_bytes = torrent_file.as_bytes().unwrap();
     let mut futs = Vec::new();
 
     // 2. Start N servers that are serving that torrent, and return their IP:port combos.
     //    Disable DHT on each.
-    for i in 0u8..num_servers {
+    for i in 0..num_servers {
         let torrent_file_bytes = torrent_file_bytes.clone();
         let tempdir = tempdir.path().to_owned();
         let fut = spawn(

--- a/crates/librqbit/src/tests/e2e.rs
+++ b/crates/librqbit/src/tests/e2e.rs
@@ -18,8 +18,16 @@ use crate::{
     AddTorrentOptions, AddTorrentResponse, Session, SessionOptions,
 };
 
+const TIMEOUT_SECS: u64 = 180;
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 64)]
 async fn test_e2e_download() {
+    tokio::time::timeout(Duration::from_secs(TIMEOUT_SECS), _test_e2e_download())
+        .await
+        .unwrap()
+}
+
+async fn _test_e2e_download() {
     let _ = tracing_subscriber::fmt::try_init();
 
     // 1. Create a torrent

--- a/crates/librqbit/src/tests/e2e.rs
+++ b/crates/librqbit/src/tests/e2e.rs
@@ -14,7 +14,9 @@ use tracing::{error_span, info, Instrument};
 
 use crate::{
     create_torrent,
-    tests::test_util::{create_default_random_dir_with_torrents, TestPeerMetadata},
+    tests::test_util::{
+        create_default_random_dir_with_torrents, spawn_debug_server, TestPeerMetadata,
+    },
     AddTorrentOptions, AddTorrentResponse, Session, SessionOptions,
 };
 
@@ -29,6 +31,8 @@ async fn test_e2e_download() {
 
 async fn _test_e2e_download() {
     let _ = tracing_subscriber::fmt::try_init();
+
+    spawn_debug_server();
 
     // 1. Create a torrent
     // Ideally (for a more complicated test) with N files, and at least N pieces that span 2 files.

--- a/crates/librqbit/src/tests/e2e.rs
+++ b/crates/librqbit/src/tests/e2e.rs
@@ -20,12 +20,16 @@ use crate::{
     AddTorrentOptions, AddTorrentResponse, Session, SessionOptions,
 };
 
-const TIMEOUT_SECS: u64 = 180;
-
 #[tokio::test(flavor = "multi_thread", worker_threads = 64)]
 async fn test_e2e_download() {
-    tokio::time::timeout(Duration::from_secs(TIMEOUT_SECS), _test_e2e_download())
+    let timeout = std::env::var("E2E_TIMEOUT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(180);
+
+    tokio::time::timeout(Duration::from_secs(timeout), _test_e2e_download())
         .await
+        .context("test_e2e_download timed out")
         .unwrap()
 }
 

--- a/crates/librqbit/src/tests/test_util.rs
+++ b/crates/librqbit/src/tests/test_util.rs
@@ -85,7 +85,17 @@ impl TestPeerMetadata {
 
 async fn debug_server() -> anyhow::Result<()> {
     async fn backtraces() -> impl IntoResponse {
-        async_backtrace::taskdump_tree(true)
+        #[cfg(feature = "async-bt")]
+        {
+            async_backtrace::taskdump_tree(true)
+        }
+        #[cfg(not(feature = "async-bt"))]
+        {
+            use crate::ApiError;
+            ApiError::from(anyhow::anyhow!(
+                "backtraces not enabled, enable async-bt feature"
+            ))
+        }
     }
 
     let app = Router::new().route("/backtrace", get(backtraces));

--- a/crates/librqbit/src/torrent_state/live/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/mod.rs
@@ -904,7 +904,7 @@ impl PeerHandler {
                         req.chunk_index
                     );
                     g.get_chunks_mut()?
-                        .mark_chunk_request_cancelled(req.piece_index, req.chunk_index);
+                        .mark_piece_broken_if_not_have(req.piece_index);
                 }
             }
             PeerState::NotNeeded => {


### PR DESCRIPTION
Debugging the e2e test and its failures, found a couple potential issues that are fixed here + some debugging code.

```
while E2E_TIMEOUT=1000000000 E2E_CLIENT_ITERS=1000 E2E_NUM_SERVERS=128 RUST_LOG=debug cargo test --features librqbit/async-bt test_e2e_download -- --nocapture > /tmp/test-log 2>&1; do :; done
```

CC @izderadicka 