### PR TITLE
[breaking] multiple refactorings in preparation for deferring torrent metadata resolution

### DIFF
--- a/crates/librqbit/examples/custom_storage.rs
+++ b/crates/librqbit/examples/custom_storage.rs
@@ -20,7 +20,11 @@ struct CustomStorage {
 impl StorageFactory for CustomStorageFactory {
     type Storage = CustomStorage;
 
-    fn create(&self, _info: &librqbit::ManagedTorrentShared) -> anyhow::Result<Self::Storage> {
+    fn create(
+        &self,
+        _: &librqbit::ManagedTorrentShared,
+        _: &librqbit::TorrentMetadata,
+    ) -> anyhow::Result<Self::Storage> {
         Ok(CustomStorage::default())
     }
 
@@ -54,7 +58,11 @@ impl TorrentStorage for CustomStorage {
         anyhow::bail!("not implemented")
     }
 
-    fn init(&mut self, _meta: &librqbit::ManagedTorrentShared) -> anyhow::Result<()> {
+    fn init(
+        &mut self,
+        _meta: &librqbit::ManagedTorrentShared,
+        _: &librqbit::TorrentMetadata,
+    ) -> anyhow::Result<()> {
         anyhow::bail!("not implemented")
     }
 }

--- a/crates/librqbit/examples/ubuntu.rs
+++ b/crates/librqbit/examples/ubuntu.rs
@@ -49,7 +49,9 @@ async fn main() -> Result<(), anyhow::Error> {
         _ => unreachable!(),
     };
 
-    info!("Details: {:?}", &handle.shared().info);
+    handle.with_metadata(|r| {
+        info!("Details: {:?}", &r.info);
+    })?;
 
     // Print stats periodically.
     tokio::spawn({

--- a/crates/librqbit/src/api.rs
+++ b/crates/librqbit/src/api.rs
@@ -209,7 +209,10 @@ impl Api {
                     let mut r = TorrentDetailsResponse {
                         id: Some(id),
                         info_hash: mgr.shared().info_hash.as_string(),
-                        name: mgr.shared().info.name.as_ref().map(|n| n.to_string()),
+                        name: mgr
+                            .with_metadata(|r| r.info.name.as_ref().map(|n| n.to_string()))
+                            .ok()
+                            .flatten(),
                         output_folder: mgr
                             .shared()
                             .options
@@ -245,7 +248,7 @@ impl Api {
         make_torrent_details(
             Some(handle.id()),
             &info_hash,
-            &handle.shared().info,
+            handle.metadata.load().as_ref().map(|r| &r.info),
             only_files.as_deref(),
             output_folder,
         )
@@ -261,8 +264,7 @@ impl Api {
         file_idx: usize,
     ) -> Result<&'static str> {
         let handle = self.mgr_handle(idx)?;
-        let info = &handle.shared().info;
-        torrent_file_mime_type(info, file_idx)
+        handle.with_metadata(|r| torrent_file_mime_type(&r.info, file_idx))?
     }
 
     pub fn api_peer_stats(
@@ -380,7 +382,7 @@ impl Api {
                 let details = make_torrent_details(
                     Some(id),
                     &handle.info_hash(),
-                    &handle.shared().info,
+                    handle.metadata.load().as_ref().map(|r| &r.info),
                     handle.only_files().as_deref(),
                     handle
                         .shared()
@@ -416,7 +418,7 @@ impl Api {
                 details: make_torrent_details(
                     None,
                     &info_hash,
-                    &info,
+                    Some(&info),
                     only_files.as_deref(),
                     output_folder.to_string_lossy().into_owned().to_string(),
                 )
@@ -426,7 +428,7 @@ impl Api {
                 let details = make_torrent_details(
                     Some(id),
                     &handle.info_hash(),
-                    &handle.shared().info,
+                    handle.metadata.load().as_ref().map(|r| &r.info),
                     handle.only_files().as_deref(),
                     handle
                         .shared()
@@ -529,37 +531,40 @@ pub struct ApiAddTorrentResponse {
 fn make_torrent_details(
     id: Option<TorrentId>,
     info_hash: &Id20,
-    info: &TorrentMetaV1Info<ByteBufOwned>,
+    info: Option<&TorrentMetaV1Info<ByteBufOwned>>,
     only_files: Option<&[usize]>,
     output_folder: String,
 ) -> Result<TorrentDetailsResponse> {
-    let files = info
-        .iter_file_details()
-        .context("error iterating filenames and lengths")?
-        .enumerate()
-        .map(|(idx, d)| {
-            let name = match d.filename.to_string() {
-                Ok(s) => s,
-                Err(err) => {
-                    warn!("error reading filename: {:?}", err);
-                    "<INVALID NAME>".to_string()
+    let files = match info {
+        Some(info) => info
+            .iter_file_details()
+            .context("error iterating filenames and lengths")?
+            .enumerate()
+            .map(|(idx, d)| {
+                let name = match d.filename.to_string() {
+                    Ok(s) => s,
+                    Err(err) => {
+                        warn!("error reading filename: {:?}", err);
+                        "<INVALID NAME>".to_string()
+                    }
+                };
+                let components = d.filename.to_vec().unwrap_or_default();
+                let included = only_files.map(|o| o.contains(&idx)).unwrap_or(true);
+                TorrentDetailsResponseFile {
+                    name,
+                    components,
+                    length: d.len,
+                    included,
+                    attributes: d.attrs(),
                 }
-            };
-            let components = d.filename.to_vec().unwrap_or_default();
-            let included = only_files.map(|o| o.contains(&idx)).unwrap_or(true);
-            TorrentDetailsResponseFile {
-                name,
-                components,
-                length: d.len,
-                included,
-                attributes: d.attrs(),
-            }
-        })
-        .collect();
+            })
+            .collect(),
+        None => Default::default(),
+    };
     Ok(TorrentDetailsResponse {
         id,
         info_hash: info_hash.as_string(),
-        name: info.name.as_ref().map(|b| b.to_string()),
+        name: info.and_then(|i| i.name.as_ref().map(|b| b.to_string())),
         files: Some(files),
         output_folder,
         stats: None,

--- a/crates/librqbit/src/api.rs
+++ b/crates/librqbit/src/api.rs
@@ -209,10 +209,7 @@ impl Api {
                     let mut r = TorrentDetailsResponse {
                         id: Some(id),
                         info_hash: mgr.shared().info_hash.as_string(),
-                        name: mgr
-                            .with_metadata(|r| r.info.name.as_ref().map(|n| n.to_string()))
-                            .ok()
-                            .flatten(),
+                        name: mgr.name(),
                         output_folder: mgr
                             .shared()
                             .options
@@ -249,6 +246,7 @@ impl Api {
             Some(handle.id()),
             &info_hash,
             handle.metadata.load().as_ref().map(|r| &r.info),
+            handle.name().as_deref(),
             only_files.as_deref(),
             output_folder,
         )
@@ -383,6 +381,7 @@ impl Api {
                     Some(id),
                     &handle.info_hash(),
                     handle.metadata.load().as_ref().map(|r| &r.info),
+                    handle.name().as_deref(),
                     handle.only_files().as_deref(),
                     handle
                         .shared()
@@ -419,6 +418,7 @@ impl Api {
                     None,
                     &info_hash,
                     Some(&info),
+                    None,
                     only_files.as_deref(),
                     output_folder.to_string_lossy().into_owned().to_string(),
                 )
@@ -429,6 +429,7 @@ impl Api {
                     Some(id),
                     &handle.info_hash(),
                     handle.metadata.load().as_ref().map(|r| &r.info),
+                    handle.name().as_deref(),
                     handle.only_files().as_deref(),
                     handle
                         .shared()
@@ -532,6 +533,7 @@ fn make_torrent_details(
     id: Option<TorrentId>,
     info_hash: &Id20,
     info: Option<&TorrentMetaV1Info<ByteBufOwned>>,
+    name: Option<&str>,
     only_files: Option<&[usize]>,
     output_folder: String,
 ) -> Result<TorrentDetailsResponse> {
@@ -564,7 +566,9 @@ fn make_torrent_details(
     Ok(TorrentDetailsResponse {
         id,
         info_hash: info_hash.as_string(),
-        name: info.and_then(|i| i.name.as_ref().map(|b| b.to_string())),
+        name: name
+            .map(|s| s.to_owned())
+            .or_else(|| info.and_then(|i| i.name.as_ref().map(|b| b.to_string()))),
         files: Some(files),
         output_folder,
         stats: None,

--- a/crates/librqbit/src/lib.rs
+++ b/crates/librqbit/src/lib.rs
@@ -82,7 +82,8 @@ pub use session::{
 };
 pub use spawn_utils::spawn as librqbit_spawn;
 pub use torrent_state::{
-    ManagedTorrent, ManagedTorrentShared, ManagedTorrentState, TorrentStats, TorrentStatsState,
+    ManagedTorrent, ManagedTorrentShared, ManagedTorrentState, TorrentMetadata, TorrentStats,
+    TorrentStatsState,
 };
 pub use type_aliases::FileInfos;
 

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -1167,20 +1167,6 @@ impl Session {
             }
         }
 
-        // Merge "initial_peers" and "peer_rx" into one stream.
-        let peer_rx = merge_two_optional_streams(
-            if !seen_peers.is_empty() {
-                debug!(
-                    count = seen_peers.len(),
-                    "merging initial peers into peer_rx"
-                );
-                Some(futures::stream::iter(seen_peers.into_iter()))
-            } else {
-                None
-            },
-            peer_rx,
-        );
-
         let _e = managed_torrent.shared.span.clone().entered();
         managed_torrent
             .start(peer_rx, opts.paused)

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -1336,9 +1336,7 @@ impl Session {
     }
 
     pub async fn pause(&self, handle: &ManagedTorrentHandle) -> anyhow::Result<()> {
-        handle
-            .pause()
-            .map(|_| handle.locked.write().paused = true)?;
+        handle.pause()?;
         self.try_update_persistence_metadata(handle).await;
         Ok(())
     }

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -1035,7 +1035,7 @@ impl Session {
                 }
             };
 
-            self.main_torrent_info(add_res, opts).await
+            self.add_torrent_internal(add_res, opts).await
         }
         .instrument(error_span!(parent: self.rs(), "add_torrent"))
         .boxed()
@@ -1068,7 +1068,7 @@ impl Session {
         Ok::<_, anyhow::Error>(Some(PathBuf::from(longest)))
     }
 
-    async fn main_torrent_info(
+    async fn add_torrent_internal(
         self: &Arc<Self>,
         add_res: InternalAddResult,
         mut opts: AddTorrentOptions,

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -1179,6 +1179,7 @@ impl Session {
                     output_folder,
                     disk_write_queue: self.disk_write_tx.clone(),
                     ratelimits: opts.ratelimits,
+                    initial_peers: opts.initial_peers.clone().unwrap_or_default(),
                     #[cfg(feature = "disable-upload")]
                     _disable_upload: self._disable_upload,
                 },
@@ -1391,7 +1392,7 @@ impl Session {
             handle.shared().trackers.clone().into_iter().collect(),
             true,
             handle.shared().options.force_tracker_interval,
-            Default::default(),
+            handle.shared().options.initial_peers.clone(),
         )?;
         handle.start(peer_rx, false)?;
         self.try_update_persistence_metadata(handle).await;

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -1168,6 +1168,7 @@ impl Session {
         }
 
         let _e = managed_torrent.shared.span.clone().entered();
+
         managed_torrent
             .start(peer_rx, opts.paused)
             .context("error starting torrent")?;

--- a/crates/librqbit/src/session_persistence/json.rs
+++ b/crates/librqbit/src/session_persistence/json.rs
@@ -150,7 +150,14 @@ impl JsonSessionPersistenceStore {
             output_folder: torrent.shared().options.output_folder.clone(),
         };
 
-        if write_torrent_file && !torrent.shared().torrent_bytes.is_empty() {
+        let torrent_bytes = torrent
+            .metadata
+            .load()
+            .as_ref()
+            .map(|i| i.torrent_bytes.clone())
+            .unwrap_or_default();
+
+        if write_torrent_file && !torrent_bytes.is_empty() {
             let torrent_bytes_file = self.torrent_bytes_filename(&torrent.info_hash());
             match tokio::fs::OpenOptions::new()
                 .create(true)
@@ -160,7 +167,7 @@ impl JsonSessionPersistenceStore {
                 .await
             {
                 Ok(mut f) => {
-                    if let Err(e) = f.write_all(&torrent.shared().torrent_bytes).await {
+                    if let Err(e) = f.write_all(&torrent_bytes).await {
                         warn!(error=?e, file=?torrent_bytes_file, "error writing torrent bytes")
                     }
                 }

--- a/crates/librqbit/src/storage/filesystem/fs.rs
+++ b/crates/librqbit/src/storage/filesystem/fs.rs
@@ -6,7 +6,10 @@ use std::{
 use anyhow::Context;
 use tracing::warn;
 
-use crate::{storage::StorageFactoryExt, torrent_state::ManagedTorrentShared};
+use crate::{
+    storage::StorageFactoryExt,
+    torrent_state::{ManagedTorrentShared, TorrentMetadata},
+};
 
 use crate::storage::{StorageFactory, TorrentStorage};
 
@@ -18,9 +21,13 @@ pub struct FilesystemStorageFactory {}
 impl StorageFactory for FilesystemStorageFactory {
     type Storage = FilesystemStorage;
 
-    fn create(&self, meta: &ManagedTorrentShared) -> anyhow::Result<FilesystemStorage> {
+    fn create(
+        &self,
+        shared: &ManagedTorrentShared,
+        _metadata: &TorrentMetadata,
+    ) -> anyhow::Result<FilesystemStorage> {
         Ok(FilesystemStorage {
-            output_folder: meta.options.output_folder.clone(),
+            output_folder: shared.options.output_folder.clone(),
             opened_files: Default::default(),
         })
     }
@@ -149,9 +156,13 @@ impl TorrentStorage for FilesystemStorage {
         }
     }
 
-    fn init(&mut self, meta: &ManagedTorrentShared) -> anyhow::Result<()> {
+    fn init(
+        &mut self,
+        shared: &ManagedTorrentShared,
+        metadata: &TorrentMetadata,
+    ) -> anyhow::Result<()> {
         let mut files = Vec::<OpenedFile>::new();
-        for file_details in meta.file_infos.iter() {
+        for file_details in metadata.file_infos.iter() {
             let mut full_path = self.output_folder.clone();
             let relative_path = &file_details.relative_filename;
             full_path.push(relative_path);
@@ -161,7 +172,7 @@ impl TorrentStorage for FilesystemStorage {
                 continue;
             };
             std::fs::create_dir_all(full_path.parent().context("bug: no parent")?)?;
-            let f = if meta.options.allow_overwrite {
+            let f = if shared.options.allow_overwrite {
                 OpenOptions::new()
                     .create(true)
                     .truncate(false)

--- a/crates/librqbit/src/storage/filesystem/mmap.rs
+++ b/crates/librqbit/src/storage/filesystem/mmap.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use memmap2::{MmapMut, MmapOptions};
 use parking_lot::RwLock;
 
-use crate::torrent_state::ManagedTorrentShared;
+use crate::torrent_state::{ManagedTorrentShared, TorrentMetadata};
 
 use crate::storage::{StorageFactory, StorageFactoryExt, TorrentStorage};
 
@@ -22,8 +22,12 @@ fn dummy_mmap() -> anyhow::Result<MmapMut> {
 impl StorageFactory for MmapFilesystemStorageFactory {
     type Storage = MmapFilesystemStorage;
 
-    fn create(&self, meta: &ManagedTorrentShared) -> anyhow::Result<Self::Storage> {
-        let fs_storage = FilesystemStorageFactory::default().create(meta)?;
+    fn create(
+        &self,
+        shared: &ManagedTorrentShared,
+        metadata: &TorrentMetadata,
+    ) -> anyhow::Result<Self::Storage> {
+        let fs_storage = FilesystemStorageFactory::default().create(shared, metadata)?;
 
         Ok(MmapFilesystemStorage {
             opened_mmaps: Vec::new(),
@@ -97,13 +101,17 @@ impl TorrentStorage for MmapFilesystemStorage {
         }))
     }
 
-    fn init(&mut self, meta: &ManagedTorrentShared) -> anyhow::Result<()> {
-        self.fs.init(meta)?;
+    fn init(
+        &mut self,
+        shared: &ManagedTorrentShared,
+        metadata: &TorrentMetadata,
+    ) -> anyhow::Result<()> {
+        self.fs.init(shared, metadata)?;
         let mut mmaps = Vec::new();
         for (idx, file) in self.fs.opened_files.iter().enumerate() {
             let fg = file.file.write();
             let fg = fg.as_ref().context("file is None")?;
-            fg.set_len(meta.file_infos[idx].len)
+            fg.set_len(metadata.file_infos[idx].len)
                 .context("mmap storage: error setting length")?;
             let mmap = unsafe { MmapOptions::new().map_mut(fg) }.context("error mapping file")?;
             mmaps.push(RwLock::new(mmap));

--- a/crates/librqbit/src/storage/middleware/timing.rs
+++ b/crates/librqbit/src/storage/middleware/timing.rs
@@ -4,6 +4,7 @@ A storage middleware that logs the time underlying storage operations took.
 
 use crate::{
     storage::{StorageFactory, StorageFactoryExt, TorrentStorage},
+    torrent_state::TorrentMetadata,
     ManagedTorrentShared,
 };
 
@@ -25,10 +26,14 @@ impl<U> TimingStorageFactory<U> {
 impl<U: StorageFactory + Clone> StorageFactory for TimingStorageFactory<U> {
     type Storage = TimingStorage<U::Storage>;
 
-    fn create(&self, info: &crate::ManagedTorrentShared) -> anyhow::Result<Self::Storage> {
+    fn create(
+        &self,
+        shared: &crate::ManagedTorrentShared,
+        metadata: &TorrentMetadata,
+    ) -> anyhow::Result<Self::Storage> {
         Ok(TimingStorage {
             name: self.name.clone(),
-            underlying: self.underlying_factory.create(info)?,
+            underlying: self.underlying_factory.create(shared, metadata)?,
         })
     }
 
@@ -104,7 +109,11 @@ impl<U: TorrentStorage> TorrentStorage for TimingStorage<U> {
         self.underlying.remove_directory_if_empty(path)
     }
 
-    fn init(&mut self, meta: &ManagedTorrentShared) -> anyhow::Result<()> {
-        self.underlying.init(meta)
+    fn init(
+        &mut self,
+        shared: &ManagedTorrentShared,
+        metadata: &TorrentMetadata,
+    ) -> anyhow::Result<()> {
+        self.underlying.init(shared, metadata)
     }
 }

--- a/crates/librqbit/src/storage/middleware/write_through_cache.rs
+++ b/crates/librqbit/src/storage/middleware/write_through_cache.rs
@@ -14,6 +14,7 @@ use parking_lot::RwLock;
 
 use crate::{
     storage::{StorageFactory, StorageFactoryExt, TorrentStorage},
+    torrent_state::TorrentMetadata,
     FileInfos, ManagedTorrentShared,
 };
 
@@ -35,18 +36,22 @@ impl<U> WriteThroughCacheStorageFactory<U> {
 impl<U: StorageFactory + Clone> StorageFactory for WriteThroughCacheStorageFactory<U> {
     type Storage = WriteThroughCacheStorage<U::Storage>;
 
-    fn create(&self, info: &crate::ManagedTorrentShared) -> anyhow::Result<Self::Storage> {
+    fn create(
+        &self,
+        shared: &crate::ManagedTorrentShared,
+        metadata: &TorrentMetadata,
+    ) -> anyhow::Result<Self::Storage> {
         let pieces = self
             .max_cache_bytes
-            .div_ceil(info.lengths.default_piece_length() as u64)
+            .div_ceil(metadata.lengths.default_piece_length() as u64)
             .try_into()?;
         let pieces = NonZeroUsize::new(pieces).context("bug: pieces == 0")?;
         let lru = RwLock::new(LruCache::new(pieces));
         Ok(WriteThroughCacheStorage {
             lru,
-            underlying: self.underlying.create(info)?,
-            lengths: info.lengths,
-            file_infos: info.file_infos.clone(),
+            underlying: self.underlying.create(shared, metadata)?,
+            lengths: metadata.lengths,
+            file_infos: metadata.file_infos.clone(),
         })
     }
 
@@ -121,7 +126,11 @@ impl<U: TorrentStorage> TorrentStorage for WriteThroughCacheStorage<U> {
         self.underlying.remove_directory_if_empty(path)
     }
 
-    fn init(&mut self, meta: &ManagedTorrentShared) -> anyhow::Result<()> {
-        self.underlying.init(meta)
+    fn init(
+        &mut self,
+        shared: &ManagedTorrentShared,
+        metadata: &TorrentMetadata,
+    ) -> anyhow::Result<()> {
+        self.underlying.init(shared, metadata)
     }
 }

--- a/crates/librqbit/src/torrent_state/mod.rs
+++ b/crates/librqbit/src/torrent_state/mod.rs
@@ -203,7 +203,7 @@ pub struct ManagedTorrentShared {
 pub struct ManagedTorrent {
     // Static torrent configuration that doesn't change.
     pub shared: Arc<ManagedTorrentShared>,
-    // Torrent metadata. Maybe be None when the magnet is resolving.
+    // Torrent metadata. Maybe be None when the magnet is resolving (not implemented yet)
     pub metadata: ArcSwapOption<TorrentMetadata>,
     pub(crate) state_change_notify: Notify,
     pub(crate) locked: RwLock<ManagedTorrentLocked>,

--- a/crates/librqbit/src/torrent_state/mod.rs
+++ b/crates/librqbit/src/torrent_state/mod.rs
@@ -182,7 +182,9 @@ pub struct ManagedTorrentShared {
 }
 
 pub struct ManagedTorrent {
+    // Static torrent configuration that doesn't change.
     pub shared: Arc<ManagedTorrentShared>,
+    // Torrent metadata. Maybe be None when the magnet is resolving.
     pub metadata: ArcSwapOption<TorrentMetadata>,
     pub(crate) state_change_notify: Notify,
     pub(crate) locked: RwLock<ManagedTorrentLocked>,

--- a/crates/librqbit/src/torrent_state/mod.rs
+++ b/crates/librqbit/src/torrent_state/mod.rs
@@ -399,10 +399,6 @@ impl ManagedTorrent {
             }
         }
 
-        if !start_paused && peer_rx.is_none() {
-            bail!("logic bug: start(start_paused=false, peer_rx=None) called. peer_rx must be set if starting the torrent")
-        }
-
         let session = self
             .shared
             .session

--- a/crates/librqbit/src/torrent_state/mod.rs
+++ b/crates/librqbit/src/torrent_state/mod.rs
@@ -6,6 +6,7 @@ mod streaming;
 pub mod utils;
 
 use std::collections::HashSet;
+use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -105,6 +106,7 @@ pub(crate) struct ManagedTorrentOptions {
     pub output_folder: PathBuf,
     pub disk_write_queue: Option<DiskWorkQueueSender>,
     pub ratelimits: LimitsConfig,
+    pub initial_peers: Vec<SocketAddr>,
     #[cfg(feature = "disable-upload")]
     pub _disable_upload: bool,
 }

--- a/crates/librqbit/src/torrent_state/mod.rs
+++ b/crates/librqbit/src/torrent_state/mod.rs
@@ -56,6 +56,15 @@ use self::paused::TorrentStatePaused;
 pub use self::stats::{TorrentStats, TorrentStatsState};
 pub use self::streaming::FileStream;
 
+// State machine transitions.
+//
+// - error -> initializing
+// - initializing -> paused
+// - paused -> live
+// - live -> paused
+//
+// - initializing -> error
+// - live -> error
 pub enum ManagedTorrentState {
     Initializing(Arc<TorrentStateInitializing>),
     Paused(TorrentStatePaused),
@@ -281,16 +290,6 @@ impl ManagedTorrent {
         peer_rx: Option<PeerStream>,
         start_paused: bool,
     ) -> anyhow::Result<()> {
-        // State machine transitions.
-        //
-        // - error -> initializing
-        // - initializing -> paused
-        // - paused -> live
-        // - live -> paused
-        //
-        // - initializing -> error
-        // - live -> error
-
         fn _start<'a>(
             t: &'a Arc<ManagedTorrent>,
             peer_rx: Option<PeerStream>,

--- a/crates/librqbit/src/torrent_state/mod.rs
+++ b/crates/librqbit/src/torrent_state/mod.rs
@@ -279,6 +279,116 @@ impl ManagedTorrent {
         peer_rx: Option<PeerStream>,
         start_paused: bool,
     ) -> anyhow::Result<()> {
+        // State machine transitions.
+        //
+        // - error -> initializing
+        // - initializing -> paused
+        // - paused -> live
+        // - live -> paused
+        //
+        // - initializing -> error
+        // - live -> error
+
+        fn _start<'a>(
+            t: &'a Arc<ManagedTorrent>,
+            peer_rx: Option<PeerStream>,
+            start_paused: bool,
+            session: Arc<Session>,
+            g: Option<parking_lot::RwLockWriteGuard<'a, ManagedTorrentLocked>>,
+            token: CancellationToken,
+        ) -> anyhow::Result<()> {
+            let mut g = g.unwrap_or_else(|| t.locked.write());
+
+            match &g.state {
+                ManagedTorrentState::Live(_) => {
+                    bail!("torrent is already live");
+                }
+                ManagedTorrentState::Initializing(init) => {
+                    let init = init.clone();
+                    drop(g);
+                    let t = t.clone();
+                    let span = t.shared().span.clone();
+                    let token = token.clone();
+
+                    spawn_with_cancel(
+                        error_span!(parent: span.clone(), "initialize_and_start"),
+                        token.clone(),
+                        async move {
+                            let concurrent_init_semaphore =
+                                session.concurrent_initialize_semaphore.clone();
+                            let _permit = concurrent_init_semaphore
+                                .acquire()
+                                .await
+                                .context("bug: concurrent init semaphore was closed")?;
+
+                            match init.check().await {
+                                Ok(paused) => {
+                                    let mut g = t.locked.write();
+                                    if let ManagedTorrentState::Initializing(_) = &g.state {
+                                    } else {
+                                        debug!("no need to start torrent anymore, as it switched state from initilizing");
+                                        return Ok(());
+                                    }
+
+                                    g.state = ManagedTorrentState::Paused(paused);
+                                    t.state_change_notify.notify_waiters();
+
+                                    if start_paused {
+                                        return Ok(());
+                                    }
+
+                                    _start(&t, peer_rx, start_paused, session, Some(g), token)
+                                }
+                                Err(err) => {
+                                    let result = anyhow::anyhow!("{:?}", err);
+                                    t.locked.write().state = ManagedTorrentState::Error(err);
+                                    t.state_change_notify.notify_waiters();
+                                    Err(result)
+                                }
+                            }
+                        },
+                    );
+                    Ok(())
+                }
+                ManagedTorrentState::Paused(_) => {
+                    if start_paused {
+                        warn!("start(start_paused=true) called, but torrent already paused");
+                        return Ok(());
+                    }
+                    let paused = g.state.take().assert_paused();
+                    let (tx, rx) = tokio::sync::oneshot::channel();
+                    let live = TorrentStateLive::new(paused, tx, token.clone())?;
+                    g.state = ManagedTorrentState::Live(live.clone());
+                    t.state_change_notify.notify_waiters();
+                    drop(g);
+
+                    spawn_fatal_errors_receiver(t, rx, token);
+                    if let Some(peer_rx) = peer_rx {
+                        spawn_peer_adder(&live, peer_rx);
+                    }
+                    Ok(())
+                }
+                ManagedTorrentState::Error(_) => {
+                    let metadata = t.metadata.load_full().expect("TODO");
+                    let initializing = Arc::new(TorrentStateInitializing::new(
+                        t.shared.clone(),
+                        metadata.clone(),
+                        g.only_files.clone(),
+                        t.shared
+                            .storage_factory
+                            .create_and_init(t.shared(), &metadata)?,
+                        true,
+                    ));
+                    g.state = ManagedTorrentState::Initializing(initializing.clone());
+                    t.state_change_notify.notify_waiters();
+
+                    // Recurse.
+                    _start(t, peer_rx, start_paused, session, Some(g), token)
+                }
+                ManagedTorrentState::None => bail!("bug: torrent is in empty state"),
+            }
+        }
+
         let session = self
             .shared
             .session
@@ -288,165 +398,14 @@ impl ManagedTorrent {
         g.paused = start_paused;
         let cancellation_token = session.cancellation_token().child_token();
 
-        let spawn_fatal_errors_receiver =
-            |state: &Arc<Self>,
-             rx: tokio::sync::oneshot::Receiver<anyhow::Error>,
-             token: CancellationToken| {
-                let span = state.shared.span.clone();
-                let state = Arc::downgrade(state);
-                spawn_with_cancel(
-                    error_span!(parent: span, "fatal_errors_receiver"),
-                    token,
-                    async move {
-                        let e = match rx.await {
-                            Ok(e) => e,
-                            Err(_) => return Ok(()),
-                        };
-                        if let Some(state) = state.upgrade() {
-                            state.stop_with_error(e);
-                        } else {
-                            warn!("tried to stop the torrent with error, but couldn't upgrade the arc");
-                        }
-                        Ok(())
-                    },
-                );
-            };
-
-        fn spawn_peer_adder(live: &Arc<TorrentStateLive>, mut peer_rx: PeerStream) {
-            live.spawn(
-                error_span!(parent: live.torrent().span.clone(), "external_peer_adder"),
-                {
-                    let live = live.clone();
-                    async move {
-                        let live = {
-                            let weak = Arc::downgrade(&live);
-                            drop(live);
-                            weak
-                        };
-
-                        loop {
-                            match timeout(Duration::from_secs(5), peer_rx.next()).await {
-                                Ok(Some(peer)) => {
-                                    trace!(?peer, "received peer from peer_rx");
-                                    let live = match live.upgrade() {
-                                        Some(live) => live,
-                                        None => return Ok(()),
-                                    };
-                                    live.add_peer_if_not_seen(peer).context("torrent closed")?;
-                                }
-                                Ok(None) => {
-                                    debug!("peer_rx closed, closing peer adder");
-                                    return Ok(());
-                                }
-                                // If timeout, check if the torrent is live.
-                                Err(_) if live.strong_count() == 0 => {
-                                    debug!("timed out waiting for peers, torrent isn't live, closing peer adder");
-                                    return Ok(());
-                                }
-                                Err(_) => continue,
-                            }
-                        }
-                    }
-                },
-            );
-        }
-
-        match &g.state {
-            ManagedTorrentState::Live(_) => {
-                bail!("torrent is already live");
-            }
-            ManagedTorrentState::Initializing(init) => {
-                let init = init.clone();
-                drop(g);
-                let t = self.clone();
-                let span = self.shared().span.clone();
-                let token = cancellation_token.clone();
-
-                spawn_with_cancel(
-                    error_span!(parent: span.clone(), "initialize_and_start"),
-                    token.clone(),
-                    async move {
-                        let concurrent_init_semaphore =
-                            session.concurrent_initialize_semaphore.clone();
-                        let _permit = concurrent_init_semaphore
-                            .acquire()
-                            .await
-                            .context("bug: concurrent init semaphore was closed")?;
-
-                        match init.check().await {
-                            Ok(paused) => {
-                                let mut g = t.locked.write();
-                                if let ManagedTorrentState::Initializing(_) = &g.state {
-                                } else {
-                                    debug!("no need to start torrent anymore, as it switched state from initilizing");
-                                    return Ok(());
-                                }
-
-                                if start_paused {
-                                    g.state = ManagedTorrentState::Paused(paused);
-                                    t.state_change_notify.notify_waiters();
-                                    return Ok(());
-                                }
-
-                                let (tx, rx) = tokio::sync::oneshot::channel();
-                                let live = TorrentStateLive::new(paused, tx, cancellation_token)?;
-                                g.state = ManagedTorrentState::Live(live.clone());
-                                drop(g);
-
-                                t.state_change_notify.notify_waiters();
-
-                                spawn_fatal_errors_receiver(&t, rx, token);
-                                if let Some(peer_rx) = peer_rx {
-                                    spawn_peer_adder(&live, peer_rx);
-                                }
-
-                                Ok(())
-                            }
-                            Err(err) => {
-                                let result = anyhow::anyhow!("{:?}", err);
-                                t.locked.write().state = ManagedTorrentState::Error(err);
-                                t.state_change_notify.notify_waiters();
-                                Err(result)
-                            }
-                        }
-                    },
-                );
-                Ok(())
-            }
-            ManagedTorrentState::Paused(_) => {
-                let paused = g.state.take().assert_paused();
-                let (tx, rx) = tokio::sync::oneshot::channel();
-                let live = TorrentStateLive::new(paused, tx, cancellation_token.clone())?;
-                g.state = ManagedTorrentState::Live(live.clone());
-                drop(g);
-
-                spawn_fatal_errors_receiver(self, rx, cancellation_token);
-                if let Some(peer_rx) = peer_rx {
-                    spawn_peer_adder(&live, peer_rx);
-                }
-                Ok(())
-            }
-            ManagedTorrentState::Error(_) => {
-                let metadata = self.metadata.load_full().expect("TODO");
-                let initializing = Arc::new(TorrentStateInitializing::new(
-                    self.shared.clone(),
-                    metadata.clone(),
-                    g.only_files.clone(),
-                    self.shared
-                        .storage_factory
-                        .create_and_init(self.shared(), &metadata)?,
-                    true,
-                ));
-                g.state = ManagedTorrentState::Initializing(initializing.clone());
-                drop(g);
-
-                self.state_change_notify.notify_waiters();
-
-                // Recurse.
-                self.start(peer_rx, start_paused)
-            }
-            ManagedTorrentState::None => bail!("bug: torrent is in empty state"),
-        }
+        _start(
+            self,
+            peer_rx,
+            start_paused,
+            session,
+            Some(g),
+            cancellation_token,
+        )
     }
 
     pub fn is_paused(&self) -> bool {
@@ -618,3 +577,67 @@ impl ManagedTorrent {
 }
 
 pub type ManagedTorrentHandle = Arc<ManagedTorrent>;
+
+fn spawn_fatal_errors_receiver(
+    state: &Arc<ManagedTorrent>,
+    rx: tokio::sync::oneshot::Receiver<anyhow::Error>,
+    token: CancellationToken,
+) {
+    let span = state.shared.span.clone();
+    let state = Arc::downgrade(state);
+    spawn_with_cancel(
+        error_span!(parent: span, "fatal_errors_receiver"),
+        token,
+        async move {
+            let e = match rx.await {
+                Ok(e) => e,
+                Err(_) => return Ok(()),
+            };
+            if let Some(state) = state.upgrade() {
+                state.stop_with_error(e);
+            } else {
+                warn!("tried to stop the torrent with error, but couldn't upgrade the arc");
+            }
+            Ok(())
+        },
+    );
+}
+
+fn spawn_peer_adder(live: &Arc<TorrentStateLive>, mut peer_rx: PeerStream) {
+    live.spawn(
+        error_span!(parent: live.torrent().span.clone(), "external_peer_adder"),
+        {
+            let live = live.clone();
+            async move {
+                let live = {
+                    let weak = Arc::downgrade(&live);
+                    drop(live);
+                    weak
+                };
+
+                loop {
+                    match timeout(Duration::from_secs(5), peer_rx.next()).await {
+                        Ok(Some(peer)) => {
+                            trace!(?peer, "received peer from peer_rx");
+                            let live = match live.upgrade() {
+                                Some(live) => live,
+                                None => return Ok(()),
+                            };
+                            live.add_peer_if_not_seen(peer).context("torrent closed")?;
+                        }
+                        Ok(None) => {
+                            debug!("peer_rx closed, closing peer adder");
+                            return Ok(());
+                        }
+                        // If timeout, check if the torrent is live.
+                        Err(_) if live.strong_count() == 0 => {
+                            debug!("timed out waiting for peers, torrent isn't live, closing peer adder");
+                            return Ok(());
+                        }
+                        Err(_) => continue,
+                    }
+                }
+            }
+        },
+    );
+}

--- a/crates/librqbit/src/torrent_state/mod.rs
+++ b/crates/librqbit/src/torrent_state/mod.rs
@@ -400,7 +400,7 @@ impl ManagedTorrent {
         }
 
         if !start_paused && peer_rx.is_none() {
-            bail!("logic bug: start(start_paused=true, peer_rx=None) called. peer_rx must be set if starting the torrent")
+            bail!("logic bug: start(start_paused=false, peer_rx=None) called. peer_rx must be set if starting the torrent")
         }
 
         let session = self

--- a/crates/librqbit/src/torrent_state/mod.rs
+++ b/crates/librqbit/src/torrent_state/mod.rs
@@ -334,11 +334,6 @@ impl ManagedTorrent {
 
                                     g.state = ManagedTorrentState::Paused(paused);
                                     t.state_change_notify.notify_waiters();
-
-                                    if start_paused {
-                                        return Ok(());
-                                    }
-
                                     _start(&t, peer_rx, start_paused, session, Some(g), token)
                                 }
                                 Err(err) => {
@@ -354,7 +349,6 @@ impl ManagedTorrent {
                 }
                 ManagedTorrentState::Paused(_) => {
                     if start_paused {
-                        warn!("start(start_paused=true) called, but torrent already paused");
                         return Ok(());
                     }
                     let paused = g.state.take().assert_paused();

--- a/crates/librqbit/src/torrent_state/mod.rs
+++ b/crates/librqbit/src/torrent_state/mod.rs
@@ -306,7 +306,6 @@ impl ManagedTorrent {
                 }
                 ManagedTorrentState::Initializing(init) => {
                     let init = init.clone();
-                    drop(g);
                     let t = t.clone();
                     let span = t.shared().span.clone();
                     let token = token.clone();
@@ -355,7 +354,6 @@ impl ManagedTorrent {
                     let live = TorrentStateLive::new(paused, tx, token.clone())?;
                     g.state = ManagedTorrentState::Live(live.clone());
                     t.state_change_notify.notify_waiters();
-                    drop(g);
 
                     spawn_fatal_errors_receiver(t, rx, token);
                     if let Some(peer_rx) = peer_rx {

--- a/crates/librqbit/src/torrent_state/paused.rs
+++ b/crates/librqbit/src/torrent_state/paused.rs
@@ -5,10 +5,11 @@ use crate::{
     type_aliases::FileStorage,
 };
 
-use super::{streaming::TorrentStreams, ManagedTorrentShared};
+use super::{streaming::TorrentStreams, ManagedTorrentShared, TorrentMetadata};
 
 pub struct TorrentStatePaused {
     pub(crate) shared: Arc<ManagedTorrentShared>,
+    pub(crate) metadata: Arc<TorrentMetadata>,
     pub(crate) files: FileStorage,
     pub(crate) chunk_tracker: ChunkTracker,
     pub(crate) streams: Arc<TorrentStreams>,
@@ -17,7 +18,7 @@ pub struct TorrentStatePaused {
 impl TorrentStatePaused {
     pub(crate) fn update_only_files(&mut self, only_files: &HashSet<usize>) -> anyhow::Result<()> {
         self.chunk_tracker
-            .update_only_files(self.shared.info.iter_file_lengths()?, only_files)?;
+            .update_only_files(self.metadata.info.iter_file_lengths()?, only_files)?;
         Ok(())
     }
 

--- a/crates/librqbit_core/src/magnet.rs
+++ b/crates/librqbit_core/src/magnet.rs
@@ -9,6 +9,7 @@ pub struct Magnet {
     id20: Option<Id20>,
     id32: Option<Id32>,
     pub trackers: Vec<String>,
+    pub name: Option<String>,
     select_only: Option<Vec<usize>>,
 }
 
@@ -29,6 +30,7 @@ impl Magnet {
             id20: Some(id20),
             id32: None,
             trackers,
+            name: None,
             select_only,
         }
     }
@@ -40,6 +42,7 @@ impl Magnet {
                 return Ok(Magnet {
                     id20: Some(id20),
                     id32: None,
+                    name: None,
                     trackers: vec![],
                     select_only: None,
                 });
@@ -52,6 +55,7 @@ impl Magnet {
         let mut info_hash_found = false;
         let mut id20: Option<Id20> = None;
         let mut id32: Option<Id32> = None;
+        let mut name: Option<String> = None;
         let mut trackers = Vec::<String>::new();
         let mut files = Vec::<usize>::new();
         for (key, value) in url.query_pairs() {
@@ -70,6 +74,11 @@ impl Magnet {
                     }
                 }
                 "tr" => trackers.push(value.into()),
+                "dn" => {
+                    if !value.is_empty() {
+                        name = Some(value.into_owned())
+                    }
+                }
                 "so" => {
                     // Process 'so' values, but silently ignore any which fail parsing
                     for file_desc in value.split(',') {
@@ -100,6 +109,7 @@ impl Magnet {
                 id20,
                 id32,
                 trackers,
+                name,
                 select_only: if files.is_empty() { None } else { Some(files) },
             }),
             false => {


### PR DESCRIPTION
Full context for what problem is being solved is here: https://github.com/ikatson/rqbit/pull/287

Some torrents don't resolve metadata from magnet links instantly and might take a long time. 

The problem with this is that (lib)rqbit's current architecture implies that the torrents persisted in session have metadata fully resolved and always available.

So today the session has no idea of torrents that are "being resolved". The use-case is - we want to be able to add a torrent to a session, and let it resolve the metadata in background.

There are 2 conceptual ways to address that:
1. Store "resolving" torrents completely separately from the the resolved ones. Then merge them together in UI, API, etc.
2. Update the current data model to support the new states and null-ness of metadata.

This PR prepares the code for the 2nd approach. Also some refactorings to increase maintainability of "add_torrent" and "start_torrent" code.