### PR TITLE
[Feature] Decode torrent as JSON in the /torrents/resolve_magnet API

### DIFF
--- a/crates/buffers/src/lib.rs
+++ b/crates/buffers/src/lib.rs
@@ -42,6 +42,9 @@ impl<'a> std::fmt::Display for HexBytes<'a> {
 }
 
 fn debug_bytes(b: &[u8], f: &mut std::fmt::Formatter<'_>, debug_strings: bool) -> std::fmt::Result {
+    if b.is_empty() {
+        return Ok(());
+    }
     if b.iter().all(|b| *b == 0) {
         return write!(f, "<{} bytes, all zeroes>", b.len());
     }


### PR DESCRIPTION
Usage

```
curl -H 'Accept: application/json' --data-raw 'magnet:?xt=urn:btih:...' \
    http://127.0.0.1:3030/torrents/resolve_magnet | jq .
```