### PR TITLE
Fix persistence bugs

### DIFF
--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -1152,6 +1152,7 @@ impl Session {
             ));
             let handle = Arc::new(ManagedTorrent {
                 locked: RwLock::new(ManagedTorrentLocked {
+                    paused: opts.paused,
                     state: ManagedTorrentState::Initializing(initializing),
                     only_files,
                 }),
@@ -1327,6 +1328,7 @@ impl Session {
     }
 
     pub async fn pause(&self, handle: &ManagedTorrentHandle) -> anyhow::Result<()> {
+        handle.locked.write().paused = true;
         handle.pause()?;
         self.try_update_persistence_metadata(handle).await;
         Ok(())

--- a/crates/librqbit/src/session_persistence/json.rs
+++ b/crates/librqbit/src/session_persistence/json.rs
@@ -8,7 +8,6 @@ use crate::{
     storage::filesystem::FilesystemStorageFactory,
     torrent_state::ManagedTorrentHandle,
     type_aliases::BF,
-    ManagedTorrentState,
 };
 use anyhow::{bail, Context};
 use async_trait::async_trait;
@@ -146,7 +145,7 @@ impl JsonSessionPersistenceStore {
             // we don't serialize this here, but to a file instead.
             torrent_bytes: Default::default(),
             only_files: torrent.only_files().clone(),
-            is_paused: torrent.with_state(|s| matches!(s, ManagedTorrentState::Paused(_))),
+            is_paused: torrent.is_paused(),
             output_folder: torrent.shared().options.output_folder.clone(),
         };
 


### PR DESCRIPTION
There were a couple bugs in recent betas:
- torrents might have started unpaused even if were previously paused
- concurrent modification of JSON file resulted in some torrents not showing up after restart as the temp file couldn't be renamed (twice)