### PR TITLE
Endpoint to show all torrents and all stats

### DIFF
--- a/crates/librqbit/src/http_api.rs
+++ b/crates/librqbit/src/http_api.rs
@@ -22,7 +22,7 @@ use tracing::{debug, error_span, trace, Span};
 
 use axum::Router;
 
-use crate::api::{Api, TorrentIdOrHash};
+use crate::api::{Api, ApiTorrentListOpts, TorrentIdOrHash};
 use crate::peer_connection::PeerConnectionOptions;
 use crate::session::{AddTorrent, AddTorrentOptions, SUPPORTED_SCHEMES};
 use crate::torrent_state::peer::stats::snapshot::PeerStatsFilter;
@@ -103,8 +103,11 @@ impl HttpApi {
             axum::Json(state.api_session_stats())
         }
 
-        async fn torrents_list(State(state): State<ApiState>) -> impl IntoResponse {
-            axum::Json(state.api_torrent_list())
+        async fn torrents_list(
+            State(state): State<ApiState>,
+            Query(opts): Query<ApiTorrentListOpts>,
+        ) -> impl IntoResponse {
+            axum::Json(state.api_torrent_list_ext(opts))
         }
 
         async fn torrents_post(

--- a/crates/librqbit/src/torrent_state/live/stats/snapshot.rs
+++ b/crates/librqbit/src/torrent_state/live/stats/snapshot.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 
 use crate::torrent_state::live::peers::stats::snapshot::AggregatePeerStats;
 
-#[derive(Debug, Serialize, Default)]
+#[derive(Debug, Serialize, Deserialize, Default)]
 pub struct StatsSnapshot {
     pub downloaded_and_checked_bytes: u64,
 

--- a/crates/librqbit/src/torrent_state/live/stats/snapshot.rs
+++ b/crates/librqbit/src/torrent_state/live/stats/snapshot.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 
 use crate::torrent_state::live::peers::stats::snapshot::AggregatePeerStats;
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Serialize, Default)]
 pub struct StatsSnapshot {
     pub downloaded_and_checked_bytes: u64,
 

--- a/crates/rqbit/src/main.rs
+++ b/crates/rqbit/src/main.rs
@@ -684,7 +684,7 @@ async fn async_main(opts: Opts, cancel: CancellationToken) -> anyhow::Result<()>
                             if let Some(id) = id {
                                 info!("{} added to the server with index {}. Query {}/torrents/{}/(stats/haves) for details", details.info_hash, id, http_api_url, id)
                             }
-                            for file in details.files {
+                            for file in details.files.into_iter().flat_map(|i| i.into_iter()) {
                                 info!(
                                     "file {:?}, size {}{}",
                                     file.name,


### PR DESCRIPTION
This adds an option ?with_stats=true to /torrents API.
Also adds more details to /torrents API.

It's not equivalent to /torrents/details except it doesn't list files (as there may be too many of them).

Fixes https://github.com/ikatson/rqbit/issues/266

Test with: http://localhost:3030/torrents?with_stats=true