### PR TITLE
Add CLI parameter to allow send downloads to remote server

### DIFF
--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -1365,7 +1365,9 @@ impl Session {
     }
 
     pub async fn pause(&self, handle: &ManagedTorrentHandle) -> anyhow::Result<()> {
-        handle.pause().map(|_| handle.locked.write().paused = true)?;
+        handle
+            .pause()
+            .map(|_| handle.locked.write().paused = true)?;
         self.try_update_persistence_metadata(handle).await;
         Ok(())
     }

--- a/crates/rqbit/src/main.rs
+++ b/crates/rqbit/src/main.rs
@@ -301,6 +301,10 @@ struct DownloadOpts {
 
     #[arg(long = "initial-peers")]
     initial_peers: Option<InitialPeers>,
+
+
+    #[arg(long = "server-url")]
+    server_url: Option<String>,
 }
 
 #[derive(Clone)]
@@ -634,7 +638,7 @@ async fn async_main(opts: Opts, cancel: CancellationToken) -> anyhow::Result<()>
             if download_opts.torrent_path.is_empty() {
                 anyhow::bail!("you must provide at least one URL to download")
             }
-            let http_api_url = format!("http://{}", opts.http_api_listen_addr);
+            let http_api_url = download_opts.server_url.clone().unwrap_or_else(||  format!("http://{}", opts.http_api_listen_addr));
             let client = http_api_client::HttpApiClient::new(&http_api_url)?;
 
             let torrent_opts = |with_output_folder: bool| AddTorrentOptions {
@@ -662,6 +666,10 @@ async fn async_main(opts: Opts, cancel: CancellationToken) -> anyhow::Result<()>
                     false
                 }
             };
+            if !connect_to_existing && download_opts.server_url.is_some() {
+                anyhow::bail!("cannot connect to server at {}", client.base_url());
+                
+            }
             if connect_to_existing {
                 for torrent_url in &download_opts.torrent_path {
                     match client

--- a/crates/rqbit/src/main.rs
+++ b/crates/rqbit/src/main.rs
@@ -302,7 +302,6 @@ struct DownloadOpts {
     #[arg(long = "initial-peers")]
     initial_peers: Option<InitialPeers>,
 
-
     #[arg(long = "server-url")]
     server_url: Option<String>,
 }
@@ -638,7 +637,10 @@ async fn async_main(opts: Opts, cancel: CancellationToken) -> anyhow::Result<()>
             if download_opts.torrent_path.is_empty() {
                 anyhow::bail!("you must provide at least one URL to download")
             }
-            let http_api_url = download_opts.server_url.clone().unwrap_or_else(||  format!("http://{}", opts.http_api_listen_addr));
+            let http_api_url = download_opts
+                .server_url
+                .clone()
+                .unwrap_or_else(|| format!("http://{}", opts.http_api_listen_addr));
             let client = http_api_client::HttpApiClient::new(&http_api_url)?;
 
             let torrent_opts = |with_output_folder: bool| AddTorrentOptions {
@@ -668,7 +670,6 @@ async fn async_main(opts: Opts, cancel: CancellationToken) -> anyhow::Result<()>
             };
             if !connect_to_existing && download_opts.server_url.is_some() {
                 anyhow::bail!("cannot connect to server at {}", client.base_url());
-                
             }
             if connect_to_existing {
                 for torrent_url in &download_opts.torrent_path {


### PR DESCRIPTION
Currently `rqbit download` tries to connect to local server - via it's listening address,  new optional parameter `server_url` can direct it to remote server.

Also one unrelated file was formatted  via `cargo fmt` so it slipped here too.  Maybe to add `cargo fmt --check` to github action to assure merged code is always well formatted?