### PR TITLE
[feature] Initial support for private torrents

### DIFF
--- a/crates/bencode/src/serde_bencode_ser.rs
+++ b/crates/bencode/src/serde_bencode_ser.rs
@@ -218,11 +218,8 @@ impl<'ser, W: std::io::Write> Serializer for &'ser mut BencodeSerializer<W> {
     type SerializeStruct = SerializeStruct<'ser, W>;
     type SerializeStructVariant = Impossible<(), SerError>;
 
-    fn serialize_bool(self, _: bool) -> Result<Self::Ok, Self::Error> {
-        Err(SerError::custom_with_ser(
-            "bencode doesn't support booleans",
-            self,
-        ))
+    fn serialize_bool(self, value: bool) -> Result<Self::Ok, Self::Error> {
+        self.write_number(if value { 1 } else { 0 })
     }
 
     fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {

--- a/crates/librqbit/src/create_torrent_file.rs
+++ b/crates/librqbit/src/create_torrent_file.rs
@@ -163,6 +163,7 @@ async fn create_torrent_raw<'a>(
         attr: None,
         sha1: None,
         symlink_path: None,
+        private: false,
     })
 }
 

--- a/crates/librqbit/src/tests/test_util.rs
+++ b/crates/librqbit/src/tests/test_util.rs
@@ -134,6 +134,7 @@ async fn debug_server() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[allow(dead_code)]
 pub fn spawn_debug_server() -> tokio::task::JoinHandle<anyhow::Result<()>> {
     tokio::spawn(debug_server())
 }

--- a/crates/librqbit/src/upnp_server_adapter.rs
+++ b/crates/librqbit/src/upnp_server_adapter.rs
@@ -430,6 +430,7 @@ mod tests {
                 attr: None,
                 sha1: None,
                 symlink_path: None,
+                private: false,
             },
             comment: None,
             created_by: None,

--- a/crates/librqbit_core/src/resources/test/private.torrent
+++ b/crates/librqbit_core/src/resources/test/private.torrent
@@ -1,0 +1,1 @@
+d10:created by20:qBittorrent v4.4.3.113:creation datei1736784212e4:infod6:lengthi2e4:name7:private12:piece lengthi16384e6:pieces20:åúDò³µS¶s`Ð}]‘ÿ^7:privatei1eee

--- a/crates/librqbit_core/src/torrent_metainfo.rs
+++ b/crates/librqbit_core/src/torrent_metainfo.rs
@@ -50,6 +50,10 @@ pub fn torrent_from_bytes<'de, BufType: Deserialize<'de> + From<&'de [u8]>>(
     torrent_from_bytes_ext(buf).map(|r| r.meta)
 }
 
+fn is_false(b: &bool) -> bool {
+    !*b
+}
+
 /// A parsed .torrent file.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct TorrentMetaV1<BufType> {
@@ -117,6 +121,9 @@ pub struct TorrentMetaV1Info<BufType> {
     // Multi-file mode
     #[serde(skip_serializing_if = "Option::is_none")]
     pub files: Option<Vec<TorrentMetaV1File<BufType>>>,
+
+    #[serde(skip_serializing_if = "is_false", default)]
+    pub private: bool,
 }
 
 #[derive(Clone, Copy)]
@@ -377,6 +384,7 @@ where
             attr: self.attr.clone_to_owned(within_buffer),
             sha1: self.sha1.clone_to_owned(within_buffer),
             symlink_path: self.symlink_path.clone_to_owned(within_buffer),
+            private: self.private,
         }
     }
 }

--- a/crates/librqbit_core/src/torrent_metainfo.rs
+++ b/crates/librqbit_core/src/torrent_metainfo.rs
@@ -509,4 +509,11 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn test_private_real_torrent() {
+        let buf = include_bytes!("resources/test/private.torrent");
+        let torrent: TorrentMetaV1Borrowed = torrent_from_bytes(buf).unwrap();
+        assert!(torrent.info.private);
+    }
 }

--- a/crates/librqbit_core/src/torrent_metainfo.rs
+++ b/crates/librqbit_core/src/torrent_metainfo.rs
@@ -413,47 +413,28 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::io::Read;
-
     use bencode::BencodeValue;
 
     use super::*;
 
-    const TORRENT_FILENAME: &str = "../librqbit/resources/ubuntu-21.04-desktop-amd64.iso.torrent";
+    const TORRENT_BYTES: &[u8] =
+        include_bytes!("../../librqbit/resources/ubuntu-21.04-desktop-amd64.iso.torrent");
 
     #[test]
     fn test_deserialize_torrent_owned() {
-        let mut buf = Vec::new();
-        std::fs::File::open(TORRENT_FILENAME)
-            .unwrap()
-            .read_to_end(&mut buf)
-            .unwrap();
-
-        let torrent: TorrentMetaV1Owned = torrent_from_bytes(&buf).unwrap();
+        let torrent: TorrentMetaV1Owned = torrent_from_bytes(TORRENT_BYTES).unwrap();
         dbg!(torrent);
     }
 
     #[test]
     fn test_deserialize_torrent_borrowed() {
-        let mut buf = Vec::new();
-        std::fs::File::open(TORRENT_FILENAME)
-            .unwrap()
-            .read_to_end(&mut buf)
-            .unwrap();
-
-        let torrent: TorrentMetaV1Borrowed = torrent_from_bytes(&buf).unwrap();
+        let torrent: TorrentMetaV1Borrowed = torrent_from_bytes(TORRENT_BYTES).unwrap();
         dbg!(torrent);
     }
 
     #[test]
     fn test_deserialize_torrent_with_info_hash() {
-        let mut buf = Vec::new();
-        std::fs::File::open(TORRENT_FILENAME)
-            .unwrap()
-            .read_to_end(&mut buf)
-            .unwrap();
-
-        let torrent: TorrentMetaV1Borrowed = torrent_from_bytes(&buf).unwrap();
+        let torrent: TorrentMetaV1Borrowed = torrent_from_bytes(TORRENT_BYTES).unwrap();
         assert_eq!(
             torrent.info_hash.as_string(),
             "64a980abe6e448226bb930ba061592e44c3781a1"
@@ -462,13 +443,7 @@ mod tests {
 
     #[test]
     fn test_serialize_then_deserialize_bencode() {
-        let mut buf = Vec::new();
-        std::fs::File::open(TORRENT_FILENAME)
-            .unwrap()
-            .read_to_end(&mut buf)
-            .unwrap();
-
-        let torrent: TorrentMetaV1Info<ByteBuf> = torrent_from_bytes(&buf).unwrap().info;
+        let torrent: TorrentMetaV1Info<ByteBuf> = torrent_from_bytes(TORRENT_BYTES).unwrap().info;
         let mut writer = Vec::new();
         bencode::bencode_serialize_to_writer(&torrent, &mut writer).unwrap();
         let deserialized = TorrentMetaV1Info::<ByteBuf>::deserialize(


### PR DESCRIPTION
BEP 0027 initial implementation https://www.bittorrent.org/beps/bep_0027.html

The intention is mainly to at least stop misbehaving when facing private torrents, i.e.:
- don't use DHT
- don't announce on multiple trackers at once

Done these:
- private field is serialized and deserialized properly
- DHT is disabled for private trackers
- only the first tracker is used from the list (to simplify implementation). The algorithm in BEP 27 is a little more involved when handling multiple trackers.