### PR TITLE
fix: log levels not coherent

### DIFF
--- a/crates/dht/src/dht.rs
+++ b/crates/dht/src/dht.rs
@@ -999,7 +999,7 @@ impl DhtWorker {
                                 error!("error: {e:#}");
                             }
                         }
-                    }.instrument(error_span!("ping", addr=addr.to_string())))
+                    }.instrument(trace_span!("ping", addr=addr.to_string())))
                 },
                 _ = futs.next(), if !futs.is_empty() => {},
             }


### PR DESCRIPTION
In `dht` crate some log levels do not reflect what they are indeed saying. This is quite annoying because some logs are in error when being really debug logs, and this floods logging and thus prevent from filtering nicely with crates like `env_logger`.

This PR improves that