### PR TITLE
Further e2e fixes for reliability

### DIFF
--- a/crates/librqbit/src/torrent_state/live/peers/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/peers/mod.rs
@@ -77,6 +77,11 @@ impl PeerStates {
         Some(p)
     }
 
+    pub fn is_peer_interested(&self, handle: PeerHandle) -> bool {
+        self.with_live(handle, |live| live.peer_interested)
+            .unwrap_or(false)
+    }
+
     pub fn mark_peer_interested(&self, handle: PeerHandle, is_interested: bool) -> Option<bool> {
         self.with_live_mut(handle, "mark_peer_interested", |live| {
             let prev = live.peer_interested;
@@ -84,6 +89,7 @@ impl PeerStates {
             prev
         })
     }
+
     pub fn update_bitfield_from_vec(&self, handle: PeerHandle, bitfield: Box<[u8]>) -> Option<()> {
         self.with_live_mut(handle, "update_bitfield_from_vec", |live| {
             live.bitfield = BF::from_boxed_slice(bitfield);


### PR DESCRIPTION
I found the root cause of e2e failures.

it was around this line ```debug!("nothing left to do, disconnecting peer");```. The server was disconnecting the peer if the server itself had the full torrent.

However, the reason it worked at all, is that "peer_chunk_requester" was stuck in "wait_for_bitfield" forever if the peer never sent it in the first place. So it never reached the bugged line.

sequence:
1. the server starts seeding
2. first peers connect. The don't send bitfield because they have nothing.
3. the server's "peer_chunk_requester" blocks forever in "wait_for_bitfield" and never reaches the line that disconnects it.
4. (intentionally) bad test peers take too long, or send garbage etc
5. the good peers run out of pieces to request and hit the "sleep 10s" line.
6. the server's rwtimeout is set to 10 seconds also, and it disconnects good peers as they weren't doing anything for 10 seconds
7. good peers reconnect. By that time they have already a bitfield to send.
8. the moment they send the bitfield, the server hits the line "nothing to do" and disconnects the peer again.