### PR TITLE
[feature] HTTP API timeouts

### DIFF
--- a/crates/librqbit/src/http_api.rs
+++ b/crates/librqbit/src/http_api.rs
@@ -213,7 +213,7 @@ impl HttpApi {
         async fn torrents_post(
             State(state): State<ApiState>,
             Query(params): Query<TorrentAddQueryParams>,
-            Timeout(timeout): Timeout<60_000, 3_600_000>,
+            Timeout(timeout): Timeout<600_000, 3_600_000>,
             data: Bytes,
         ) -> Result<impl IntoResponse> {
             let is_url = params.is_url;
@@ -322,7 +322,7 @@ impl HttpApi {
 
         async fn resolve_magnet(
             State(state): State<ApiState>,
-            Timeout(timeout): Timeout<60_000, 3_600_000>,
+            Timeout(timeout): Timeout<600_000, 3_600_000>,
             inp_headers: HeaderMap,
             url: String,
         ) -> Result<impl IntoResponse> {

--- a/crates/librqbit/src/http_api.rs
+++ b/crates/librqbit/src/http_api.rs
@@ -82,6 +82,65 @@ async fn simple_basic_auth(
     }
 }
 
+mod timeout {
+    use std::time::Duration;
+
+    use anyhow::Context;
+    use axum::{extract::Query, RequestPartsExt};
+    use http::request::Parts;
+    use serde::Deserialize;
+
+    use crate::ApiError;
+
+    struct Timeout<const DEFAULT_MS: usize, const MAX_MS: usize>(pub Duration);
+
+    #[async_trait::async_trait]
+    impl<S, const DEFAULT_MS: usize, const MAX_MS: usize> axum::extract::FromRequestParts<S>
+        for Timeout<DEFAULT_MS, MAX_MS>
+    where
+        S: Send + Sync,
+    {
+        type Rejection = ApiError;
+
+        /// Perform the extraction.
+        async fn from_request_parts(
+            parts: &mut Parts,
+            _state: &S,
+        ) -> Result<Self, Self::Rejection> {
+            #[derive(Deserialize)]
+            struct QueryT {
+                timeout_ms: Option<usize>,
+            }
+
+            let q = parts
+                .extract::<Query<QueryT>>()
+                .await
+                .context("error running Timeout extractor")?;
+
+            let timeout_ms = q
+                .timeout_ms
+                .map(Ok)
+                .or_else(|| {
+                    parts
+                        .headers
+                        .get("x-req-timeout-ms")
+                        .map(|v| {
+                            std::str::from_utf8(v.as_bytes())
+                                .context("invalid utf-8 in timeout value")
+                        })
+                        .map(|v| {
+                            v.and_then(|v| v.parse::<usize>().context("invalid timeout integer"))
+                        })
+                })
+                .transpose()
+                .context("error parsing timeout")?
+                .unwrap_or(DEFAULT_MS);
+            let timeout_ms = timeout_ms.min(MAX_MS);
+            Ok(Timeout(Duration::from_millis(timeout_ms as u64)))
+        }
+    }
+}
+
 impl HttpApi {
     pub fn new(api: Api, opts: Option<HttpApiOptions>) -> Self {
         Self {

--- a/crates/librqbit/webui/src/http-api.ts
+++ b/crates/librqbit/webui/src/http-api.ts
@@ -11,7 +11,7 @@ import {
 // Define API URL and base path
 const apiUrl = (() => {
   if (window.origin === "null" || window.origin === "http://localhost:3031") {
-    return "http://localhost:3030"
+    return "http://localhost:3030";
   }
   let port = /http.*:\/\/.*:(\d+)/.exec(window.origin)?.[1];
   if (port == "3031") {


### PR DESCRIPTION
This adds default 10 min timeouts to HTTP endpoints that can hang forever.
You can override with "timeout_ms" query parameter or "x-timeout-ms" header.