### PR TITLE
refactor: use byteorder crate to enhance portability (to BE systems), and enhance code readability, avoiding manual byte manipulations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2596,6 +2596,7 @@ version = "5.1.0"
 dependencies = [
  "anyhow",
  "backoff",
+ "byteorder",
  "bytes",
  "chrono",
  "dashmap 6.1.0",

--- a/crates/dht/Cargo.toml
+++ b/crates/dht/Cargo.toml
@@ -36,6 +36,7 @@ librqbit-core = { path = "../librqbit_core", default-features = false, version =
 chrono = { version = "0.4.31", features = ["serde"] }
 tokio-util = "0.7.10"
 bytes = "1.7.1"
+byteorder = "1.5.0"
 
 [dev-dependencies]
 tracing-subscriber = "0.3"


### PR DESCRIPTION
Note: this also fixes what I think is a small bug here: https://github.com/ikatson/rqbit/pull/250/files#diff-b4f79704f8a70bb6832cd8eb994612ba62b1e199efcebd39228d0761a257920dR285

where `6` is always printed instead of the invalid size like other instances do