### PR TITLE
Allows graceful timeout of listing files when adding a torrent via web-ui.

### DIFF
--- a/crates/librqbit/webui/src/api-types.ts
+++ b/crates/librqbit/webui/src/api-types.ts
@@ -114,6 +114,7 @@ export interface ErrorDetails {
   status?: number;
   statusText?: string;
   text: string | React.ReactNode;
+  timedOut: boolean;
 }
 
 export type Duration = number;
@@ -193,7 +194,8 @@ export interface RqbitAPI {
   ) => string | null;
   uploadTorrent: (
     data: string | File,
-    opts?: AddTorrentOptions,
+    opts: AddTorrentOptions,
+    timeout?: number | undefined
   ) => Promise<AddTorrentResponse>;
 
   pause: (index: number) => Promise<void>;

--- a/crates/librqbit/webui/src/components/buttons/UploadButton.tsx
+++ b/crates/librqbit/webui/src/components/buttons/UploadButton.tsx
@@ -31,13 +31,20 @@ export const UploadButton: React.FC<{
     let t = setTimeout(async () => {
       setLoading(true);
       try {
-        const response = await API.uploadTorrent(data, { list_only: true });
+        const response = await API.uploadTorrent(data, { list_only: true }, 2_000);
         setListTorrentResponse(response);
-      } catch (e) {
-        setListTorrentError({
-          text: "Error listing torrent files",
-          details: e as ApiErrorDetails,
-        });
+      } catch (e: unknown) {
+        let error = e as ApiErrorDetails;
+        if (error.timedOut) {
+          setListTorrentResponse(null);
+          // Timeout is not an error for a listOnly request
+          setListTorrentError(null);
+        } else {
+          setListTorrentError({
+            text: "Error listing torrent files",
+            details: error,
+          });
+        }
       } finally {
         setLoading(false);
       }

--- a/crates/librqbit/webui/src/components/modal/FileSelectionModal.tsx
+++ b/crates/librqbit/webui/src/components/modal/FileSelectionModal.tsx
@@ -52,16 +52,18 @@ export const FileSelectionModal = (props: {
   };
 
   const handleUpload = async () => {
-    if (!listTorrentResponse) {
-      return;
-    }
+    // TODO this comment refers to the desired state, not the current state
+    // TODO implement listTorrentResponse==null support
+    // If listTorrentResponse is null, that indicates that the data is not available at the moment
+    // This is typically the case for magnet links that may not have dht peers
     setUploading(true);
-    let initialPeers = listTorrentResponse.seen_peers
+    let initialPeers = listTorrentResponse?.seen_peers
       ? listTorrentResponse.seen_peers.slice(0, 32)
       : null;
+    let only_files = selectedFiles.size <= 0 ? null : Array.from(selectedFiles);
     let opts: AddTorrentOptions = {
       overwrite: true,
-      only_files: Array.from(selectedFiles),
+      only_files,
       initial_peers: initialPeers,
       output_folder: outputFolder,
     };

--- a/crates/librqbit/webui/src/rqbit-web.tsx
+++ b/crates/librqbit/webui/src/rqbit-web.tsx
@@ -49,7 +49,10 @@ export const RqbitWebUI = (props: {
     );
     setTorrents(torrents.torrents);
   };
-  setRefreshTorrents(refreshTorrents);
+
+  useEffect(() => {
+    setRefreshTorrents(refreshTorrents);
+  }, [])
 
   const setStats = useStatsStore((state) => state.setStats);
 


### PR DESCRIPTION
Fix for #286 

Current state:

- [x] Add a timeout for http requests
- [x] Use timeout in `UploadButton` and correct types
- [ ] File Selection modal should detect that no `ListTorrentResponse` is present and only present file destination picker