### PR TITLE
Disable upload: do not expose in default builds, move under a feature flag.

### DIFF
--- a/crates/librqbit/Cargo.toml
+++ b/crates/librqbit/Cargo.toml
@@ -37,6 +37,7 @@ tracing-subscriber-utils = ["tracing-subscriber"]
 postgres = ["sqlx"]
 async-bt = ["async-backtrace"]
 watch = ["notify"]
+disable-upload = []
 
 [dependencies]
 sqlx = { version = "0.8.2", features = [

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -124,7 +124,8 @@ pub struct Session {
 
     pub(crate) stats: SessionStats,
 
-    disable_upload: bool,
+    #[cfg(feature = "disable-upload")]
+    _disable_upload: bool,
 
     // This is stored for all tasks to stop when session is dropped.
     _cancellation_token_drop_guard: DropGuard,
@@ -416,6 +417,7 @@ pub struct SessionOptions {
     // the root span to use. If not set will be None.
     pub root_span: Option<Span>,
 
+    #[cfg(feature = "disable-upload")]
     pub disable_upload: bool,
 }
 
@@ -492,6 +494,7 @@ impl Session {
             let peer_id = opts.peer_id.unwrap_or_else(generate_peer_id);
             let token = opts.cancellation_token.take().unwrap_or_default();
 
+            #[cfg(feature = "disable-upload")]
             if opts.disable_upload {
                 warn!("uploading disabled");
             }
@@ -629,7 +632,8 @@ impl Session {
                 concurrent_initialize_semaphore: Arc::new(tokio::sync::Semaphore::new(
                     opts.concurrent_init_limit.unwrap_or(3),
                 )),
-                disable_upload: opts.disable_upload,
+                #[cfg(feature = "disable-upload")]
+                _disable_upload: opts.disable_upload,
             });
 
             if let Some(mut disk_write_rx) = disk_write_rx {
@@ -1170,7 +1174,8 @@ impl Session {
                     allow_overwrite: opts.overwrite,
                     output_folder,
                     disk_write_queue: self.disk_write_tx.clone(),
-                    disable_upload: self.disable_upload,
+                    #[cfg(feature = "disable-upload")]
+                    _disable_upload: self._disable_upload,
                 },
                 connector: self.connector.clone(),
                 session: Arc::downgrade(self),

--- a/crates/librqbit/src/torrent_state/live/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/mod.rs
@@ -525,7 +525,7 @@ impl TorrentStateLive {
         let state = self;
         loop {
             let addr = peer_queue_rx.recv().await.context("torrent closed")?;
-            if state.torrent.options.disable_upload && state.is_finished_and_no_active_streams() {
+            if state.torrent.options.disable_upload() && state.is_finished_and_no_active_streams() {
                 debug!("ignoring peer {} as we are finished", addr);
                 state.peers.mark_peer_not_needed(addr);
                 continue;
@@ -939,7 +939,7 @@ impl<'a> PeerConnectionHandler for &'a PeerHandler {
     }
 
     fn should_send_bitfield(&self) -> bool {
-        if self.state.torrent().options.disable_upload {
+        if self.state.torrent().options.disable_upload() {
             return false;
         }
 
@@ -947,7 +947,7 @@ impl<'a> PeerConnectionHandler for &'a PeerHandler {
     }
 
     fn should_transmit_have(&self, id: ValidPieceIndex) -> bool {
-        if self.state.torrent.options.disable_upload {
+        if self.state.torrent.options.disable_upload() {
             return false;
         }
         let have = self
@@ -1187,7 +1187,7 @@ impl PeerHandler {
     }
 
     fn on_download_request(&self, request: Request) -> anyhow::Result<()> {
-        if self.state.torrent().options.disable_upload {
+        if self.state.torrent().options.disable_upload() {
             anyhow::bail!("upload disabled, but peer requested a piece")
         }
 

--- a/crates/librqbit/src/torrent_state/mod.rs
+++ b/crates/librqbit/src/torrent_state/mod.rs
@@ -103,7 +103,20 @@ pub(crate) struct ManagedTorrentOptions {
     pub allow_overwrite: bool,
     pub output_folder: PathBuf,
     pub disk_write_queue: Option<DiskWorkQueueSender>,
-    pub disable_upload: bool,
+    #[cfg(feature = "disable-upload")]
+    pub _disable_upload: bool,
+}
+
+impl ManagedTorrentOptions {
+    #[cfg(feature = "disable-upload")]
+    pub fn disable_upload(&self) -> bool {
+        self._disable_upload
+    }
+
+    #[cfg(not(feature = "disable-upload"))]
+    pub const fn disable_upload(&self) -> bool {
+        false
+    }
 }
 
 /// Common information about torrent shared among all possible states.

--- a/crates/rqbit/Cargo.toml
+++ b/crates/rqbit/Cargo.toml
@@ -21,6 +21,7 @@ default-tls = ["librqbit/default-tls"]
 rust-tls = ["librqbit/rust-tls"]
 debug_slow_disk = ["librqbit/storage_middleware"]
 postgres = ["librqbit/postgres"]
+disable-upload = ["librqbit/disable-upload"]
 
 [dependencies]
 librqbit = { version = "7.1.0-beta.0", path = "../librqbit", default-features = false, features = [

--- a/crates/rqbit/src/main.rs
+++ b/crates/rqbit/src/main.rs
@@ -215,6 +215,7 @@ struct Opts {
     ///
     /// Might be useful e.g. if rqbit upload consumes all your upload bandwidth and interferes
     /// with your other Internet usage.
+    #[cfg(feature = "disable-upload")]
     #[arg(long, env = "RQBIT_DISABLE_UPLOAD")]
     disable_upload: bool,
 }
@@ -474,6 +475,7 @@ async fn async_main(opts: Opts, cancel: CancellationToken) -> anyhow::Result<()>
         root_span: None,
         fastresume: false,
         cancellation_token: Some(cancel.clone()),
+        #[cfg(feature = "disable-upload")]
         disable_upload: opts.disable_upload,
     };
 

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -38,3 +38,4 @@ tauri-plugin-shell = "2"
 # this feature is used for production builds or when `devPath` points to the filesystem
 # DO NOT REMOVE!!
 custom-protocol = ["tauri/custom-protocol"]
+disable-upload = ["librqbit/disable-upload"]

--- a/desktop/src-tauri/src/config.rs
+++ b/desktop/src-tauri/src/config.rs
@@ -144,6 +144,7 @@ pub struct RqbitDesktopConfigUpnp {
 pub struct RqbitDesktopConfig {
     pub default_download_location: PathBuf,
 
+    #[cfg(feature = "disable-upload")]
     #[serde(default)]
     pub disable_upload: bool,
 
@@ -171,6 +172,7 @@ impl Default for RqbitDesktopConfig {
             persistence: Default::default(),
             peer_opts: Default::default(),
             http_api: Default::default(),
+            #[cfg(feature = "disable-upload")]
             disable_upload: false,
         }
     }

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -105,6 +105,7 @@ async fn api_from_config(
             },
             enable_upnp_port_forwarding: !config.upnp.disable_tcp_port_forward,
             fastresume: config.persistence.fastresume,
+            #[cfg(feature = "disable-upload")]
             disable_upload: config.disable_upload,
             ..Default::default()
         },

--- a/desktop/src/configuration.tsx
+++ b/desktop/src/configuration.tsx
@@ -41,7 +41,7 @@ interface RqbitDesktopConfigUpnp {
 
 export interface RqbitDesktopConfig {
   default_download_location: PathLike;
-  disable_upload: boolean;
+  disable_upload?: boolean;
   dht: RqbitDesktopConfigDht;
   tcp_listen: RqbitDesktopConfigTcpListen;
   upnp: RqbitDesktopConfigUpnp;

--- a/desktop/src/configure.tsx
+++ b/desktop/src/configure.tsx
@@ -211,15 +211,18 @@ export const ConfigModal: React.FC<{
             help="Where to download torrents by default. You can override this per torrent."
           />
 
-          <FormCheck
-            label="Disable upload"
-            name="disable_upload"
-            checked={config.disable_upload}
-            onChange={handleToggleChange}
-            help="Disable uploading entirely. If this is set, rqbit won't share piece availability and will disconnect on download request.
+          {defaultConfig.disable_upload !== undefined &&
+            config.disable_upload !== undefined && (
+              <FormCheck
+                label="Disable upload"
+                name="disable_upload"
+                checked={config.disable_upload}
+                onChange={handleToggleChange}
+                help="Disable uploading entirely. If this is set, rqbit won't share piece availability and will disconnect on download request.
 
 Might be useful e.g. if rqbit upload consumes all your upload bandwidth and interferes with your other Internet usage."
-          />
+              />
+            )}
         </Tab>
 
         <Tab name="DHT" currentTab={tab}>


### PR DESCRIPTION
Following an extensive discussion in #220, moved upload disabling under a feature flag, so that it's not exposed in CI builds, but still possible to do it if you are are ready to compile from source with non-default options.