### PR TITLE
[Feature] UPNP MediaServer: send notifies on all interfaces, no need to specify hostname

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1639,6 +1639,7 @@ dependencies = [
  "librqbit-sha1-wrapper",
  "librqbit-upnp",
  "mime_guess",
+ "network-interface",
  "parking_lot",
  "quick-xml",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2493,6 +2493,7 @@ dependencies = [
  "clap_complete",
  "console-subscriber",
  "futures",
+ "gethostname",
  "libc",
  "librqbit",
  "librqbit-upnp-serve",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
+name = "assert_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e2651f366b7ee3f97729fded1441539b49d5f39eeb05b842689e11e84501b2"
+dependencies = [
+ "const_panic",
+]
+
+[[package]]
 name = "async-backtrace"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,6 +539,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const_panic"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7782af8f90fe69a4bb41e460abe1727d493403d8b2cc43201a3a3e906b24379f"
 
 [[package]]
 name = "core-foundation"
@@ -1517,6 +1532,7 @@ name = "librqbit-core"
 version = "4.0.1"
 dependencies = [
  "anyhow",
+ "assert_cfg",
  "bytes",
  "data-encoding",
  "directories",
@@ -1583,6 +1599,7 @@ dependencies = [
 name = "librqbit-sha1-wrapper"
 version = "4.0.0"
 dependencies = [
+ "assert_cfg",
  "crypto-hash",
  "ring",
 ]

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ webui-build: webui-deps
 	npm run build
 
 # NOTE: on LG TV using hostname is unstable for some reason, use IP address.
-export RQBIT_UPNP_SERVER_HOSTNAME ?= $(shell hostname)
+export RQBIT_UPNP_SERVER_ENABLE ?= true
 export RQBIT_UPNP_SERVER_FRIENDLY_NAME ?= rqbit-dev
 export RQBIT_HTTP_API_LISTEN_ADDR ?= 0.0.0.0:3030
 RQBIT_OUTPUT_FOLDER ?= /tmp/scratch

--- a/crates/librqbit/Cargo.toml
+++ b/crates/librqbit/Cargo.toml
@@ -17,8 +17,19 @@ http-api = ["axum", "tower-http"]
 upnp-serve-adapter = ["upnp-serve"]
 webui = []
 timed_existence = []
-default-tls = ["reqwest/default-tls", "sha1w/sha1-crypto-hash"]
-rust-tls = ["reqwest/rustls-tls", "sha1w/sha1-ring"]
+default-tls = [
+    "reqwest/default-tls",
+    "sha1w/sha1-crypto-hash",
+    "bencode/sha1-crypto-hash",
+    "librqbit-core/sha1-crypto-hash",
+]
+rust-tls = [
+    "reqwest/rustls-tls",
+    "sha1w/sha1-ring",
+    "sha1w/sha1-ring",
+    "bencode/sha1-ring",
+    "librqbit-core/sha1-ring",
+]
 storage_middleware = ["lru"]
 storage_examples = []
 tracing-subscriber-utils = ["tracing-subscriber"]

--- a/crates/librqbit_core/Cargo.toml
+++ b/crates/librqbit_core/Cargo.toml
@@ -31,6 +31,7 @@ directories = "5"
 tokio-util = "0.7.10"
 data-encoding = "2.6.0"
 bytes = "1.7.1"
+assert_cfg = "0.1.0"
 
 
 [dev-dependencies]

--- a/crates/librqbit_core/src/lib.rs
+++ b/crates/librqbit_core/src/lib.rs
@@ -9,3 +9,8 @@ pub mod speed_estimator;
 pub mod torrent_metainfo;
 
 pub use hash_id::Id20;
+
+assert_cfg::exactly_one! {
+    feature = "sha1-crypto-hash",
+    feature = "sha1-ring",
+}

--- a/crates/librqbit_core/src/torrent_metainfo.rs
+++ b/crates/librqbit_core/src/torrent_metainfo.rs
@@ -29,7 +29,11 @@ pub fn torrent_from_bytes_ext<'de, BufType: Deserialize<'de> + From<&'de [u8]>>(
     let mut t = TorrentMetaV1::deserialize(&mut de)?;
     let (digest, info_bytes) = match (de.torrent_info_digest, de.torrent_info_bytes) {
         (Some(digest), Some(info_bytes)) => (digest, info_bytes),
-        _ => anyhow::bail!("programming error"),
+        (o1, o2) => anyhow::bail!(
+            "programming error: digest.is_some()={}, info_bytes.is_some()={}. Probably one of bencode/sha1* features isn't enabled.",
+            o1.is_some(),
+            o2.is_some()
+        ),
     };
     t.info_hash = Id20::new(digest);
     Ok(ParsedTorrent {

--- a/crates/rqbit/Cargo.toml
+++ b/crates/rqbit/Cargo.toml
@@ -48,6 +48,7 @@ upnp-serve = { path = "../upnp-serve", default-features = false, version = "0.1.
 libc = "0.2.158"
 signal-hook = "0.3.17"
 tokio-util = "0.7.11"
+gethostname = "0.5.0"
 
 [dev-dependencies]
 futures = { version = "0.3" }

--- a/crates/sha1w/Cargo.toml
+++ b/crates/sha1w/Cargo.toml
@@ -16,5 +16,6 @@ sha1-crypto-hash = ["crypto-hash"]
 sha1-ring = ["ring"]
 
 [dependencies]
+assert_cfg = "0.1.0"
 crypto-hash = { version = "0.3", optional = true }
 ring = { version = "0.17", optional = true }

--- a/crates/sha1w/src/lib.rs
+++ b/crates/sha1w/src/lib.rs
@@ -11,6 +11,11 @@ pub trait ISha1 {
     fn finish(self) -> [u8; 20];
 }
 
+assert_cfg::exactly_one! {
+    feature = "sha1-crypto-hash",
+    feature = "sha1-ring",
+}
+
 #[cfg(feature = "sha1-crypto-hash")]
 mod crypto_hash_impl {
     use super::ISha1;

--- a/crates/upnp-serve/Cargo.toml
+++ b/crates/upnp-serve/Cargo.toml
@@ -34,6 +34,7 @@ tokio-util = "0.7.11"
 reqwest = { version = "0.12.7", default-features = false }
 socket2 = "0.5.7"
 quick-xml = { version = "0.36.1", features = ["serialize"] }
+network-interface = "2.0.0"
 
 [dev-dependencies]
 tracing-subscriber = "0.3.18"

--- a/crates/upnp-serve/examples/upnp-stub-server.rs
+++ b/crates/upnp-serve/examples/upnp-stub-server.rs
@@ -34,8 +34,6 @@ async fn main() -> anyhow::Result<()> {
     info!("Creating UpnpServer");
     let mut server = UpnpServer::new(UpnpServerOptions {
         friendly_name: "demo upnp server".to_owned(),
-        http_hostname: std::env::var("UPNP_HOSTNAME")
-            .context("you need to set UPNP_HOSTNAME to your IP visible from LAN")?,
         http_listen_port: HTTP_PORT,
         http_prefix: HTTP_PREFIX.to_owned(),
         browse_provider: Box::new(items),

--- a/crates/upnp-serve/src/lib.rs
+++ b/crates/upnp-serve/src/lib.rs
@@ -20,7 +20,6 @@ pub mod upnp_types;
 
 pub struct UpnpServerOptions {
     pub friendly_name: String,
-    pub http_hostname: String,
     pub http_listen_port: u16,
     pub http_prefix: String,
     pub browse_provider: Box<dyn ContentDirectoryBrowseProvider>,
@@ -57,14 +56,16 @@ impl UpnpServer {
         let usn = create_usn(&opts).context("error generating USN")?;
 
         let description_http_location = {
-            let hostname = &opts.http_hostname;
             let port = opts.http_listen_port;
             let http_prefix = &opts.http_prefix;
-            format!("http://{hostname}:{port}{http_prefix}/description.xml")
+            let surl = format!("http://0.0.0.0:{port}{http_prefix}/description.xml");
+            url::Url::parse(&surl)
+                .context(surl)
+                .context("error parsing url")?
         };
 
         info!(
-            location = description_http_location,
+            location = %description_http_location,
             "starting UPnP/SSDP announcer for MediaServer"
         );
         let ssdp_runner = crate::ssdp::SsdpRunner::new(ssdp::SsdpRunnerOptions {

--- a/crates/upnp-serve/src/ssdp.rs
+++ b/crates/upnp-serve/src/ssdp.rs
@@ -209,7 +209,7 @@ Content-Length: 0\r\n\r\n"
                     let msg = self.generate_notify_message(kind, nts, &format!("{location}"));
                     trace!(content=?msg, addr=?UPNP_BROADCAST_ADDR, "sending SSDP NOTIFY");
                     if let Err(e) = sock.send_to(msg.as_bytes(), UPNP_BROADCAST_ADDR).await {
-                        warn!(sock_addr=%addr, error=%e, "error sending SSDP NOTIFY")
+                        debug!(sock_addr=%addr, error=%e, kind, nts, "error sending SSDP NOTIFY")
                     } else {
                         debug!(kind, nts, %location, "sent SSDP NOTIFY")
                     }

--- a/crates/upnp-serve/src/upnp_types.rs
+++ b/crates/upnp-serve/src/upnp_types.rs
@@ -70,11 +70,19 @@ pub mod content_directory {
     }
 
     pub trait ContentDirectoryBrowseProvider: Send + Sync {
-        fn browse_direct_children(&self, parent_id: usize) -> Vec<ItemOrContainer>;
+        fn browse_direct_children(
+            &self,
+            parent_id: usize,
+            http_hostname: &str,
+        ) -> Vec<ItemOrContainer>;
     }
 
     impl ContentDirectoryBrowseProvider for Vec<ItemOrContainer> {
-        fn browse_direct_children(&self, _parent_id: usize) -> Vec<ItemOrContainer> {
+        fn browse_direct_children(
+            &self,
+            _parent_id: usize,
+            _http_host: &str,
+        ) -> Vec<ItemOrContainer> {
             self.clone()
         }
     }

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -69,6 +69,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
+name = "assert_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e2651f366b7ee3f97729fded1441539b49d5f39eeb05b842689e11e84501b2"
+dependencies = [
+ "const_panic",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,6 +506,12 @@ checksum = "1fed34f46747aa73dfaa578069fd8279d2818ade2b55f38f22a9401c7f4083e2"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "const_panic"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7782af8f90fe69a4bb41e460abe1727d493403d8b2cc43201a3a3e906b24379f"
 
 [[package]]
 name = "convert_case"
@@ -1916,6 +1931,7 @@ name = "librqbit-core"
 version = "4.0.1"
 dependencies = [
  "anyhow",
+ "assert_cfg",
  "bytes",
  "data-encoding",
  "directories",
@@ -1980,6 +1996,7 @@ dependencies = [
 name = "librqbit-sha1-wrapper"
 version = "4.0.0"
 dependencies = [
+ "assert_cfg",
  "crypto-hash",
 ]
 
@@ -2034,6 +2051,7 @@ dependencies = [
  "librqbit-sha1-wrapper",
  "librqbit-upnp",
  "mime_guess",
+ "network-interface",
  "parking_lot",
  "quick-xml 0.36.1",
  "reqwest",
@@ -3051,6 +3069,7 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "directories",
+ "gethostname",
  "http 1.1.0",
  "librqbit",
  "parking_lot",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -31,6 +31,7 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 tracing = "0.1"
 serde_with = "3.4.0"
 parking_lot = "0.12.1"
+gethostname = "0.5.0"
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem

--- a/desktop/src-tauri/src/config.rs
+++ b/desktop/src-tauri/src/config.rs
@@ -136,9 +136,6 @@ pub struct RqbitDesktopConfigUpnp {
     pub enable_server: bool,
 
     #[serde(default)]
-    pub server_hostname: Option<String>,
-
-    #[serde(default)]
     pub server_friendly_name: Option<String>,
 }
 
@@ -182,12 +179,6 @@ impl RqbitDesktopConfig {
             }
             if self.http_api.listen_addr.ip().is_loopback() {
                 anyhow::bail!("if UPnP server is enabled, you need to set HTTP API IP to 0.0.0.0 or at least non-localhost address.")
-            }
-            match self.upnp.server_hostname.as_ref().map(|s| s.trim()) {
-                Some("") | None => {
-                    anyhow::bail!("UPnP hostname must be set to non-empty string")
-                }
-                Some(_) => {}
             }
         }
         Ok(())

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -122,13 +122,6 @@ async fn api_from_config(
         let api = api.clone();
         let read_only = config.http_api.read_only;
         let upnp_router = if config.upnp.enable_server {
-            let hostname = config
-                .upnp
-                .server_hostname
-                .as_ref()
-                .map(|h| h.trim())
-                .context("empty UPNP hostname")?
-                .to_owned();
             let friendly_name = config
                 .upnp
                 .server_friendly_name
@@ -136,10 +129,15 @@ async fn api_from_config(
                 .map(|f| f.trim())
                 .filter(|s| !s.is_empty())
                 .map(|s| s.to_owned())
-                .unwrap_or_else(|| format!("rqbit@{hostname}"));
+                .unwrap_or_else(|| {
+                    format!(
+                        "rqbit-desktop@{}",
+                        gethostname::gethostname().to_string_lossy()
+                    )
+                });
 
             let mut upnp_adapter = session
-                .make_upnp_adapter(friendly_name, hostname, config.http_api.listen_addr.port())
+                .make_upnp_adapter(friendly_name, config.http_api.listen_addr.port())
                 .await
                 .context("error starting UPnP server")?;
             let router = upnp_adapter.take_router()?;

--- a/desktop/src/configuration.tsx
+++ b/desktop/src/configuration.tsx
@@ -36,7 +36,6 @@ interface RqbitDesktopConfigUpnp {
   disable: boolean;
 
   enable_server: boolean;
-  server_hostname: string;
   server_friendly_name: string;
 }
 

--- a/desktop/src/configure.tsx
+++ b/desktop/src/configure.tsx
@@ -295,16 +295,6 @@ export const ConfigModal: React.FC<{
 
             <FormInput
               inputType="text"
-              label="[Required] Hostname"
-              name="upnp.server_hostname"
-              value={config.upnp.server_hostname}
-              disabled={!config.upnp.enable_server}
-              onChange={handleInputChange}
-              help="Set this to your LAN IP or hostname resolvable from LAN."
-            />
-
-            <FormInput
-              inputType="text"
               label="Friendly name"
               name="upnp.server_friendly_name"
               value={config.upnp.server_friendly_name}

--- a/docker/compose-examples/server.yaml
+++ b/docker/compose-examples/server.yaml
@@ -11,7 +11,7 @@ services:
       - 4240:4240 # TCP BitTorrent port
     environment:
       # Replace this with your LAN hostname or IP, resolvable from other devices in your LAN
-      RQBIT_UPNP_SERVER_HOSTNAME: 192.168.0.112
+      RQBIT_UPNP_SERVER_ENABLE: "true"
       RQBIT_UPNP_SERVER_FRIENDLY_NAME: rqbit-docker
 
       # Replace this if you want to change the HTTP/Web UI port


### PR DESCRIPTION
It was inconvenient to specify UPNP_SERVER_HOSTNAME. Also turned on LG TV doesn't like actual hostnames in there, it rather prefers IPs.

So to increase usability, multicast NOTIFY packets are now sent to all interfaces. The location returned is dependent on the outgoing or incoming address.