### PR TITLE
Fix a bug in torrent deletion

### DIFF
--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -1179,7 +1179,9 @@ impl Session {
 
         if let Some(p) = self.persistence.as_ref() {
             if let Err(e) = p.delete(id).await {
-                error!(error=?e, "error deleting torrent from database");
+                error!(error=?e, "error deleting torrent from persistence database");
+            } else {
+                debug!(?id, "deleted torrent from persistence database")
             }
         }
 


### PR DESCRIPTION
The recent session persistence change introduced a bug where torrent deletion was deadlocking forever.