### PR TITLE
Change to restarting of dead peers

### DIFF
--- a/crates/librqbit/src/torrent_state/live/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/mod.rs
@@ -113,7 +113,7 @@ use super::{
 
 #[derive(Debug)]
 struct InflightPiece {
-    peer: PeerHandle, 
+    peer: PeerHandle,
     started: Instant,
 }
 
@@ -1001,7 +1001,7 @@ impl PeerHandler {
             }
         };
 
-        let error = match error {
+        let _error = match error {
             Some(e) => e,
             None => {
                 trace!("peer died without errors, not re-queueing");
@@ -1022,6 +1022,7 @@ impl PeerHandler {
 
         if self.incoming {
             // do not retry incoming peers
+            debug!("incoming peer {handle} died, not re-queueing");
             return Ok(());
         }
 
@@ -1031,16 +1032,11 @@ impl PeerHandler {
         drop(pe);
 
         if let Some(dur) = backoff {
-            debug!(
-                "{} peer {} died -  {error} and will retry in {dur:?}",
-                if self.incoming { "incoming" } else { "outgoing" },
-                self.addr
-            );
             self.state.clone().spawn(
                 error_span!(
                     parent: self.state.torrent.span.clone(),
                     "wait_for_peer",
-                    peer = handle.to_string(), 
+                    peer = handle.to_string(),
                     duration = format!("{dur:?}")
                 ),
                 async move {

--- a/crates/librqbit/src/torrent_state/live/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/mod.rs
@@ -113,7 +113,7 @@ use super::{
 
 #[derive(Debug)]
 struct InflightPiece {
-    peer: PeerHandle,
+    peer: PeerHandle, 
     started: Instant,
 }
 
@@ -1013,11 +1013,6 @@ impl PeerHandler {
         if self.state.is_finished_and_no_active_streams() {
             debug!("torrent finished, not re-queueing");
             pe.value_mut().state.set(PeerState::NotNeeded, &pstats);
-            // also cancel all retried dead peers
-            if ! self.state.cancellation_token.is_cancelled() {
-                self.state.cancellation_token.cancel();
-            }
-            
             return Ok(());
         }
 

--- a/crates/librqbit/src/torrent_state/live/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/mod.rs
@@ -1022,7 +1022,10 @@ impl PeerHandler {
 
         if self.incoming {
             // do not retry incoming peers
-            debug!("incoming peer {handle} died, not re-queueing");
+            debug!(
+                peer = handle.to_string(),
+                "incoming peer died, not re-queueing"
+            );
             return Ok(());
         }
 


### PR DESCRIPTION
For a while I was observing how dead peers are retried and found couple of thing, which I think are sub-optimal:
- when incoming peer has error, then `on_peer_died` is called and eventually peer is scheduled as outgoing,   The `SocketAddress` in this case  has outgoing port of peer I think, so retry with it as outgoing does not make sense to me.
- scheduled retries  stay pending even after the download of torrent is finished ( often with long waiting times). They keep popping out long after then.  I think it would be better to cancel them after download finishes.

This not final PR - rather a sketch to  illustrate my findings.  There is probably better way to solve it.