### PR TITLE
Switch x86_64 build to use musl

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,12 +80,12 @@ jobs:
 
       - name: install linux cross compiler
         run: brew tap messense/macos-cross-toolchains &&
-          brew install x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu arm-unknown-linux-gnueabihf armv7-unknown-linux-gnueabihf armv7-unknown-linux-musleabihf
+          brew install x86_64-unknown-linux-musl aarch64-unknown-linux-gnu arm-unknown-linux-gnueabihf armv7-unknown-linux-gnueabihf armv7-unknown-linux-musleabihf
 
       - name: Build release linux x86_64 binary
-        run: rustup target install x86_64-unknown-linux-gnu &&
+        run: rustup target install x86_64-unknown-linux-musl &&
           make release-linux-x86_64 &&
-          mv target/x86_64-unknown-linux-gnu/release-github/rqbit target/artifacts/rqbit-linux-static-x86_64
+          mv target/x86_64-unknown-linux-musl/release-github/rqbit target/artifacts/rqbit-linux-static-x86_64
       - uses: softprops/action-gh-release@v1
         with:
           generate_release_notes: true

--- a/Makefile
+++ b/Makefile
@@ -97,10 +97,10 @@ release-linux: release-linux-x86_64 release-linux-aarch64 release-linux-armv6 re
 
 @PHONY: release-linux-x86_64
 release-linux-x86_64:
-	TARGET=x86_64-unknown-linux-gnu \
-	TARGET_SNAKE_CASE=x86_64_unknown_linux_gnu \
-	TARGET_SNAKE_UPPER_CASE=X86_64_UNKNOWN_LINUX_GNU \
-	CROSS_COMPILE_PREFIX=x86_64-unknown-linux-gnu \
+	TARGET=x86_64-unknown-linux-musl \
+	TARGET_SNAKE_CASE=x86_64_unknown_linux_musl \
+	TARGET_SNAKE_UPPER_CASE=X86_64_UNKNOWN_LINUX_MUSL \
+	CROSS_COMPILE_PREFIX=x86_64-unknown-linux-musl \
 	$(MAKE) release-linux-current-target
 
 @PHONY: release-linux-aarch64


### PR DESCRIPTION
Preparing for a docker image build, don't want to depend on glibc there, want to use "scratch" image and single binary