### PR TITLE
Standardized m3u8 formatting

### DIFF
--- a/crates/librqbit/src/http_api.rs
+++ b/crates/librqbit/src/http_api.rs
@@ -190,6 +190,7 @@ impl HttpApi {
             let body = it
                 .into_iter()
                 .map(|(torrent_idx, file_idx, filename)| {
+                    // TODO: add #EXTINF:{duration} and maybe codecs ?
                     format!("http://{host}/torrents/{torrent_idx}/stream/{file_idx}/{filename}")
                 })
                 .join("\r\n");
@@ -201,7 +202,7 @@ impl HttpApi {
                         "attachment; filename=\"rqbit-playlist.m3u8\"",
                     ),
                 ],
-                body,
+                format!("#EXTM3U\r\n{body}"), // https://en.wikipedia.org/wiki/M3U
             )
         }
 


### PR DESCRIPTION
Currently you're breaking the m3u8 standard and it breaks some media players. Adding the `#EXTM3U` tag should fix it. 

There is more information that *would* be best practice to add but I don't know how to add it. Please read the [m3u8 spec](https://www.rfc-editor.org/rfc/rfc8216) or the [wiki](https://en.wikipedia.org/wiki/M3U) for more information.