### PR TITLE
In PEX we should also look at dropped peers

### DIFF
--- a/crates/librqbit/src/torrent_state/live/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/mod.rs
@@ -1687,14 +1687,16 @@ impl PeerHandler {
         B: AsRef<[u8]> + std::fmt::Debug,
     {
         // TODO: this is just first attempt at pex - will need more sophistication on adding peers - BEP 40,  check number of live, seen peers ...
-        msg.added_peers().for_each(|peer| {
-            self.state
-                .add_peer_if_not_seen(peer.addr)
-                .map_err(|error| {
-                    warn!(?peer, ?error, "failed to add peer");
-                    error
-                })
-                .ok();
-        });
+        msg.dropped_peers()
+            .chain(msg.added_peers())
+            .for_each(|peer| {
+                self.state
+                    .add_peer_if_not_seen(peer.addr)
+                    .map_err(|error| {
+                        warn!(?peer, ?error, "failed to add peer");
+                        error
+                    })
+                    .ok();
+            });
     }
 }


### PR DESCRIPTION
As per BEP 11 - dropped peers are peers that have been active, but  not needed by remote peer anymore.  So it's good chance they will have a free slot, so we should try them too - before added peers