### PR TITLE
Enable thin LTO release but not release-github

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,4 @@ lto = "thin"
 [profile.release-github]
 inherits = "release"
 debug = false
+lto = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ default-members = [
 [profile.release]
 panic = "abort"
 debug = true
+lto = "thin"
 
 [profile.release-github]
 inherits = "release"


### PR DESCRIPTION
Enable lto thin mode to reduce sizes
release
none -> thin
size: 217.7 mb -> 186.5 mb
time: 50s -> 51s

thin -> fat
size 186.5 mb -> 150.5 mb
time 51s -> 2m 


Looks like release-github doesnt require it though as thin lto actually increases the binary size with debug disabled

release-github
none -> thin
size: 15.3 mb -> 16.4 mb
time: 37s -> 38s 

thin -> fat
size: 16.4 mb -> 12.8
time: 38s -> 1m 15s


tauri build release mode also has a pretty big drop
305.3 mb -> 237.8 mb

tauri build with debug false
18.5 mb -> 20.1 mb
