### PR TITLE
feat: implement BEP-53 support

### DIFF
--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -886,7 +886,10 @@ impl Session {
                         .as_id20()
                         .context("magnet link didn't contain a BTv1 infohash")?;
                     if let Some(so) = magnet.get_select_only() {
-                        opts.only_files = Some(so);
+                        // Only overwrite opts.only_files if user didn't specify
+                        if opts.only_files.is_none() {
+                            opts.only_files = Some(so);
+                        }
                     }
 
                     let peer_rx = self.make_peer_rx(

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -868,7 +868,7 @@ impl Session {
     ) -> BoxFuture<'a, anyhow::Result<AddTorrentResponse>> {
         async move {
             // Magnet links are different in that we first need to discover the metadata.
-            let opts = opts.unwrap_or_default();
+            let mut opts = opts.unwrap_or_default();
 
             let paused = opts.list_only || opts.paused;
 
@@ -885,6 +885,9 @@ impl Session {
                     let info_hash = magnet
                         .as_id20()
                         .context("magnet link didn't contain a BTv1 infohash")?;
+                    if let Some(so) = magnet.get_select_only() {
+                        opts.only_files = Some(so);
+                    }
 
                     let peer_rx = self.make_peer_rx(
                         info_hash,

--- a/crates/librqbit/src/session_persistence/mod.rs
+++ b/crates/librqbit/src/session_persistence/mod.rs
@@ -41,7 +41,7 @@ impl SerializedTorrent {
             AddTorrent::TorrentFileBytes(self.torrent_bytes)
         } else {
             let magnet =
-                Magnet::from_id20(self.info_hash, self.trackers.into_iter().collect()).to_string();
+                Magnet::from_id20(self.info_hash, self.trackers.into_iter().collect(), self.only_files.clone()).to_string();
             AddTorrent::from_url(magnet)
         };
 

--- a/crates/librqbit/src/session_persistence/mod.rs
+++ b/crates/librqbit/src/session_persistence/mod.rs
@@ -40,8 +40,12 @@ impl SerializedTorrent {
         let add_torrent = if !self.torrent_bytes.is_empty() {
             AddTorrent::TorrentFileBytes(self.torrent_bytes)
         } else {
-            let magnet =
-                Magnet::from_id20(self.info_hash, self.trackers.into_iter().collect(), self.only_files.clone()).to_string();
+            let magnet = Magnet::from_id20(
+                self.info_hash,
+                self.trackers.into_iter().collect(),
+                self.only_files.clone(),
+            )
+            .to_string();
             AddTorrent::from_url(magnet)
         };
 

--- a/crates/librqbit/src/tests/e2e.rs
+++ b/crates/librqbit/src/tests/e2e.rs
@@ -196,7 +196,7 @@ async fn _test_e2e_download(drop_checks: &DropChecks) {
         .and_then(|v| v.parse().ok())
         .unwrap_or(1usize);
 
-    let magnet = Magnet::from_id20(torrent_file.info_hash(), Vec::new()).to_string();
+    let magnet = Magnet::from_id20(torrent_file.info_hash(), Vec::new(), None).to_string();
 
     // 3. Start a client with the initial peers, and download the file.
     for _ in 0..client_iters {

--- a/crates/librqbit_core/src/magnet.rs
+++ b/crates/librqbit_core/src/magnet.rs
@@ -9,6 +9,7 @@ pub struct Magnet {
     id20: Option<Id20>,
     id32: Option<Id32>,
     pub trackers: Vec<String>,
+    select_only: Option<Vec<usize>>
 }
 
 impl Magnet {
@@ -19,12 +20,16 @@ impl Magnet {
     pub fn as_id32(&self) -> Option<Id32> {
         self.id32
     }
+    pub fn get_select_only(&self) -> Option<Vec<usize>> {
+        self.select_only.clone()
+    }
 
-    pub fn from_id20(id20: Id20, trackers: Vec<String>) -> Self {
+    pub fn from_id20(id20: Id20, trackers: Vec<String>, select_only: Option<Vec<usize>> ) -> Self {
         Self {
             id20: Some(id20),
             id32: None,
             trackers,
+            select_only,
         }
     }
 
@@ -38,6 +43,7 @@ impl Magnet {
         let mut id20: Option<Id20> = None;
         let mut id32: Option<Id32> = None;
         let mut trackers = Vec::<String>::new();
+        let mut files = Vec::<usize>::new();
         for (key, value) in url.query_pairs() {
             match key.as_ref() {
                 "xt" => {
@@ -54,6 +60,26 @@ impl Magnet {
                     }
                 }
                 "tr" => trackers.push(value.into()),
+                "so" => {
+                    for file_desc in value.split(',') {
+                        if file_desc.is_empty() {
+                            continue;
+                        }
+                        // Handling ranges of file indices
+                        if let Some((start, end)) = file_desc.split_once('-') {
+                            let start_idx: usize = start.parse()?;
+                            let end_idx: usize = end.parse()?;
+                            if start_idx >= end_idx {
+                                anyhow::bail!("range start must be less than range end");
+                            }
+                            files.extend(start_idx..=end_idx);
+                        } else {
+                            // Handling single file index
+                            let idx: usize = file_desc.parse()?;
+                            files.push(idx);
+                        }
+                    }
+                }
                 _ => {}
             }
         }
@@ -62,6 +88,10 @@ impl Magnet {
                 id20,
                 id32,
                 trackers,
+                select_only: match files.is_empty() {
+                    true => None,
+                    false => Some(files),
+                },
             }),
             false => {
                 anyhow::bail!("did not find infohash")
@@ -96,6 +126,18 @@ impl std::fmt::Display for Magnet {
         for tracker in self.trackers.iter() {
             write_ampersand(f)?;
             write!(f, "tr={tracker}")?;
+        }
+        if let Some(select_only) = &self.select_only {
+            if !select_only.is_empty() {
+                write_ampersand(f)?;
+                write!(f, "so=")?;
+                for (index, file) in select_only.iter().enumerate() {
+                    if index > 0 {
+                        write!(f, ",")?; // Add a comma before all but the first index
+                    }
+                    write!(f, "{}", file)?;
+                }
+            }
         }
         Ok(())
     }
@@ -133,13 +175,19 @@ mod tests {
     fn test_magnet_to_string() {
         let id20 = Id20::from_str("a621779b5e3d486e127c3efbca9b6f8d135f52e5").unwrap();
         assert_eq!(
-            &Magnet::from_id20(id20, Default::default()).to_string(),
+            &Magnet::from_id20(id20, Default::default(), None).to_string(),
             "magnet:?xt=urn:btih:a621779b5e3d486e127c3efbca9b6f8d135f52e5"
         );
 
         assert_eq!(
-            &Magnet::from_id20(id20, vec!["foo".to_string(), "bar".to_string()]).to_string(),
+            &Magnet::from_id20(id20, vec!["foo".to_string(), "bar".to_string()], None).to_string(),
             "magnet:?xt=urn:btih:a621779b5e3d486e127c3efbca9b6f8d135f52e5&tr=foo&tr=bar"
         );
+
+        assert_eq!(
+            &Magnet::from_id20(id20, Default::default(), Some(vec![1,2,3])).to_string(),
+            "magnet:?xt=urn:btih:a621779b5e3d486e127c3efbca9b6f8d135f52e5&so=1,2,3"
+        );
+
     }
 }

--- a/crates/librqbit_core/src/magnet.rs
+++ b/crates/librqbit_core/src/magnet.rs
@@ -9,7 +9,7 @@ pub struct Magnet {
     id20: Option<Id20>,
     id32: Option<Id32>,
     pub trackers: Vec<String>,
-    select_only: Option<Vec<usize>>
+    select_only: Option<Vec<usize>>,
 }
 
 impl Magnet {
@@ -24,7 +24,7 @@ impl Magnet {
         self.select_only.clone()
     }
 
-    pub fn from_id20(id20: Id20, trackers: Vec<String>, select_only: Option<Vec<usize>> ) -> Self {
+    pub fn from_id20(id20: Id20, trackers: Vec<String>, select_only: Option<Vec<usize>>) -> Self {
         Self {
             id20: Some(id20),
             id32: None,
@@ -187,9 +187,8 @@ mod tests {
         );
 
         assert_eq!(
-            &Magnet::from_id20(id20, Default::default(), Some(vec![1,2,3])).to_string(),
+            &Magnet::from_id20(id20, Default::default(), Some(vec![1, 2, 3])).to_string(),
             "magnet:?xt=urn:btih:a621779b5e3d486e127c3efbca9b6f8d135f52e5&so=1,2,3"
         );
-
     }
 }

--- a/crates/librqbit_core/src/magnet.rs
+++ b/crates/librqbit_core/src/magnet.rs
@@ -90,9 +90,10 @@ impl Magnet {
                 id20,
                 id32,
                 trackers,
-                select_only: match files.is_empty() {
-                    true => None,
-                    false => Some(files),
+                select_only: if files.is_empty() {
+                    None
+                } else {
+                    Some(files)
                 },
             }),
             false => {


### PR DESCRIPTION
Implement support for [BEP-53](https://www.bittorrent.org/beps/bep_0053.html) Select Only magnet extension

This does **not** include full support in the GUI / web interface. When initially adding a torrent with SO, the gui will show ALL as selected, even though the actual download will only download the sections needed for that file. Once a torrent has been added, the file list then becomes accurate.

See below patch, for how I tried to have the UI be reactive to `so=` however, this patch didn't work. I'd love to get feedback on a patch that works, but even without I think this PR is valuable and net positive

```
diff --git a/crates/librqbit/webui/src/components/modal/FileSelectionModal.tsx b/crates/librqbit/webui/src/components/modal/FileSelectionModal.tsx
index 0a41f33..d767c60 100644
--- a/crates/librqbit/webui/src/components/modal/FileSelectionModal.tsx
+++ b/crates/librqbit/webui/src/components/modal/FileSelectionModal.tsx
@@ -1,5 +1,5 @@
 import { useContext, useEffect, useState } from "react";
-import { AddTorrentResponse, AddTorrentOptions } from "../../api-types";
+import {AddTorrentResponse, AddTorrentOptions, TorrentDetails} from "../../api-types";
 import { APIContext } from "../../context";
 import { ErrorComponent } from "../ErrorComponent";
 import { ErrorWithLabel } from "../../rqbit-web";
@@ -34,6 +34,8 @@ export const FileSelectionModal = (props: {
   const [uploadError, setUploadError] = useState<ErrorWithLabel | null>(null);
   const [unpopularTorrent, setUnpopularTorrent] = useState(false);
   const [outputFolder, setOutputFolder] = useState<string>("");
+  const [detailsResponse, updateDetailsResponse] =
+      useState<TorrentDetails | null>(null);
   const refreshTorrents = useTorrentStore((state) => state.refreshTorrents);
   const API = useContext(APIContext);
 
@@ -76,6 +78,18 @@ export const FileSelectionModal = (props: {
         () => {
           onHide();
           refreshTorrents();
+          useEffect(() => {
+            console.log('trying to set selected files');
+            setSelectedFiles(
+                new Set<number>(
+                    detailsResponse?.files
+                        .map((f, id) => ({ f, id }))
+                        .filter(({ f }) => f.included)
+                        .map(({ id }) => id) ?? []
+                )
+            );
+          }, [detailsResponse]);
+
         },
         (e) => {
           setUploadError({ text: "Error starting torrent", details: e });
```