### PR TITLE
Add docker build for linux/amd64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,12 @@ jobs:
           files: |
             target/artifacts/rqbit-linux-static-x86_64
 
+      - name: Archive target/artifacts/rqbit-linux-static-x86_64
+        uses: actions/upload-artifact@v4
+        with:
+          name: rqbit-linux-static-x86_64
+          path: target/artifacts/rqbit-linux-static-x86_64
+
       - name: Build release linux armv6 binary
         run: rustup target install arm-unknown-linux-gnueabihf &&
           make release-linux-armv6 &&
@@ -132,3 +138,34 @@ jobs:
           generate_release_notes: true
           files: |
             target/artifacts/rqbit-linux-static-aarch64
+
+  build-push-docker:
+    runs-on: ubuntu-latest
+    needs: cross-compile-on-macos
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download a single artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: rqbit-linux-static-x86_64
+
+      - name: Move the binary to a different place
+        run: mkdir -p target/x86_64/ && mv rqbit-linux-static-x86_64 target/x86_64/rqbit
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: ikatson/rqbit:${{ github.ref_name }}
+          context: target/x86_64/
+          platforms: linux/amd64
+          file: docker/Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,14 @@ release-linux-x86_64:
 	CROSS_COMPILE_PREFIX=x86_64-unknown-linux-musl \
 	$(MAKE) release-linux-current-target
 
+@PHONY: docker-x86_64
+docker-x86_64:
+	docker build \
+        -f docker/Dockerfile \
+        -t ikatson/rqbit:$(shell git describe --tags) \
+		--platform linux/amd64 \
+		target/x86_64-unknown-linux-musl/release-github/
+
 @PHONY: release-linux-aarch64
 release-linux-aarch64:
 	TARGET=aarch64-unknown-linux-gnu \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,21 @@
+FROM scratch
+
+## Assumes you are running this from respective context folder.
+COPY --chmod=755 rqbit /bin/rqbit
+
+WORKDIR /home/rqbit
+
+ENV XDG_DATA_HOME=/home/rqbit/config
+ENV XDG_CACHE_HOME=/home/rqbit/cache
+
+ENV RQBIT_HTTP_API_LISTEN_ADDR=0.0.0.0:3000
+ENV RQBIT_TCP_LISTEN_MIN_PORT=4240
+ENV RQBIT_TCP_LISTEN_MAX_PORT=4241
+
+VOLUME /home/rqbit/config
+VOLUME /home/rqbit/cache
+VOLUME /home/rqbit/output
+
+EXPOSE 3000
+EXPOSE 4240
+ENTRYPOINT ["/bin/rqbit"]


### PR DESCRIPTION
This adds a docker build for CI. Assumes the binary was prebuilt already outside of docker.