### PR TITLE
[Feature] Fast resume - quick restart without rehashing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ devserver-postgres:
 	echo -n '' > /tmp/rqbit-log && cargo run -- \
 		--log-file /tmp/rqbit-log \
 		--log-file-rust-log=debug,librqbit=trace \
-		server start --persistence-config postgres:///rqbit /tmp/scratch/
+		server start --fastresume --persistence-config postgres:///rqbit /tmp/scratch/
 
 @PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ devserver:
 	echo -n '' > /tmp/rqbit-log && cargo run -- \
 		--log-file /tmp/rqbit-log \
 		--log-file-rust-log=debug,librqbit=trace \
-		server start /tmp/scratch/
+		server start --fastresume /tmp/scratch/
 
 @PHONY: devserver
 devserver-postgres:

--- a/crates/librqbit/src/api.rs
+++ b/crates/librqbit/src/api.rs
@@ -363,7 +363,7 @@ impl Api {
 
     pub fn api_dump_haves(&self, idx: TorrentIdOrHash) -> Result<String> {
         let mgr = self.mgr_handle(idx)?;
-        Ok(mgr.with_chunk_tracker(|chunks| format!("{:?}", chunks.get_have_pieces()))?)
+        Ok(mgr.with_chunk_tracker(|chunks| format!("{:?}", chunks.get_have_pieces().as_slice()))?)
     }
 
     pub fn api_stream(&self, idx: TorrentIdOrHash, file_id: usize) -> Result<FileStream> {

--- a/crates/librqbit/src/bitv.rs
+++ b/crates/librqbit/src/bitv.rs
@@ -9,14 +9,12 @@ use bitvec::{
     view::{AsBits, AsMutBits},
 };
 
-#[async_trait::async_trait]
 pub trait BitV: Send + Sync {
     fn as_slice(&self) -> &BitSlice<u8, Lsb0>;
     fn as_slice_mut(&mut self) -> &mut BitSlice<u8, Lsb0>;
     fn into_dyn(self) -> Box<dyn BitV>;
     fn as_bytes(&self) -> &[u8];
-
-    async fn flush(&mut self) -> anyhow::Result<()>;
+    fn flush(&mut self) -> anyhow::Result<()>;
 }
 
 pub type BoxBitV = Box<dyn BitV>;
@@ -48,7 +46,7 @@ impl BitV for BitVec<u8, Lsb0> {
         self.as_raw_slice()
     }
 
-    async fn flush(&mut self) -> anyhow::Result<()> {
+    fn flush(&mut self) -> anyhow::Result<()> {
         Ok(())
     }
 
@@ -71,7 +69,7 @@ impl BitV for BitBox<u8, Lsb0> {
         self.as_raw_slice()
     }
 
-    async fn flush(&mut self) -> anyhow::Result<()> {
+    fn flush(&mut self) -> anyhow::Result<()> {
         Ok(())
     }
 
@@ -80,7 +78,6 @@ impl BitV for BitBox<u8, Lsb0> {
     }
 }
 
-#[async_trait::async_trait]
 impl BitV for MmapBitV {
     fn as_slice(&self) -> &BitSlice<u8, Lsb0> {
         self.mmap.as_bits()
@@ -94,7 +91,7 @@ impl BitV for MmapBitV {
         &self.mmap
     }
 
-    async fn flush(&mut self) -> anyhow::Result<()> {
+    fn flush(&mut self) -> anyhow::Result<()> {
         Ok(self.mmap.flush()?)
     }
 
@@ -103,7 +100,6 @@ impl BitV for MmapBitV {
     }
 }
 
-#[async_trait::async_trait]
 impl BitV for Box<dyn BitV> {
     fn as_slice(&self) -> &BitSlice<u8, Lsb0> {
         (**self).as_slice()
@@ -117,8 +113,8 @@ impl BitV for Box<dyn BitV> {
         (**self).as_bytes()
     }
 
-    async fn flush(&mut self) -> anyhow::Result<()> {
-        (**self).flush().await
+    fn flush(&mut self) -> anyhow::Result<()> {
+        (**self).flush()
     }
 
     fn into_dyn(self) -> Box<dyn BitV> {

--- a/crates/librqbit/src/bitv.rs
+++ b/crates/librqbit/src/bitv.rs
@@ -3,15 +3,15 @@ use std::fs::File;
 use anyhow::Context;
 use bitvec::{
     boxed::BitBox,
-    order::Lsb0,
+    order::Msb0,
     slice::BitSlice,
     vec::BitVec,
     view::{AsBits, AsMutBits},
 };
 
 pub trait BitV: Send + Sync {
-    fn as_slice(&self) -> &BitSlice<u8, Lsb0>;
-    fn as_slice_mut(&mut self) -> &mut BitSlice<u8, Lsb0>;
+    fn as_slice(&self) -> &BitSlice<u8, Msb0>;
+    fn as_slice_mut(&mut self) -> &mut BitSlice<u8, Msb0>;
     fn into_dyn(self) -> Box<dyn BitV>;
     fn as_bytes(&self) -> &[u8];
     fn flush(&mut self) -> anyhow::Result<()>;
@@ -33,12 +33,12 @@ impl MmapBitV {
 }
 
 #[async_trait::async_trait]
-impl BitV for BitVec<u8, Lsb0> {
-    fn as_slice(&self) -> &BitSlice<u8, Lsb0> {
+impl BitV for BitVec<u8, Msb0> {
+    fn as_slice(&self) -> &BitSlice<u8, Msb0> {
         self.as_bitslice()
     }
 
-    fn as_slice_mut(&mut self) -> &mut BitSlice<u8, Lsb0> {
+    fn as_slice_mut(&mut self) -> &mut BitSlice<u8, Msb0> {
         self.as_mut_bitslice()
     }
 
@@ -56,12 +56,12 @@ impl BitV for BitVec<u8, Lsb0> {
 }
 
 #[async_trait::async_trait]
-impl BitV for BitBox<u8, Lsb0> {
-    fn as_slice(&self) -> &BitSlice<u8, Lsb0> {
+impl BitV for BitBox<u8, Msb0> {
+    fn as_slice(&self) -> &BitSlice<u8, Msb0> {
         self.as_bitslice()
     }
 
-    fn as_slice_mut(&mut self) -> &mut BitSlice<u8, Lsb0> {
+    fn as_slice_mut(&mut self) -> &mut BitSlice<u8, Msb0> {
         self.as_mut_bitslice()
     }
 
@@ -79,11 +79,11 @@ impl BitV for BitBox<u8, Lsb0> {
 }
 
 impl BitV for MmapBitV {
-    fn as_slice(&self) -> &BitSlice<u8, Lsb0> {
+    fn as_slice(&self) -> &BitSlice<u8, Msb0> {
         self.mmap.as_bits()
     }
 
-    fn as_slice_mut(&mut self) -> &mut BitSlice<u8, Lsb0> {
+    fn as_slice_mut(&mut self) -> &mut BitSlice<u8, Msb0> {
         self.mmap.as_mut_bits()
     }
 
@@ -101,11 +101,11 @@ impl BitV for MmapBitV {
 }
 
 impl BitV for Box<dyn BitV> {
-    fn as_slice(&self) -> &BitSlice<u8, Lsb0> {
+    fn as_slice(&self) -> &BitSlice<u8, Msb0> {
         (**self).as_slice()
     }
 
-    fn as_slice_mut(&mut self) -> &mut BitSlice<u8, Lsb0> {
+    fn as_slice_mut(&mut self) -> &mut BitSlice<u8, Msb0> {
         (**self).as_slice_mut()
     }
 

--- a/crates/librqbit/src/bitv.rs
+++ b/crates/librqbit/src/bitv.rs
@@ -1,16 +1,25 @@
 use std::fs::File;
 
 use anyhow::Context;
-use bitvec::{order::Lsb0, slice::BitSlice, vec::BitVec, view::AsBits, view::AsMutBits};
+use bitvec::{
+    boxed::BitBox,
+    order::Lsb0,
+    slice::BitSlice,
+    vec::BitVec,
+    view::{AsBits, AsMutBits},
+};
 
 #[async_trait::async_trait]
-pub trait BitV: Send {
+pub trait BitV: Send + Sync {
     fn as_slice(&self) -> &BitSlice<u8, Lsb0>;
     fn as_slice_mut(&mut self) -> &mut BitSlice<u8, Lsb0>;
     fn into_dyn(self) -> Box<dyn BitV>;
+    fn as_bytes(&self) -> &[u8];
 
     async fn flush(&mut self) -> anyhow::Result<()>;
 }
+
+pub type BoxBitV = Box<dyn BitV>;
 
 pub struct MmapBitV {
     _file: File,
@@ -35,6 +44,33 @@ impl BitV for BitVec<u8, Lsb0> {
         self.as_mut_bitslice()
     }
 
+    fn as_bytes(&self) -> &[u8] {
+        self.as_raw_slice()
+    }
+
+    async fn flush(&mut self) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn into_dyn(self) -> Box<dyn BitV> {
+        Box::new(self)
+    }
+}
+
+#[async_trait::async_trait]
+impl BitV for BitBox<u8, Lsb0> {
+    fn as_slice(&self) -> &BitSlice<u8, Lsb0> {
+        self.as_bitslice()
+    }
+
+    fn as_slice_mut(&mut self) -> &mut BitSlice<u8, Lsb0> {
+        self.as_mut_bitslice()
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        self.as_raw_slice()
+    }
+
     async fn flush(&mut self) -> anyhow::Result<()> {
         Ok(())
     }
@@ -54,6 +90,10 @@ impl BitV for MmapBitV {
         self.mmap.as_mut_bits()
     }
 
+    fn as_bytes(&self) -> &[u8] {
+        &self.mmap
+    }
+
     async fn flush(&mut self) -> anyhow::Result<()> {
         Ok(self.mmap.flush()?)
     }
@@ -71,6 +111,10 @@ impl BitV for Box<dyn BitV> {
 
     fn as_slice_mut(&mut self) -> &mut BitSlice<u8, Lsb0> {
         (**self).as_slice_mut()
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        (**self).as_bytes()
     }
 
     async fn flush(&mut self) -> anyhow::Result<()> {

--- a/crates/librqbit/src/bitv.rs
+++ b/crates/librqbit/src/bitv.rs
@@ -1,0 +1,78 @@
+use std::fs::File;
+
+use anyhow::Context;
+use bitvec::{order::Lsb0, slice::BitSlice, vec::BitVec, view::AsBits, view::AsMutBits};
+
+pub trait BitV: Send {
+    fn as_slice(&self) -> &BitSlice<u8, Lsb0>;
+    fn as_slice_mut(&mut self) -> &mut BitSlice<u8, Lsb0>;
+    fn flush(&mut self) -> anyhow::Result<()>;
+    fn into_dyn(self) -> Box<dyn BitV>;
+}
+
+pub struct MmapBitV {
+    _file: File,
+    mmap: memmap2::MmapMut,
+}
+
+impl MmapBitV {
+    pub fn new(file: File) -> anyhow::Result<Self> {
+        let mmap =
+            unsafe { memmap2::MmapOptions::new().map_mut(&file) }.context("error mmapping file")?;
+        Ok(Self { mmap, _file: file })
+    }
+}
+
+impl BitV for BitVec<u8, Lsb0> {
+    fn as_slice(&self) -> &BitSlice<u8, Lsb0> {
+        self.as_bitslice()
+    }
+
+    fn as_slice_mut(&mut self) -> &mut BitSlice<u8, Lsb0> {
+        self.as_mut_bitslice()
+    }
+
+    fn flush(&mut self) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn into_dyn(self) -> Box<dyn BitV> {
+        Box::new(self)
+    }
+}
+
+impl BitV for MmapBitV {
+    fn as_slice(&self) -> &BitSlice<u8, Lsb0> {
+        self.mmap.as_bits()
+    }
+
+    fn as_slice_mut(&mut self) -> &mut BitSlice<u8, Lsb0> {
+        self.mmap.as_mut_bits()
+    }
+
+    fn flush(&mut self) -> anyhow::Result<()> {
+        Ok(self.mmap.flush()?)
+    }
+
+    fn into_dyn(self) -> Box<dyn BitV> {
+        Box::new(self)
+    }
+}
+
+impl BitV for Box<dyn BitV> {
+    fn as_slice(&self) -> &BitSlice<u8, Lsb0> {
+        (**self).as_slice()
+    }
+
+    fn as_slice_mut(&mut self) -> &mut BitSlice<u8, Lsb0> {
+        (**self).as_slice_mut()
+    }
+
+    fn flush(&mut self) -> anyhow::Result<()> {
+        (**self).flush()
+    }
+
+    fn into_dyn(self) -> Box<dyn BitV> {
+        self
+    }
+}

--- a/crates/librqbit/src/bitv_factory.rs
+++ b/crates/librqbit/src/bitv_factory.rs
@@ -1,14 +1,12 @@
-use bitvec::{order::Lsb0, vec::BitVec};
-
-use crate::{api::TorrentIdOrHash, bitv::BitV};
+use crate::{api::TorrentIdOrHash, bitv::BitV, type_aliases::BF};
 
 #[async_trait::async_trait]
-pub trait BitVFactory: Send {
+pub trait BitVFactory: Send + Sync {
     async fn load(&self, id: TorrentIdOrHash) -> anyhow::Result<Option<Box<dyn BitV>>>;
     async fn store_initial_check(
         &self,
         id: TorrentIdOrHash,
-        b: BitVec<u8, Lsb0>,
+        b: BF,
     ) -> anyhow::Result<Box<dyn BitV>>;
 }
 
@@ -21,8 +19,8 @@ impl BitVFactory for NonPersistentBitVFactory {
     }
     async fn store_initial_check(
         &self,
-        id: TorrentIdOrHash,
-        b: BitVec<u8, Lsb0>,
+        _id: TorrentIdOrHash,
+        b: BF,
     ) -> anyhow::Result<Box<dyn BitV>> {
         Ok(Box::new(b))
     }

--- a/crates/librqbit/src/bitv_factory.rs
+++ b/crates/librqbit/src/bitv_factory.rs
@@ -1,0 +1,29 @@
+use bitvec::{order::Lsb0, vec::BitVec};
+
+use crate::{api::TorrentIdOrHash, bitv::BitV};
+
+#[async_trait::async_trait]
+pub trait BitVFactory: Send {
+    async fn load(&self, id: TorrentIdOrHash) -> anyhow::Result<Option<Box<dyn BitV>>>;
+    async fn store_initial_check(
+        &self,
+        id: TorrentIdOrHash,
+        b: BitVec<u8, Lsb0>,
+    ) -> anyhow::Result<Box<dyn BitV>>;
+}
+
+pub struct NonPersistentBitVFactory {}
+
+#[async_trait::async_trait]
+impl BitVFactory for NonPersistentBitVFactory {
+    async fn load(&self, _: TorrentIdOrHash) -> anyhow::Result<Option<Box<dyn BitV>>> {
+        Ok(None)
+    }
+    async fn store_initial_check(
+        &self,
+        id: TorrentIdOrHash,
+        b: BitVec<u8, Lsb0>,
+    ) -> anyhow::Result<Box<dyn BitV>> {
+        Ok(Box::new(b))
+    }
+}

--- a/crates/librqbit/src/bitv_factory.rs
+++ b/crates/librqbit/src/bitv_factory.rs
@@ -17,6 +17,7 @@ impl BitVFactory for NonPersistentBitVFactory {
     async fn load(&self, _: TorrentIdOrHash) -> anyhow::Result<Option<Box<dyn BitV>>> {
         Ok(None)
     }
+
     async fn store_initial_check(
         &self,
         _id: TorrentIdOrHash,

--- a/crates/librqbit/src/chunk_tracker.rs
+++ b/crates/librqbit/src/chunk_tracker.rs
@@ -1,13 +1,15 @@
 use std::collections::HashSet;
 
 use anyhow::Context;
+use bitvec::{order::Lsb0, slice::BitSlice};
 use librqbit_core::lengths::{ChunkInfo, Lengths, ValidPieceIndex};
 use peer_binary_protocol::Piece;
 use tracing::{debug, trace};
 
 use crate::{
+    bitv::{BitV, BoxBitV},
     file_info::FileInfo,
-    type_aliases::{FileInfos, FilePriorities, BF},
+    type_aliases::{FileInfos, FilePriorities, BF, BS},
 };
 
 pub struct ChunkTracker {
@@ -26,7 +28,7 @@ pub struct ChunkTracker {
     chunk_status: BF,
 
     // These are the pieces that we actually have, fully checked and downloaded.
-    have: BF,
+    have: BoxBitV,
 
     // The pieces that the user selected. This doesn't change unless update_only_files
     // was called.
@@ -70,7 +72,7 @@ impl HaveNeededSelected {
 // Comput the have-status of chunks.
 //
 // Save as "have_pieces", but there's one bit per chunk (not per piece).
-fn compute_chunk_have_status(lengths: &Lengths, have_pieces: &BF) -> anyhow::Result<BF> {
+fn compute_chunk_have_status(lengths: &Lengths, have_pieces: &BS) -> anyhow::Result<BF> {
     if have_pieces.len() < lengths.total_pieces() as usize {
         anyhow::bail!(
             "bug: have_pieces.len() < lengths.total_pieces(); {} < {}",
@@ -98,15 +100,19 @@ fn compute_chunk_have_status(lengths: &Lengths, have_pieces: &BF) -> anyhow::Res
     Ok(chunk_bf)
 }
 
-fn compute_queued_pieces_unchecked(have_pieces: &BF, selected_pieces: &BF) -> BF {
+fn compute_queued_pieces_unchecked(have_pieces: &BS, selected_pieces: &BS) -> BF {
     // it's needed ONLY if it's selected and we don't have it.
     use core::ops::BitAnd;
     use core::ops::Not;
 
-    have_pieces.clone().not().bitand(selected_pieces)
+    have_pieces
+        .to_bitvec()
+        .not()
+        .bitand(selected_pieces)
+        .into_boxed_bitslice()
 }
 
-fn compute_queued_pieces(have_pieces: &BF, selected_pieces: &BF) -> anyhow::Result<BF> {
+fn compute_queued_pieces(have_pieces: &BS, selected_pieces: &BS) -> anyhow::Result<BF> {
     if have_pieces.len() != selected_pieces.len() {
         anyhow::bail!(
             "have_pieces.len() != selected_pieces.len(), {} != {}",
@@ -131,20 +137,20 @@ pub enum ChunkMarkingResult {
 impl ChunkTracker {
     pub fn new(
         // Have pieces are the ones we have already downloaded and verified.
-        have_pieces: BF,
+        have_pieces: BoxBitV,
         // Selected pieces are the ones the user has selected
         selected_pieces: BF,
         lengths: Lengths,
         file_infos: &FileInfos,
     ) -> anyhow::Result<Self> {
-        let needed_pieces = compute_queued_pieces(&have_pieces, &selected_pieces)
+        let needed_pieces = compute_queued_pieces(have_pieces.as_slice(), &selected_pieces)
             .context("error computing needed pieces")?;
 
         // TODO: ideally this needs to be a list based on needed files, e.g.
         // last needed piece for each file. But let's keep simple for now.
 
         let mut ct = Self {
-            chunk_status: compute_chunk_have_status(&lengths, &have_pieces)
+            chunk_status: compute_chunk_have_status(&lengths, have_pieces.as_slice())
                 .context("error computing chunk status")?,
             queue_pieces: needed_pieces,
             selected: selected_pieces,
@@ -163,7 +169,7 @@ impl ChunkTracker {
             *slot = fi
                 .piece_range
                 .clone()
-                .filter(|p| self.have[*p as usize])
+                .filter(|p| self.have.as_slice()[*p as usize])
                 .map(|id| {
                     self.lengths
                         .size_of_piece_in_file(id, fi.offset_in_torrent, fi.len)
@@ -176,8 +182,8 @@ impl ChunkTracker {
         &self.lengths
     }
 
-    pub fn get_have_pieces(&self) -> &BF {
-        &self.have
+    pub fn get_have_pieces(&self) -> &dyn BitV {
+        &*self.have
     }
 
     pub fn reserve_needed_piece(&mut self, index: ValidPieceIndex) {
@@ -193,7 +199,7 @@ impl ChunkTracker {
         for piece in self.lengths.iter_piece_infos() {
             let id = piece.piece_index.get() as usize;
             let len = piece.len as u64;
-            let is_have = self.have[id];
+            let is_have = self.have.as_slice()[id];
             let is_selected = self.selected[id];
             let is_needed = is_selected && !is_have;
             hns.have_bytes += len * (is_have as u64);
@@ -219,12 +225,13 @@ impl ChunkTracker {
     }
 
     pub(crate) fn is_piece_have(&self, id: ValidPieceIndex) -> bool {
-        self.have[id.get() as usize]
+        self.have.as_slice()[id.get() as usize]
     }
 
     pub fn mark_piece_broken_if_not_have(&mut self, index: ValidPieceIndex) {
         if self
             .have
+            .as_slice()
             .get(index.get() as usize)
             .map(|r| *r)
             .unwrap_or_default()
@@ -240,8 +247,8 @@ impl ChunkTracker {
 
     pub fn mark_piece_downloaded(&mut self, idx: ValidPieceIndex) {
         let id = idx.get() as usize;
-        if !self.have[id] {
-            self.have.set(id, true);
+        if !self.have.as_slice()[id] {
+            self.have.as_slice_mut().set(id, true);
             let len = self.lengths.piece_length(idx) as u64;
             self.hns.have_bytes += len;
             if self.selected[id] {
@@ -252,6 +259,7 @@ impl ChunkTracker {
 
     pub fn is_chunk_ready_to_upload(&self, chunk: &ChunkInfo) -> bool {
         self.have
+            .as_slice()
             .get(chunk.piece_index.get() as usize)
             .map(|b| *b)
             .unwrap_or(false)
@@ -327,7 +335,8 @@ impl ChunkTracker {
                 current_piece_remaining -= TryInto::<u32>::try_into(shift)?;
 
                 if current_piece_remaining == 0 {
-                    let current_piece_have = self.have[current_piece.piece_index.get() as usize];
+                    let current_piece_have =
+                        self.have.as_slice()[current_piece.piece_index.get() as usize];
                     if current_piece_have {
                         have_bytes += current_piece.len as u64;
                     }
@@ -380,6 +389,7 @@ impl ChunkTracker {
 
     pub fn is_file_finished(&self, file_info: &FileInfo) -> bool {
         self.have
+            .as_slice()
             .get(file_info.piece_range_usize())
             .map(|r| r.all())
             .unwrap_or(true)
@@ -414,9 +424,10 @@ impl ChunkTracker {
 mod tests {
     use std::collections::HashSet;
 
+    use bitvec::{order::Lsb0, vec::BitVec};
     use librqbit_core::{constants::CHUNK_SIZE, lengths::Lengths};
 
-    use crate::{chunk_tracker::HaveNeededSelected, type_aliases::BF};
+    use crate::{bitv::BitV, chunk_tracker::HaveNeededSelected, type_aliases::BF};
 
     use super::{compute_chunk_have_status, ChunkTracker};
 
@@ -534,12 +545,12 @@ mod tests {
         ];
 
         let bf_len = l.piece_bitfield_bytes();
-        let initial_have = BF::from_boxed_slice(vec![0u8; bf_len].into_boxed_slice());
+        let initial_have: BitVec<u8, Lsb0> = BitVec::from_vec(vec![0u8; bf_len]);
         let initial_selected = BF::from_boxed_slice(vec![u8::MAX; bf_len].into_boxed_slice());
 
         // Initially, we need all files and all pieces.
         let mut ct = ChunkTracker::new(
-            initial_have.clone(),
+            initial_have.clone().into_dyn(),
             initial_selected.clone(),
             l,
             &Default::default(),
@@ -556,7 +567,7 @@ mod tests {
                 needed_bytes: total_len,
             }
         );
-        assert_eq!(ct.have, initial_have);
+        assert_eq!(ct.have.as_slice(), initial_have.as_bitslice());
         assert_eq!(ct.queue_pieces, initial_selected);
 
         // Select only the first file.

--- a/crates/librqbit/src/chunk_tracker.rs
+++ b/crates/librqbit/src/chunk_tracker.rs
@@ -1,7 +1,6 @@
 use std::collections::HashSet;
 
 use anyhow::Context;
-use bitvec::{order::Lsb0, slice::BitSlice};
 use librqbit_core::lengths::{ChunkInfo, Lengths, ValidPieceIndex};
 use peer_binary_protocol::Piece;
 use tracing::{debug, trace};

--- a/crates/librqbit/src/chunk_tracker.rs
+++ b/crates/librqbit/src/chunk_tracker.rs
@@ -185,6 +185,10 @@ impl ChunkTracker {
         &*self.have
     }
 
+    pub fn get_have_pieces_mut(&mut self) -> &mut dyn BitV {
+        &mut *self.have
+    }
+
     pub fn reserve_needed_piece(&mut self, index: ValidPieceIndex) {
         self.queue_pieces.set(index.get() as usize, false)
     }

--- a/crates/librqbit/src/chunk_tracker.rs
+++ b/crates/librqbit/src/chunk_tracker.rs
@@ -425,10 +425,8 @@ impl ChunkTracker {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
-
-    use bitvec::{order::Lsb0, vec::BitVec};
     use librqbit_core::{constants::CHUNK_SIZE, lengths::Lengths};
+    use std::collections::HashSet;
 
     use crate::{bitv::BitV, chunk_tracker::HaveNeededSelected, type_aliases::BF};
 
@@ -548,7 +546,7 @@ mod tests {
         ];
 
         let bf_len = l.piece_bitfield_bytes();
-        let initial_have: BitVec<u8, Lsb0> = BitVec::from_vec(vec![0u8; bf_len]);
+        let initial_have = BF::from_boxed_slice(vec![0u8; bf_len].into_boxed_slice());
         let initial_selected = BF::from_boxed_slice(vec![u8::MAX; bf_len].into_boxed_slice());
 
         // Initially, we need all files and all pieces.

--- a/crates/librqbit/src/lib.rs
+++ b/crates/librqbit/src/lib.rs
@@ -40,6 +40,7 @@ macro_rules! aframe {
 
 pub mod api;
 mod api_error;
+mod bitv;
 mod chunk_tracker;
 mod create_torrent_file;
 mod dht_utils;

--- a/crates/librqbit/src/lib.rs
+++ b/crates/librqbit/src/lib.rs
@@ -41,6 +41,7 @@ macro_rules! aframe {
 pub mod api;
 mod api_error;
 mod bitv;
+mod bitv_factory;
 mod chunk_tracker;
 mod create_torrent_file;
 mod dht_utils;

--- a/crates/librqbit/src/session_persistence/json.rs
+++ b/crates/librqbit/src/session_persistence/json.rs
@@ -181,7 +181,11 @@ impl BitVFactory for JsonSessionPersistenceStore {
     async fn load(&self, id: TorrentIdOrHash) -> anyhow::Result<Option<Box<dyn BitV>>> {
         let h = self.to_hash(id).await?;
         let filename = self.bitv_filename(&h);
-        let f = match std::fs::OpenOptions::new().write(true).open(&filename) {
+        let f = match std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&filename)
+        {
             Ok(f) => f,
             Err(e) => match e.kind() {
                 std::io::ErrorKind::NotFound => return Ok(None),
@@ -203,18 +207,23 @@ impl BitVFactory for JsonSessionPersistenceStore {
             .write(true)
             .create(true)
             .truncate(true)
-            .open(&filename)
+            .open(&tmp_filename)
             .await
             .with_context(|| format!("error opening {filename:?}"))?;
         tokio::io::copy(&mut b.as_raw_slice(), &mut dst)
             .await
             .context("error writing bitslice to {filename:?}")?;
-        tokio::fs::rename(tmp_filename, &filename).await?;
+        tokio::fs::rename(&tmp_filename, &filename)
+            .await
+            .with_context(|| format!("error renaming {tmp_filename:?} to {filename:?}"))?;
         let f = std::fs::OpenOptions::new()
+            .read(true)
             .write(true)
             .open(&filename)
             .with_context(|| format!("error opening {filename:?}"))?;
-        Ok(MmapBitV::new(f)?.into_dyn())
+        Ok(MmapBitV::new(f)
+            .with_context(|| format!("error constructing MmapBitV from file {filename:?}"))?
+            .into_dyn())
     }
 }
 
@@ -241,11 +250,15 @@ impl SessionPersistenceStore for JsonSessionPersistenceStore {
         if let Some(t) = removed {
             debug!(?id, "deleted from in-memory db, flushing");
             self.flush().await?;
-            let tf = self.torrent_bytes_filename(&t.info_hash);
-            if let Err(e) = tokio::fs::remove_file(&tf).await {
-                warn!(error=?e, filename=?tf, "error removing torrent file");
-            } else {
-                debug!(filename=?tf, "removed");
+            for tf in [
+                self.torrent_bytes_filename(&t.info_hash),
+                self.bitv_filename(&t.info_hash),
+            ] {
+                if let Err(e) = tokio::fs::remove_file(&tf).await {
+                    warn!(error=?e, filename=?tf, "error removing");
+                } else {
+                    debug!(filename=?tf, "removed");
+                }
             }
         } else {
             bail!("error deleting: didn't find torrent id={id}")

--- a/crates/librqbit/src/session_persistence/json.rs
+++ b/crates/librqbit/src/session_persistence/json.rs
@@ -221,6 +221,7 @@ impl BitVFactory for JsonSessionPersistenceStore {
             .write(true)
             .open(&filename)
             .with_context(|| format!("error opening {filename:?}"))?;
+        trace!(?filename, "stored initial check bitfield");
         Ok(MmapBitV::new(f)
             .with_context(|| format!("error constructing MmapBitV from file {filename:?}"))?
             .into_dyn())

--- a/crates/librqbit/src/session_persistence/mod.rs
+++ b/crates/librqbit/src/session_persistence/mod.rs
@@ -13,7 +13,8 @@ use librqbit_core::Id20;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{
-    session::TorrentId, torrent_state::ManagedTorrentHandle, AddTorrent, AddTorrentOptions,
+    bitv_factory::BitVFactory, session::TorrentId, torrent_state::ManagedTorrentHandle, AddTorrent,
+    AddTorrentOptions,
 };
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -63,7 +64,7 @@ impl SerializedTorrent {
 
 // TODO: make this info_hash first, ID-second.
 #[async_trait]
-pub trait SessionPersistenceStore: core::fmt::Debug + Send + Sync {
+pub trait SessionPersistenceStore: core::fmt::Debug + Send + Sync + BitVFactory {
     async fn next_id(&self) -> anyhow::Result<TorrentId>;
     async fn store(&self, id: TorrentId, torrent: &ManagedTorrentHandle) -> anyhow::Result<()>;
     async fn delete(&self, id: TorrentId) -> anyhow::Result<()>;

--- a/crates/librqbit/src/session_persistence/mod.rs
+++ b/crates/librqbit/src/session_persistence/mod.rs
@@ -79,8 +79,6 @@ pub trait SessionPersistenceStore: core::fmt::Debug + Send + Sync + BitVFactory 
     ) -> anyhow::Result<BoxStream<'_, anyhow::Result<(TorrentId, SerializedTorrent)>>>;
 }
 
-pub type BoxSessionPersistenceStore = Box<dyn SessionPersistenceStore>;
-
 fn serialize_info_hash<S>(id: &Id20, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,

--- a/crates/librqbit/src/session_persistence/postgres.rs
+++ b/crates/librqbit/src/session_persistence/postgres.rs
@@ -2,10 +2,9 @@ use std::path::PathBuf;
 
 use crate::{
     api::TorrentIdOrHash, bitv::BitV, bitv_factory::BitVFactory, session::TorrentId,
-    torrent_state::ManagedTorrentHandle,
+    torrent_state::ManagedTorrentHandle, type_aliases::BF,
 };
 use anyhow::Context;
-use bitvec::{order::Lsb0, vec::BitVec};
 use futures::{stream::BoxStream, StreamExt};
 use librqbit_core::Id20;
 use sqlx::{Pool, Postgres};
@@ -183,7 +182,7 @@ impl BitVFactory for PostgresSessionStorage {
     async fn store_initial_check(
         &self,
         _: TorrentIdOrHash,
-        b: BitVec<u8, Lsb0>,
+        b: BF,
     ) -> anyhow::Result<Box<dyn BitV>> {
         Ok(b.into_dyn())
     }

--- a/crates/librqbit/src/tests/e2e.rs
+++ b/crates/librqbit/src/tests/e2e.rs
@@ -191,6 +191,7 @@ async fn _test_e2e_download() {
                 persistence: Some(SessionPersistenceConfig::Json {
                     folder: Some(session_persistence),
                 }),
+                fastresume: true,
                 listen_port_range: None,
                 enable_upnp_port_forwarding: false,
                 root_span: Some(error_span!("client")),

--- a/crates/librqbit/src/tests/e2e.rs
+++ b/crates/librqbit/src/tests/e2e.rs
@@ -10,7 +10,7 @@ use tokio::{
     spawn,
     time::{interval, timeout},
 };
-use tracing::{error_span, info, Instrument};
+use tracing::{error, error_span, info, Instrument};
 
 use crate::{
     create_torrent,
@@ -35,6 +35,10 @@ async fn test_e2e_download() {
 
 async fn _test_e2e_download() {
     let _ = tracing_subscriber::fmt::try_init();
+    match crate::try_increase_nofile_limit() {
+        Ok(limit) => info!(limit, "increased ulimit"),
+        Err(e) => error!(error=?e, "error increasing ulimit"),
+    };
 
     spawn_debug_server();
 

--- a/crates/librqbit/src/tests/test_util.rs
+++ b/crates/librqbit/src/tests/test_util.rs
@@ -5,7 +5,7 @@ use axum::{response::IntoResponse, routing::get, Router};
 use librqbit_core::Id20;
 use rand::{thread_rng, Rng, RngCore, SeedableRng};
 use tempfile::TempDir;
-use tracing::info;
+use tracing::{debug, info};
 
 pub fn create_new_file_with_random_content(path: &Path, mut size: usize) {
     let mut file = std::fs::OpenOptions::new()
@@ -14,7 +14,7 @@ pub fn create_new_file_with_random_content(path: &Path, mut size: usize) {
         .open(path)
         .unwrap();
 
-    eprintln!("creating temp file {:?}", path);
+    debug!(?path, "creating temp file");
 
     const BUF_SIZE: usize = 8192 * 16;
     let mut rng = rand::rngs::SmallRng::from_entropy();
@@ -32,7 +32,7 @@ pub fn create_default_random_dir_with_torrents(
     tempdir_prefix: Option<&str>,
 ) -> TempDir {
     let dir = TempDir::with_prefix(tempdir_prefix.unwrap_or("rqbit_test")).unwrap();
-    dbg!(dir.path());
+    info!(path=?dir.path(), "created tempdir");
     for f in 0..num_files {
         create_new_file_with_random_content(&dir.path().join(&format!("{f}.data")), file_size);
     }

--- a/crates/librqbit/src/torrent_state/initializing.rs
+++ b/crates/librqbit/src/torrent_state/initializing.rs
@@ -8,7 +8,9 @@ use anyhow::Context;
 use size_format::SizeFormatterBinary as SF;
 use tracing::{debug, info, warn};
 
-use crate::{chunk_tracker::ChunkTracker, file_ops::FileOps, type_aliases::FileStorage};
+use crate::{
+    bitv::BitV, chunk_tracker::ChunkTracker, file_ops::FileOps, type_aliases::FileStorage,
+};
 
 use super::{paused::TorrentStatePaused, ManagedTorrentInfo};
 
@@ -86,7 +88,7 @@ impl TorrentStateInitializing {
         })?;
 
         let chunk_tracker = ChunkTracker::new(
-            initial_check_results.have_pieces,
+            initial_check_results.have_pieces.into_dyn(),
             initial_check_results.selected_pieces,
             self.meta.lengths,
             &self.meta.file_infos,

--- a/crates/librqbit/src/torrent_state/initializing.rs
+++ b/crates/librqbit/src/torrent_state/initializing.rs
@@ -99,7 +99,10 @@ impl TorrentStateInitializing {
                     )
                     .initial_check(&self.checked_bytes)
                 })?;
-                bitv_factory.store_initial_check(id, have_pieces).await?
+                bitv_factory
+                    .store_initial_check(id, have_pieces)
+                    .await
+                    .context("error storing initial check bitfield")?
             }
         };
 

--- a/crates/librqbit/src/torrent_state/initializing.rs
+++ b/crates/librqbit/src/torrent_state/initializing.rs
@@ -5,11 +5,16 @@ use std::{
 
 use anyhow::Context;
 
+use librqbit_core::lengths::Lengths;
 use size_format::SizeFormatterBinary as SF;
 use tracing::{debug, info, warn};
 
 use crate::{
-    bitv::BitV, chunk_tracker::ChunkTracker, file_ops::FileOps, type_aliases::FileStorage,
+    bitv::BitV,
+    chunk_tracker::ChunkTracker,
+    file_ops::FileOps,
+    type_aliases::{FileStorage, BF},
+    FileInfos,
 };
 
 use super::{paused::TorrentStatePaused, ManagedTorrentInfo};
@@ -19,6 +24,24 @@ pub struct TorrentStateInitializing {
     pub(crate) meta: Arc<ManagedTorrentInfo>,
     pub(crate) only_files: Option<Vec<usize>>,
     pub(crate) checked_bytes: AtomicU64,
+}
+
+fn compute_selected_pieces(
+    lengths: &Lengths,
+    only_files: Option<&[usize]>,
+    file_infos: &FileInfos,
+) -> BF {
+    let mut bf = BF::from_boxed_slice(vec![0u8; lengths.piece_bitfield_bytes()].into_boxed_slice());
+    for (_, fi) in file_infos
+        .iter()
+        .enumerate()
+        .filter(|(id, _)| only_files.map(|of| of.contains(id)).unwrap_or(false))
+    {
+        if let Some(r) = bf.get_mut(fi.piece_range_usize()) {
+            r.fill(true);
+        }
+    }
+    bf
 }
 
 impl TorrentStateInitializing {
@@ -42,21 +65,37 @@ impl TorrentStateInitializing {
 
     pub async fn check(&self) -> anyhow::Result<TorrentStatePaused> {
         info!("Doing initial checksum validation, this might take a while...");
-        let initial_check_results = self.meta.spawner.spawn_block_in_place(|| {
+        let have_pieces = self.meta.spawner.spawn_block_in_place(|| {
             FileOps::new(
                 &self.meta.info,
                 &self.files,
                 &self.meta.file_infos,
                 &self.meta.lengths,
             )
-            .initial_check(self.only_files.as_deref(), &self.checked_bytes)
+            .initial_check(&self.checked_bytes)
         })?;
+
+        let selected_pieces = compute_selected_pieces(
+            &self.meta.lengths,
+            self.only_files.as_deref(),
+            &self.meta.file_infos,
+        );
+
+        let chunk_tracker = ChunkTracker::new(
+            have_pieces.into_dyn(),
+            selected_pieces,
+            self.meta.lengths,
+            &self.meta.file_infos,
+        )
+        .context("error creating chunk tracker")?;
+
+        let hns = chunk_tracker.get_hns();
 
         info!(
             "Initial check results: have {}, needed {}, total selected {}",
-            SF::new(initial_check_results.have_bytes),
-            SF::new(initial_check_results.needed_bytes),
-            SF::new(initial_check_results.selected_bytes)
+            SF::new(hns.have_bytes),
+            SF::new(hns.needed_bytes),
+            SF::new(hns.selected_bytes)
         );
 
         // Ensure file lenghts are correct, and reopen read-only.
@@ -86,14 +125,6 @@ impl TorrentStateInitializing {
             }
             Ok::<_, anyhow::Error>(())
         })?;
-
-        let chunk_tracker = ChunkTracker::new(
-            initial_check_results.have_pieces.into_dyn(),
-            initial_check_results.selected_pieces,
-            self.meta.lengths,
-            &self.meta.file_infos,
-        )
-        .context("error creating chunk tracker")?;
 
         let paused = TorrentStatePaused {
             info: self.meta.clone(),

--- a/crates/librqbit/src/torrent_state/live/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/mod.rs
@@ -835,7 +835,7 @@ impl<'a> PeerConnectionHandler for &'a PeerHandler {
 
     fn serialize_bitfield_message_to_buf(&self, buf: &mut Vec<u8>) -> anyhow::Result<usize> {
         let g = self.state.lock_read("serialize_bitfield_message_to_buf");
-        let msg = Message::Bitfield(ByteBuf(g.get_chunks()?.get_have_pieces().as_raw_slice()));
+        let msg = Message::Bitfield(ByteBuf(g.get_chunks()?.get_have_pieces().as_bytes()));
         let len = msg.serialize(buf, &|| None)?;
         trace!("sending: {:?}, length={}", &msg, len);
         Ok(len)

--- a/crates/librqbit/src/torrent_state/live/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/mod.rs
@@ -131,6 +131,8 @@ pub(crate) struct TorrentStateLocked {
 
     // If this is None, then it was already used
     fatal_errors_tx: Option<tokio::sync::oneshot::Sender<anyhow::Error>>,
+
+    unflushed_bitv_bytes: u64,
 }
 
 impl TorrentStateLocked {
@@ -145,6 +147,23 @@ impl TorrentStateLocked {
             .as_mut()
             .context("chunk tracker empty, torrent was paused")
     }
+
+    fn try_flush_bitv(&mut self) {
+        if self.unflushed_bitv_bytes == 0 {
+            return;
+        }
+
+        if let Some(Err(e)) = self
+            .chunks
+            .as_mut()
+            .map(|ct| ct.get_have_pieces_mut().flush())
+        {
+            warn!(error=?e, "error flushing bitfield");
+        } else {
+            trace!("flushed bitfield");
+            self.unflushed_bitv_bytes = 0;
+        }
+    }
 }
 
 #[derive(Default)]
@@ -154,6 +173,8 @@ pub struct TorrentStateOptions {
     #[allow(dead_code)]
     pub peer_read_write_timeout: Option<Duration>,
 }
+
+const FLUSH_BITV_EVERY_BYTES: u64 = 16 * 1024 * 1024;
 
 pub struct TorrentStateLive {
     peers: PeerStates,
@@ -223,6 +244,7 @@ impl TorrentStateLive {
                 inflight_pieces: Default::default(),
                 file_priorities,
                 fatal_errors_tx: Some(fatal_errors_tx),
+                unflushed_bitv_bytes: 0,
             }),
             files: paused.files,
             stats: AtomicStats {
@@ -684,6 +706,7 @@ impl TorrentStateLive {
 
     fn on_piece_completed(&self, id: ValidPieceIndex) -> anyhow::Result<()> {
         let mut g = self.lock_write("on_piece_completed");
+        let g = &mut **g;
         let chunks = g.get_chunks_mut()?;
 
         // if we have all the pieces of the file, reopen it read only
@@ -701,13 +724,20 @@ impl TorrentStateLive {
         self.streams
             .wake_streams_on_piece_completed(id, &self.meta.lengths);
 
+        g.unflushed_bitv_bytes += self.meta.lengths.piece_length(id) as u64;
+        if g.unflushed_bitv_bytes >= FLUSH_BITV_EVERY_BYTES {
+            g.try_flush_bitv()
+        }
+
+        let chunks = g.get_chunks()?;
         if chunks.is_finished() {
             if chunks.get_selected_pieces()[id.get_usize()] {
+                g.try_flush_bitv();
                 info!("torrent finished downloading");
             }
             self.finished_notify.notify_waiters();
 
-            if !self.has_active_streams_unfinished_files(&g) {
+            if !self.has_active_streams_unfinished_files(g) {
                 // There is not poing being connected to peers that have all the torrent, when
                 // we don't need anything from them, and they don't need anything from us.
                 self.disconnect_all_peers_that_have_full_torrent();

--- a/crates/librqbit/src/torrent_state/live/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/mod.rs
@@ -152,7 +152,7 @@ impl TorrentStateLocked {
         if self.unflushed_bitv_bytes == 0 {
             return;
         }
-
+        trace!("trying to flush bitfield");
         if let Some(Err(e)) = self
             .chunks
             .as_mut()

--- a/crates/librqbit/src/torrent_state/streaming.rs
+++ b/crates/librqbit/src/torrent_state/streaming.rs
@@ -187,7 +187,7 @@ impl AsyncRead for FileStream {
         // if the piece is not there, register to wake when it is
         // check if we have the piece for real
         let have = poll_try_io!(self.torrent.with_chunk_tracker(|ct| {
-            let have = ct.get_have_pieces()[current.id.get() as usize];
+            let have = ct.get_have_pieces().as_slice()[current.id.get() as usize];
             if !have {
                 self.streams
                     .register_waker(self.stream_id, cx.waker().clone());

--- a/crates/librqbit/src/type_aliases.rs
+++ b/crates/librqbit/src/type_aliases.rs
@@ -4,7 +4,8 @@ use futures::stream::BoxStream;
 
 use crate::{file_info::FileInfo, storage::TorrentStorage};
 
-pub type BF = bitvec::boxed::BitBox<u8, bitvec::order::Msb0>;
+pub type BS = bitvec::slice::BitSlice<u8, bitvec::order::Lsb0>;
+pub type BF = bitvec::boxed::BitBox<u8, bitvec::order::Lsb0>;
 
 pub type PeerHandle = SocketAddr;
 pub type PeerStream = BoxStream<'static, SocketAddr>;

--- a/crates/librqbit/src/type_aliases.rs
+++ b/crates/librqbit/src/type_aliases.rs
@@ -4,8 +4,10 @@ use futures::stream::BoxStream;
 
 use crate::{file_info::FileInfo, storage::TorrentStorage};
 
-pub type BS = bitvec::slice::BitSlice<u8, bitvec::order::Lsb0>;
-pub type BF = bitvec::boxed::BitBox<u8, bitvec::order::Lsb0>;
+// NOTE: Msb0 is used because that's what bittorrent protocol uses for bitfield.
+// Don't change to Lsb0 even though it might be a bit faster (in theory) on LE architectures.
+pub type BS = bitvec::slice::BitSlice<u8, bitvec::order::Msb0>;
+pub type BF = bitvec::boxed::BitBox<u8, bitvec::order::Msb0>;
 
 pub type PeerHandle = SocketAddr;
 pub type PeerStream = BoxStream<'static, SocketAddr>;

--- a/crates/peer_binary_protocol/src/lib.rs
+++ b/crates/peer_binary_protocol/src/lib.rs
@@ -199,8 +199,8 @@ pub enum Message<ByteBuf: std::hash::Hash + Eq> {
 pub type MessageBorrowed<'a> = Message<ByteBuf<'a>>;
 pub type MessageOwned = Message<ByteBufOwned>;
 
-pub type BitfieldBorrowed<'a> = &'a bitvec::slice::BitSlice<u8, bitvec::order::Lsb0>;
-pub type BitfieldOwned = bitvec::vec::BitVec<u8, bitvec::order::Lsb0>;
+pub type BitfieldBorrowed<'a> = &'a bitvec::slice::BitSlice<u8, bitvec::order::Msb0>;
+pub type BitfieldOwned = bitvec::vec::BitVec<u8, bitvec::order::Msb0>;
 
 pub struct Bitfield<'a> {
     pub data: BitfieldBorrowed<'a>,

--- a/crates/rqbit/src/main.rs
+++ b/crates/rqbit/src/main.rs
@@ -143,6 +143,10 @@ struct ServerStartOptions {
     /// The folder to store session data in. By default uses OS specific folder.
     #[arg(long = "persistence-config")]
     persistence_config: Option<String>,
+
+    /// [Experimental] if set, will try to resume quickly after restart and skip checksumming.
+    #[arg(long = "fastresume")]
+    fastresume: bool,
 }
 
 #[derive(Parser)]
@@ -421,6 +425,8 @@ async fn async_main(opts: Opts) -> anyhow::Result<()> {
                         sopts.persistence = Some(SessionPersistenceConfig::Json { folder: None })
                     }
                 }
+
+                sopts.fastresume = start_opts.fastresume;
 
                 let session =
                     Session::new_with_opts(PathBuf::from(&start_opts.output_folder), sopts)

--- a/crates/rqbit/src/main.rs
+++ b/crates/rqbit/src/main.rs
@@ -341,6 +341,7 @@ async fn async_main(opts: Opts) -> anyhow::Result<()> {
         socks_proxy_url: socks_url,
         concurrent_init_limit: Some(opts.concurrent_init_limit),
         root_span: None,
+        fastresume: false,
     };
 
     let stats_printer = |session: Arc<Session>| async move {


### PR DESCRIPTION
First mentioned in https://github.com/ikatson/rqbit/issues/138

rqbit can now now store bitfields in persistent storage which allows quick restarts without rehashing. Disabled by default to flesh out bugs.

Usage:

```
rqbit server start --fastresume ...
```

This required some refactoring throughout to thread this through and let bitfields be memory mapped or backed by postgres (if using that as the store)

TODO:
- [ ] make flush async
- [ ] if restarting from error state, clear the bitfield state first
- [ ] add to desktop UI