### PR TITLE
[Perf] Increase http_api stream capacity (perf optimisation)

### DIFF
--- a/crates/librqbit/src/http_api.rs
+++ b/crates/librqbit/src/http_api.rs
@@ -416,7 +416,7 @@ impl HttpApi {
                 );
             }
 
-            let s = tokio_util::io::ReaderStream::new(stream);
+            let s = tokio_util::io::ReaderStream::with_capacity(stream, 65536);
             Ok((status, (output_headers, axum::body::Body::from_stream(s))))
         }
 


### PR DESCRIPTION
Noticed the default buffer was too small which made the per-chunk code show up in perf.