### PR TITLE
[UPnP / DLNA] Updates for Samsung to work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,13 +63,23 @@ docker-build-armv7:
 clean:
 	rm -rf target
 
+CARGO_RELEASE_PROFILE ?= release-github
+
 @PHONY: release-linux-current-target
 release-linux-current-target:
 	CC_$(TARGET_SNAKE_CASE)=$(CROSS_COMPILE_PREFIX)-gcc \
 	CXX_$(TARGET_SNAKE_CASE)=$(CROSS_COMPILE_PREFIX)-g++ \
 	AR_$(TARGET_SNAKE_CASE)=$(CROSS_COMPILE_PREFIX)-ar \
 	CARGO_TARGET_$(TARGET_SNAKE_UPPER_CASE)_LINKER=$(CROSS_COMPILE_PREFIX)-gcc \
-	cargo build  --profile release-github --target=$(TARGET) --features=openssl-vendored
+	cargo build  --profile $(CARGO_RELEASE_PROFILE) --target=$(TARGET) --features=openssl-vendored
+
+@PHONY: debug-linux-docker-x86_64
+debug-linux-docker-x86_64:
+	CARGO_RELEASE_PROFILE=dev \
+	$(MAKE) release-linux-x86_64 && \
+	cp target/x86_64-unknown-linux-musl/debug/rqbit target/cross/linux/amd64/ && \
+	docker build -t ikatson/rqbit:tmp-debug -f docker/Dockerfile --platform linux/amd64 target/cross && \
+	docker push ikatson/rqbit:tmp-debug
 
 @PHONY: release-linux-x86_64
 release-linux-x86_64:

--- a/crates/librqbit/src/http_api.rs
+++ b/crates/librqbit/src/http_api.rs
@@ -346,6 +346,16 @@ impl HttpApi {
             let mut output_headers = HeaderMap::new();
             output_headers.insert("Accept-Ranges", HeaderValue::from_static("bytes"));
 
+            output_headers.insert(
+                "transferMode.dlna.org",
+                HeaderValue::from_static("Streaming"),
+            );
+
+            output_headers.insert(
+                "contentFeatures.dlna.org",
+                HeaderValue::from_static("DLNA.ORG_OP=01"),
+            );
+
             if let Ok(mime) = state.torrent_file_mime_type(idx, file_id) {
                 output_headers.insert(
                     http::header::CONTENT_TYPE,

--- a/crates/librqbit/src/http_api.rs
+++ b/crates/librqbit/src/http_api.rs
@@ -346,15 +346,28 @@ impl HttpApi {
             let mut output_headers = HeaderMap::new();
             output_headers.insert("Accept-Ranges", HeaderValue::from_static("bytes"));
 
-            output_headers.insert(
-                "transferMode.dlna.org",
-                HeaderValue::from_static("Streaming"),
-            );
+            const DLNA_TRANSFER_MODE: &str = "transferMode.dlna.org";
+            const DLNA_GET_CONTENT_FEATURES: &str = "getcontentFeatures.dlna.org";
+            const DLNA_CONTENT_FEATURES: &str = "contentFeatures.dlna.org";
 
-            output_headers.insert(
-                "contentFeatures.dlna.org",
-                HeaderValue::from_static("DLNA.ORG_OP=01"),
-            );
+            if headers
+                .get(DLNA_TRANSFER_MODE)
+                .map(|v| matches!(v.as_bytes(), b"Streaming" | b"streaming"))
+                .unwrap_or(false)
+            {
+                output_headers.insert(DLNA_TRANSFER_MODE, HeaderValue::from_static("Streaming"));
+            }
+
+            if headers
+                .get(DLNA_GET_CONTENT_FEATURES)
+                .map(|v| v.as_bytes() == b"1")
+                .unwrap_or(false)
+            {
+                output_headers.insert(
+                    DLNA_CONTENT_FEATURES,
+                    HeaderValue::from_static("DLNA.ORG_OP=01"),
+                );
+            }
 
             if let Ok(mime) = state.torrent_file_mime_type(idx, file_id) {
                 output_headers.insert(

--- a/crates/librqbit/src/upnp_server_adapter.rs
+++ b/crates/librqbit/src/upnp_server_adapter.rs
@@ -74,7 +74,7 @@ impl TorrentFileTreeNode {
                     .unwrap_or_else(|| self.title.clone());
                 ItemOrContainer::Item(Item {
                     id: encoded_id,
-                    parent_id: encoded_parent_id,
+                    parent_id: encoded_parent_id.map(|id| id as isize),
                     title: self.title.clone(),
                     mime_type: mime_guess::from_path(filename).first(),
                     url: format!(
@@ -600,7 +600,7 @@ mod tests {
             adapter.browse_direct_children(encode_id(1, 1), "127.0.0.1"),
             vec![ItemOrContainer::Item(Item {
                 id: encode_id(2, 1),
-                parent_id: Some(encode_id(1, 1)),
+                parent_id: Some(encode_id(1, 1) as isize),
                 title: "f2".into(),
                 mime_type: None,
                 url: "http://127.0.0.1:9005/torrents/1/stream/0/d1/f2".into()

--- a/crates/librqbit/src/upnp_server_adapter.rs
+++ b/crates/librqbit/src/upnp_server_adapter.rs
@@ -62,7 +62,8 @@ impl TorrentFileTreeNode {
         let encoded_parent_id = self.parent_id.map(|p| encode_id(p, torrent.id()));
         match self.real_torrent_file_id {
             Some(fid) => {
-                let filename = &torrent.shared().file_infos[fid].relative_filename;
+                let fi = &torrent.shared().file_infos[fid];
+                let filename = &fi.relative_filename;
                 // Torrent path joined with "/"
                 let last_url_bit = torrent
                     .shared()
@@ -91,6 +92,7 @@ impl TorrentFileTreeNode {
                         fid,
                         last_url_bit
                     ),
+                    size: fi.len,
                 })
             }
             None => ItemOrContainer::Container(Container {
@@ -588,7 +590,8 @@ mod tests {
                     parent_id: 0,
                     title: "f1".into(),
                     mime_type: None,
-                    url: "http://127.0.0.1:9005/torrents/0/stream/0/f1".into()
+                    url: "http://127.0.0.1:9005/torrents/0/stream/0/f1".into(),
+                    size: 1,
                 }),
                 ItemOrContainer::Container(Container {
                     id: encode_id(0, 1),
@@ -606,7 +609,8 @@ mod tests {
                 parent_id: 0,
                 title: "f1".into(),
                 mime_type: None,
-                url: "http://127.0.0.1:9005/torrents/0/stream/0/f1".into()
+                url: "http://127.0.0.1:9005/torrents/0/stream/0/f1".into(),
+                size: 1,
             })]
         );
 
@@ -648,6 +652,7 @@ mod tests {
                 title: "f2".into(),
                 mime_type: None,
                 url: "http://127.0.0.1:9005/torrents/1/stream/0/d1/f2".into(),
+                size: 1,
             })]
         );
 
@@ -659,6 +664,7 @@ mod tests {
                 title: "f2".into(),
                 mime_type: None,
                 url: "http://127.0.0.1:9005/torrents/1/stream/0/d1/f2".into(),
+                size: 1,
             })]
         );
     }

--- a/crates/librqbit/src/upnp_server_adapter.rs
+++ b/crates/librqbit/src/upnp_server_adapter.rs
@@ -521,7 +521,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_browse_direct_children() {
+    async fn test_browse() {
         setup_test_logging();
 
         let t1 = create_torrent(Some("t1"), &["f1"]);
@@ -571,6 +571,16 @@ mod tests {
         };
 
         assert_eq!(
+            adapter.browse_metadata(0, "127.0.0.1"),
+            vec![ItemOrContainer::Container(Container {
+                id: 0,
+                parent_id: None,
+                children_count: Some(2),
+                title: "root".into()
+            })]
+        );
+
+        assert_eq!(
             adapter.browse_direct_children(0, "127.0.0.1"),
             vec![
                 ItemOrContainer::Item(Item {
@@ -590,6 +600,27 @@ mod tests {
         );
 
         assert_eq!(
+            adapter.browse_metadata(encode_id(0, 0), "127.0.0.1"),
+            vec![ItemOrContainer::Item(Item {
+                id: encode_id(0, 0),
+                parent_id: 0,
+                title: "f1".into(),
+                mime_type: None,
+                url: "http://127.0.0.1:9005/torrents/0/stream/0/f1".into()
+            })]
+        );
+
+        assert_eq!(
+            adapter.browse_metadata(encode_id(0, 1), "127.0.0.1"),
+            vec![ItemOrContainer::Container(Container {
+                id: encode_id(0, 1),
+                parent_id: Some(0),
+                children_count: Some(1),
+                title: "t2".into()
+            })]
+        );
+
+        assert_eq!(
             adapter.browse_direct_children(encode_id(0, 1), "127.0.0.1"),
             vec![ItemOrContainer::Container(Container {
                 id: encode_id(1, 1),
@@ -600,7 +631,28 @@ mod tests {
         );
 
         assert_eq!(
+            adapter.browse_metadata(encode_id(1, 1), "127.0.0.1"),
+            vec![ItemOrContainer::Container(Container {
+                id: encode_id(1, 1),
+                parent_id: Some(encode_id(0, 1)),
+                children_count: Some(1),
+                title: "d1".into()
+            }),]
+        );
+
+        assert_eq!(
             adapter.browse_direct_children(encode_id(1, 1), "127.0.0.1"),
+            vec![ItemOrContainer::Item(Item {
+                id: encode_id(2, 1),
+                parent_id: encode_id(1, 1),
+                title: "f2".into(),
+                mime_type: None,
+                url: "http://127.0.0.1:9005/torrents/1/stream/0/d1/f2".into(),
+            })]
+        );
+
+        assert_eq!(
+            adapter.browse_metadata(encode_id(2, 1), "127.0.0.1"),
             vec![ItemOrContainer::Item(Item {
                 id: encode_id(2, 1),
                 parent_id: encode_id(1, 1),

--- a/crates/librqbit/src/upnp_server_adapter.rs
+++ b/crates/librqbit/src/upnp_server_adapter.rs
@@ -74,7 +74,7 @@ impl TorrentFileTreeNode {
                     .unwrap_or_else(|| self.title.clone());
                 ItemOrContainer::Item(Item {
                     id: encoded_id,
-                    parent_id: encoded_parent_id.map(|id| id as isize),
+                    parent_id: encoded_parent_id.unwrap_or_default(),
                     title: self.title.clone(),
                     mime_type: mime_guess::from_path(filename).first(),
                     url: format!(
@@ -124,7 +124,7 @@ impl TorrentFileTree {
                 .context("bug")??;
             let root_node = TorrentFileTreeNode {
                 title: filename.to_owned(),
-                parent_id: None,
+                parent_id: Some(0),
                 children: vec![],
                 real_torrent_file_id: Some(0),
             };
@@ -220,7 +220,7 @@ impl UpnpServerSessionAdapter {
                     );
                     Some(ItemOrContainer::Item(Item {
                         id: upnp_id,
-                        parent_id: None,
+                        parent_id: 0,
                         title,
                         mime_type,
                         url,
@@ -238,7 +238,7 @@ impl UpnpServerSessionAdapter {
                     // Create a folder
                     Some(ItemOrContainer::Container(Container {
                         id: upnp_id,
-                        parent_id: None,
+                        parent_id: Some(0),
                         title,
                         children_count: None,
                     }))
@@ -572,14 +572,14 @@ mod tests {
             vec![
                 ItemOrContainer::Item(Item {
                     id: encode_id(0, 0),
-                    parent_id: None,
+                    parent_id: Some(0),
                     title: "f1".into(),
                     mime_type: None,
                     url: "http://127.0.0.1:9005/torrents/0/stream/0/f1".into()
                 }),
                 ItemOrContainer::Container(Container {
                     id: encode_id(0, 1),
-                    parent_id: None,
+                    parent_id: Some(0),
                     children_count: None,
                     title: "t2".into()
                 })

--- a/crates/upnp-serve/examples/upnp-stub-server.rs
+++ b/crates/upnp-serve/examples/upnp-stub-server.rs
@@ -26,6 +26,7 @@ async fn main() -> anyhow::Result<()> {
         url: "http://192.168.0.165:3030/torrents/4/stream/0/file.mkv".to_owned(),
         id: 1,
         parent_id: 0,
+        size: 1,
     })];
 
     const HTTP_PORT: u16 = 9005;

--- a/crates/upnp-serve/examples/upnp-stub-server.rs
+++ b/crates/upnp-serve/examples/upnp-stub-server.rs
@@ -6,11 +6,27 @@ use std::{
 use anyhow::Context;
 use axum::routing::get;
 use librqbit_upnp_serve::{
-    services::content_directory::browse::response::{Item, ItemOrContainer},
+    services::content_directory::{
+        browse::response::{Item, ItemOrContainer},
+        ContentDirectoryBrowseProvider,
+    },
     UpnpServer, UpnpServerOptions,
 };
 use mime_guess::Mime;
 use tracing::{error, info};
+
+struct VecWrap(Vec<ItemOrContainer>);
+
+impl ContentDirectoryBrowseProvider for VecWrap {
+    fn browse_direct_children(&self, _parent_id: usize, _http_host: &str) -> Vec<ItemOrContainer> {
+        self.0.clone()
+    }
+
+    fn browse_metadata(&self, _object_id: usize, _http_hostname: &str) -> Vec<ItemOrContainer> {
+        // TODO. Remove the vec provider from core code.
+        vec![]
+    }
+}
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -20,14 +36,14 @@ async fn main() -> anyhow::Result<()> {
 
     tracing_subscriber::fmt::init();
 
-    let items: Vec<ItemOrContainer> = vec![ItemOrContainer::Item(Item {
+    let items = VecWrap(vec![ItemOrContainer::Item(Item {
         title: "Example".to_owned(),
         mime_type: Some(Mime::from_str("video/x-matroska")?),
         url: "http://192.168.0.165:3030/torrents/4/stream/0/file.mkv".to_owned(),
         id: 1,
         parent_id: 0,
         size: 1,
-    })];
+    })]);
 
     const HTTP_PORT: u16 = 9005;
     const HTTP_PREFIX: &str = "/upnp";

--- a/crates/upnp-serve/examples/upnp-stub-server.rs
+++ b/crates/upnp-serve/examples/upnp-stub-server.rs
@@ -25,7 +25,7 @@ async fn main() -> anyhow::Result<()> {
         mime_type: Some(Mime::from_str("video/x-matroska")?),
         url: "http://192.168.0.165:3030/torrents/4/stream/0/file.mkv".to_owned(),
         id: 1,
-        parent_id: Some(0),
+        parent_id: 0,
     })];
 
     const HTTP_PORT: u16 = 9005;

--- a/crates/upnp-serve/src/resources/templates/content_directory/control/browse/item.tmpl.xml
+++ b/crates/upnp-serve/src/resources/templates/content_directory/control/browse/item.tmpl.xml
@@ -1,5 +1,5 @@
 <item id="{id}" parentID="{parent_id}" restricted="true">
     <dc:title>{title}</dc:title>
     <upnp:class>{upnp_class}</upnp:class>
-    <res protocolInfo="http-get:*:{mime_type}:DLNA.ORG_OP=01">{url}</res>
+    <res protocolInfo="http-get:*:{mime_type}:DLNA.ORG_OP=01" size="{size}">{url}</res>
 </item>

--- a/crates/upnp-serve/src/resources/templates/content_directory/control/browse/response.tmpl.xml
+++ b/crates/upnp-serve/src/resources/templates/content_directory/control/browse/response.tmpl.xml
@@ -2,11 +2,7 @@
 <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
     <s:Body>
         <u:BrowseResponse xmlns:u="urn:schemas-upnp-org:service:ContentDirectory:1">
-            <Result><![CDATA[<DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"
-            xmlns:dc="http://purl.org/dc/elements/1.1/"
-            xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/">
-  {items}
-</DIDL-Lite>]]></Result>
+            <Result>{items_encoded}</Result>
             <NumberReturned>{number_returned}</NumberReturned>
             <TotalMatches>{total_matches}</TotalMatches>
             <UpdateID>{update_id}</UpdateID>

--- a/crates/upnp-serve/src/services/content_directory.rs
+++ b/crates/upnp-serve/src/services/content_directory.rs
@@ -293,7 +293,15 @@ pub(crate) async fn http_handler(
                     ),
                 )
                     .into_response(),
-                BrowseFlag::BrowseMetadata => StatusCode::NOT_IMPLEMENTED.into_response(),
+                BrowseFlag::BrowseMetadata => (
+                    [(CONTENT_TYPE, CONTENT_TYPE_XML_UTF8)],
+                    browse::response::render(
+                        state
+                            .provider
+                            .browse_metadata(request.object_id, http_hostname),
+                    ),
+                )
+                    .into_response(),
             }
         }
         SOAP_ACTION_GET_SYSTEM_UPDATE_ID => {
@@ -314,11 +322,17 @@ pub(crate) async fn http_handler(
 pub trait ContentDirectoryBrowseProvider: Send + Sync {
     fn browse_direct_children(&self, parent_id: usize, http_hostname: &str)
         -> Vec<ItemOrContainer>;
+    fn browse_metadata(&self, object_id: usize, http_hostname: &str) -> Vec<ItemOrContainer>;
 }
 
 impl ContentDirectoryBrowseProvider for Vec<ItemOrContainer> {
     fn browse_direct_children(&self, _parent_id: usize, _http_host: &str) -> Vec<ItemOrContainer> {
         self.clone()
+    }
+
+    fn browse_metadata(&self, _object_id: usize, _http_hostname: &str) -> Vec<ItemOrContainer> {
+        // TODO. Remove the vec provider from core code.
+        vec![]
     }
 }
 

--- a/crates/upnp-serve/src/services/content_directory.rs
+++ b/crates/upnp-serve/src/services/content_directory.rs
@@ -147,6 +147,9 @@ pub mod browse {
     </DIDL-Lite>"#,
                     items = envelope.items
                 );
+
+                // This COULD have been done with CDATA, but some Samsung TVs don't like that, they want
+                // escaped XML instead.
                 let items_encoded = quick_xml::escape::escape(items_encoded.as_ref());
 
                 format!(
@@ -337,17 +340,6 @@ pub trait ContentDirectoryBrowseProvider: Send + Sync {
     fn browse_direct_children(&self, parent_id: usize, http_hostname: &str)
         -> Vec<ItemOrContainer>;
     fn browse_metadata(&self, object_id: usize, http_hostname: &str) -> Vec<ItemOrContainer>;
-}
-
-impl ContentDirectoryBrowseProvider for Vec<ItemOrContainer> {
-    fn browse_direct_children(&self, _parent_id: usize, _http_host: &str) -> Vec<ItemOrContainer> {
-        self.clone()
-    }
-
-    fn browse_metadata(&self, _object_id: usize, _http_hostname: &str) -> Vec<ItemOrContainer> {
-        // TODO. Remove the vec provider from core code.
-        vec![]
-    }
 }
 
 #[cfg(test)]

--- a/crates/upnp-serve/src/services/content_directory.rs
+++ b/crates/upnp-serve/src/services/content_directory.rs
@@ -76,6 +76,7 @@ pub mod browse {
             pub title: String,
             pub mime_type: Option<mime_guess::Mime>,
             pub url: String,
+            pub size: u64,
         }
 
         #[derive(Debug, Clone, PartialEq, Eq)]
@@ -103,7 +104,8 @@ pub mod browse {
                         mime_type = mime,
                         url = item.url,
                         upnp_class = upnp_class,
-                        title = item.title
+                        title = item.title,
+                        size = item.size
                     ))
                 }
 

--- a/crates/upnp-serve/src/services/content_directory.rs
+++ b/crates/upnp-serve/src/services/content_directory.rs
@@ -135,11 +135,21 @@ pub mod browse {
             }
 
             fn render_response(envelope: &Envelope<'_>) -> String {
+                let items_encoded = format!(
+                    r#"<DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"
+                xmlns:dc="http://purl.org/dc/elements/1.1/"
+                xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/">
+      {items}
+    </DIDL-Lite>"#,
+                    items = envelope.items
+                );
+                let items_encoded = quick_xml::escape::escape(items_encoded.as_ref());
+
                 format!(
                     include_str!(
                         "../resources/templates/content_directory/control/browse/response.tmpl.xml"
                     ),
-                    items = envelope.items,
+                    items_encoded = items_encoded,
                     number_returned = envelope.number_returned,
                     total_matches = envelope.total_matches,
                     update_id = envelope.update_id

--- a/crates/upnp-serve/src/services/content_directory.rs
+++ b/crates/upnp-serve/src/services/content_directory.rs
@@ -70,7 +70,7 @@ pub mod browse {
         #[derive(Debug, Clone, PartialEq, Eq)]
         pub struct Item {
             pub id: usize,
-            pub parent_id: Option<usize>,
+            pub parent_id: Option<isize>,
             pub title: String,
             pub mime_type: Option<mime_guess::Mime>,
             pub url: String,
@@ -97,7 +97,7 @@ pub mod browse {
                             "../resources/templates/content_directory/control/browse/item.tmpl.xml"
                         ),
                         id = item.id,
-                        parent_id = item.parent_id.unwrap_or(0),
+                        parent_id = item.parent_id.unwrap_or(-1),
                         mime_type = mime,
                         url = item.url,
                         upnp_class = upnp_class,

--- a/crates/upnp-serve/src/services/content_directory.rs
+++ b/crates/upnp-serve/src/services/content_directory.rs
@@ -70,7 +70,7 @@ pub mod browse {
         #[derive(Debug, Clone, PartialEq, Eq)]
         pub struct Item {
             pub id: usize,
-            pub parent_id: Option<isize>,
+            pub parent_id: usize,
             pub title: String,
             pub mime_type: Option<mime_guess::Mime>,
             pub url: String,
@@ -97,7 +97,7 @@ pub mod browse {
                             "../resources/templates/content_directory/control/browse/item.tmpl.xml"
                         ),
                         id = item.id,
-                        parent_id = item.parent_id.unwrap_or(-1),
+                        parent_id = item.parent_id,
                         mime_type = mime,
                         url = item.url,
                         upnp_class = upnp_class,
@@ -115,7 +115,7 @@ pub mod browse {
                             "../resources/templates/content_directory/control/browse/container.tmpl.xml"
                         ),
                         id = item.id,
-                        parent_id = item.parent_id.unwrap_or(0),
+                        parent_id = item.parent_id.map(|p| p as isize).unwrap_or(-1),
                         title = item.title,
                         childCountTag = child_count_tag
                     )

--- a/crates/upnp-serve/src/services/content_directory.rs
+++ b/crates/upnp-serve/src/services/content_directory.rs
@@ -62,6 +62,8 @@ pub mod browse {
         #[derive(Debug, Clone, PartialEq, Eq)]
         pub struct Container {
             pub id: usize,
+            // Parent id is None only for the root container.
+            // The only way to see the root container is BrowseMetadata on ObjectID=0
             pub parent_id: Option<usize>,
             pub children_count: Option<usize>,
             pub title: String,


### PR DESCRIPTION
These are various tweaks to make the built-in upnp server to work on Samsung (tested on one example TV).