### PR TITLE
CI: Use binstall, Always run tests/linux

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -16,6 +16,7 @@ jobs:
         platform: [linux/arm/v7, linux/amd64, linux/arm64]
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         id: builder1

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -95,7 +95,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ikatson/rqbit
+            ${{ vars.DOCKERHUB_USERNAME }}/rqbit, enable=${{ vars.DOCKERHUB_USERNAME != '' }}
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
@@ -120,6 +120,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
+        if: "${{ vars.DOCKERHUB_USERNAME != '' }}"
+        id: docker_login
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
@@ -128,7 +130,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          push: true
+          push: ${{ steps.docker_login.outcome == 'success' }}
           tags: ${{ steps.meta.outputs.tags }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           context: target/cross/

--- a/.github/workflows/release-osx.yml
+++ b/.github/workflows/release-osx.yml
@@ -14,8 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install Binstall
+        uses: cargo-bins/cargo-binstall@main
       - name: install Tauri
-        run: cargo install tauri-cli --profile dev
+        run: cargo binstall tauri-cli --no-confirm
       - name: npm install (desktop)
         working-directory: desktop
         run: npm install

--- a/.github/workflows/release-osx.yml
+++ b/.github/workflows/release-osx.yml
@@ -16,11 +16,14 @@ jobs:
 
       - name: Install Binstall
         uses: cargo-bins/cargo-binstall@main
+
       - name: install Tauri
         run: cargo binstall tauri-cli --no-confirm
+
       - name: npm install (desktop)
         working-directory: desktop
         run: npm install
+
       - name: npm install (librqbit/webui)
         working-directory: crates/librqbit/webui
         run: npm install
@@ -30,6 +33,7 @@ jobs:
         run:
           rustup target add aarch64-apple-darwin && rustup target add x86_64-apple-darwin &&
           cargo tauri build --target universal-apple-darwin --ci
+
       - uses: softprops/action-gh-release@v1
         with:
           generate_release_notes: true
@@ -44,6 +48,7 @@ jobs:
           cargo build --profile release-github --target x86_64-apple-darwin &&
           cargo build --profile release-github --target aarch64-apple-darwin &&
           lipo ./target/x86_64-apple-darwin/release-github/rqbit ./target/aarch64-apple-darwin/release-github/rqbit -create -output ./target/artifacts/rqbit-osx-universal
+
       - uses: softprops/action-gh-release@v1
         with:
           generate_release_notes: true

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -13,13 +13,17 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
+
       - name: Install Binstall
         uses: cargo-bins/cargo-binstall@main
+
       - name: install Tauri
         run: cargo binstall tauri-cli --no-confirm
+
       - name: npm install (desktop)
         working-directory: desktop
         run: npm install
+
       - name: npm install (librqbit/webui)
         working-directory: crates/librqbit/webui
         run: npm install
@@ -27,6 +31,7 @@ jobs:
       - name: cargo tauri build
         working-directory: desktop
         run: cargo tauri build --ci
+
       - uses: softprops/action-gh-release@v1
         with:
           generate_release_notes: true
@@ -35,6 +40,7 @@ jobs:
 
       - name: Build release
         run: cargo build --profile release-github
+
       - uses: softprops/action-gh-release@v1
         with:
           generate_release_notes: true

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -13,8 +13,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install Binstall
+        uses: cargo-bins/cargo-binstall@main
       - name: install Tauri
-        run: cargo install tauri-cli --profile dev
+        run: cargo binstall tauri-cli --no-confirm
       - name: npm install (desktop)
         working-directory: desktop
         run: npm install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,13 +19,19 @@ jobs:
       - name: rustup toolchain install ${{ matrix.rust_version }}
         run: |
           rustup toolchain install ${{ matrix.rust_version }}
+
       - uses: actions/checkout@v4
+
       - run: rustup override set ${{ matrix.rust_version }}
+
       - run: rustup component add rustfmt
+
       - name: cargo check
         run: cargo check
+
       - name: cargo fmt --check
         run: cargo fmt --check
+
   test:
     strategy:
       matrix:
@@ -33,16 +39,21 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+
       - run: rustup toolchain install stable --profile minimal
+
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: v1
+      
       - name: Run tests
         if: ${{ matrix.os == 'windows-latest' }}
         run: cargo test --workspace
+
       - name: Run tests
         if: ${{ matrix.os == 'macos-latest' }}
         run: ulimit -n unlimited && cargo test --workspace
+      
       - name: Run tests
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: cargo test


### PR DESCRIPTION
- Uses binstall to avoid building tauri-cli
- Sets tests and linux release to always run on push/pr
  - Useful to always catch regressions and testing new branches via docker
- Adjust the linux release workflow so it does not fail when a dockerhub username is not provided
  - Useful for other contributors to not get failed actions if they dont use dockerhub
