### PR TITLE
Fix: transactional pause

### DIFF
--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -1365,16 +1365,17 @@ impl Session {
     }
 
     pub async fn pause(&self, handle: &ManagedTorrentHandle) -> anyhow::Result<()> {
-        let mut g = handle.locked.write();
-        let prev = g.paused;
-        g.paused = true;
-        drop(g);
+        let prev_state;
+        {
+            let mut g = handle.locked.write();
+            prev_state = g.paused;
+            g.paused = true;
+        }
 
-        handle.locked.write().paused = true;
         match handle.pause() {
             Ok(()) => {}
             Err(err) => {
-                handle.locked.write().paused = prev;
+                handle.locked.write().paused = prev_state;
                 return Err(err);
             }
         }

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -1365,20 +1365,7 @@ impl Session {
     }
 
     pub async fn pause(&self, handle: &ManagedTorrentHandle) -> anyhow::Result<()> {
-        let prev_state;
-        {
-            let mut g = handle.locked.write();
-            prev_state = g.paused;
-            g.paused = true;
-        }
-
-        match handle.pause() {
-            Ok(()) => {}
-            Err(err) => {
-                handle.locked.write().paused = prev_state;
-                return Err(err);
-            }
-        }
+        handle.pause().map(|_| handle.locked.write().paused = true)?;
         self.try_update_persistence_metadata(handle).await;
         Ok(())
     }


### PR DESCRIPTION
Hi! Thanks for the great library!
I've recently faced a bug when pausing while initializing torrent returned an error, but it changed the internal flag. This fix should prevent such behavior.