### PR TITLE
Correct peer outgoing address for incomming peers

### DIFF
--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -895,7 +895,7 @@ impl Session {
                             if let Some(custom_trackers) = opts.trackers.clone() {
                                  trackers.extend(custom_trackers);
                             }
-                            trackers  
+                            trackers
                         },
                         announce_port,
                         opts.force_tracker_interval,
@@ -989,7 +989,7 @@ impl Session {
                     if let Some(custom_trackers) = opts.trackers.clone() {
                         trackers.extend(custom_trackers);
                     }
-                            
+
                     let peer_rx = if paused {
                         None
                     } else {

--- a/crates/librqbit/src/torrent_state/live/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/mod.rs
@@ -66,7 +66,6 @@ use librqbit_core::{
     torrent_metainfo::TorrentMetaV1Info,
 };
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
-use peer::OutgoingAddressType;
 use peer_binary_protocol::{
     extended::{
         handshake::ExtendedHandshake, ut_metadata::UtMetadata, ut_pex::UtPex, ExtendedMessage,
@@ -932,7 +931,7 @@ impl<'a> PeerConnectionHandler for &'a PeerHandler {
                 self.state
                     .peers
                     .with_peer_mut(self.addr, "update outgoing addr", |peer| {
-                        peer.outgoing_address = OutgoingAddressType::Known(outgoing_addr)
+                        peer.outgoing_address = Some(outgoing_addr)
                     });
             }
         }

--- a/crates/librqbit/src/torrent_state/live/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/mod.rs
@@ -919,6 +919,17 @@ impl<'a> PeerConnectionHandler for &'a PeerHandler {
         if let Some(peer_pex_msg_id) = hs.ut_pex() {
             trace!("peer supports pex at {peer_pex_msg_id}");
         }
+        if let Some(port) = hs.p {
+            // Lets update outgoing Socket address for incoming connection
+            if self.incoming {
+                if let Ok(port) = <u32 as TryInto<u16>>::try_into(port) {
+                    let outgoing_addr = SocketAddr::new(self.addr.ip(), port);
+                    self.state.peers.with_peer_mut(self.addr, "update outgoing addr", 
+                |peer| peer.outgoing_address=Some(outgoing_addr));
+                }
+                
+            }
+        }
         Ok(())
     }
 

--- a/crates/librqbit/src/torrent_state/live/peer/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/peer/mod.rs
@@ -18,10 +18,18 @@ pub(crate) type PeerRx = UnboundedReceiver<WriterRequest>;
 pub(crate) type PeerTx = UnboundedSender<WriterRequest>;
 
 #[derive(Debug, Default)]
+pub(crate) enum OutgoingAddressType {
+    #[default]
+    Default,
+    None,
+    Known(SocketAddr),
+}
+
+#[derive(Debug, Default)]
 pub(crate) struct Peer {
     pub state: PeerStateNoMut,
     pub stats: stats::atomic::PeerStats,
-    pub outgoing_address: Option<SocketAddr>,
+    pub outgoing_address: OutgoingAddressType,
 }
 
 impl Peer {
@@ -37,7 +45,7 @@ impl Peer {
         Self {
             state,
             stats: Default::default(),
-            outgoing_address: None,
+            outgoing_address: OutgoingAddressType::None,
         }
     }
 }

--- a/crates/librqbit/src/torrent_state/live/peer/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/peer/mod.rs
@@ -77,12 +77,6 @@ impl Peer {
         } else {
             None
         }
-        // pe.state.not_needed_to_queued(&self.peer_stats()) {
-        //     let retry_addr = match pe.value().outgoing_address {
-        //         peer::OutgoingAddressType::Default => *pe.key(),
-        //         peer::OutgoingAddressType::None => unreachable!("bug"), // already filtered
-        //         peer::OutgoingAddressType::Known(socket_addr) => socket_addr,
-        //     };
     }
 }
 

--- a/crates/librqbit/src/torrent_state/live/peer/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/peer/mod.rs
@@ -1,6 +1,7 @@
 pub mod stats;
 
 use std::collections::HashSet;
+use std::net::SocketAddr;
 
 use librqbit_core::hash_id::Id20;
 use librqbit_core::lengths::ChunkInfo;
@@ -20,6 +21,7 @@ pub(crate) type PeerTx = UnboundedSender<WriterRequest>;
 pub(crate) struct Peer {
     pub state: PeerStateNoMut,
     pub stats: stats::atomic::PeerStats,
+    pub outgoing_address: Option<SocketAddr>,
 }
 
 impl Peer {
@@ -35,6 +37,7 @@ impl Peer {
         Self {
             state,
             stats: Default::default(),
+            outgoing_address: None,
         }
     }
 }

--- a/crates/librqbit/src/torrent_state/live/peers/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/peers/mod.rs
@@ -43,7 +43,7 @@ impl PeerStates {
         match self.states.entry(addr) {
             Entry::Occupied(_) => None,
             Entry::Vacant(vac) => {
-                vac.insert(Default::default());
+                vac.insert(Peer::new_with_outgoing_address(addr));
                 atomic_inc(&self.stats.queued);
                 atomic_inc(&self.session_stats.peers.queued);
 

--- a/crates/peer_binary_protocol/src/extended/handshake.rs
+++ b/crates/peer_binary_protocol/src/extended/handshake.rs
@@ -71,14 +71,14 @@ where
     }
 
     pub fn ip_addr(&self) -> Option<IpAddr> {
-        if let Some(b) = self.ipv4 {
+        if let Some(ref b) = self.ipv4 {
             let b = b.as_slice();
             if b.len() == 4 {
                 let ip_bytes: &[u8; 4] = b[0..4].try_into().unwrap(); // Safe to unwrap as we check slice length
                 return Some(IpAddr::from(*ip_bytes));
             }
         }
-        if let Some(b) = self.ipv6 {
+        if let Some(ref b) = self.ipv6 {
             let b = b.as_slice();
             if b.len() == 16 {
                 let ip_bytes: &[u8; 16] = b[0..16].try_into().unwrap(); // Safe to unwrap as we check slice length

--- a/crates/peer_binary_protocol/src/extended/handshake.rs
+++ b/crates/peer_binary_protocol/src/extended/handshake.rs
@@ -69,6 +69,28 @@ where
             ut_pex: self.ut_pex(),
         }
     }
+
+    pub fn ip_addr(&self) -> Option<IpAddr> {
+        if let Some(b) = self.ipv4 {
+            let b = b.as_slice();
+            if b.len() == 4 {
+                let ip_bytes: &[u8; 4] = b[0..4].try_into().unwrap(); // Safe to unwrap as we check slice length
+                return Some(IpAddr::from(*ip_bytes));
+            }
+        }
+        if let Some(b) = self.ipv6 {
+            let b = b.as_slice();
+            if b.len() == 16 {
+                let ip_bytes: &[u8; 16] = b[0..16].try_into().unwrap(); // Safe to unwrap as we check slice length
+                return Some(IpAddr::from(*ip_bytes));
+            }
+        }
+        None
+    }
+
+    pub fn port(&self) -> Option<u16> {
+        self.p.and_then(|p| u16::try_from(p).ok())
+    }
 }
 
 impl<ByteBuf> CloneToOwned for ExtendedHandshake<ByteBuf>


### PR DESCRIPTION
For live torrents peers are kept in DashMap with their SocketAddress as the key. Both outgoing and incoming peers are there.
For incoming peers SocketAddress  key is the address of client,  but it is used when retrying connection (in case of changing "only files" for instance).  In these retries this address is used as peer listening address, which will not work.   But we can have peer listening port and ip address from Extended Handshake,  so this can be used instead, if available.

This PR is trying to implement this - only retry incoming peers if we know their listening address, otherwise keep them as not need (as we do not know where to connect them).

There is still an issue with the peers map,   one peer can be there multiple times -  once with outgoing listening SocketAddress and  more times  with client  incoming SocketAddress -  but to change this will require more significant change to logic -  probably  using Peer ID as key. So this is only partial fix,   but it looks like having same peer in hash table does not cause problems. 