### PR TITLE
[Feature] Can put rqbit Web UI behind proxy server

### DIFF
--- a/crates/librqbit/webui/src/http-api.ts
+++ b/crates/librqbit/webui/src/http-api.ts
@@ -10,21 +10,26 @@ import {
 
 // Define API URL and base path
 const apiUrl = (() => {
-  if (window.origin === "null" || window.origin === "http://localhost:3031") {
+  if (window.origin === "null") {
     return "http://localhost:3030";
   }
-  let port = /http.*:\/\/.*:(\d+)/.exec(window.origin)?.[1];
-  if (port == "3031") {
-    return window.origin.replace("3031", "3030");
+  const url = new URL(window.location.href);
+
+  // assume Vite devserver
+  if (url.port == "3031") {
+    return `${url.protocol}//${url.hostname}:3030`;
   }
-  return "";
+
+  // Remove "/web" or "/web/" from the end and also ending slash.
+  const path = /(.*?)\/?(\/web\/?)?$/.exec(url.pathname)![1] ?? "";
+  return path;
 })();
 
 const makeRequest = async (
   method: string,
   path: string,
   data?: any,
-  isJson?: boolean,
+  isJson?: boolean
 ): Promise<any> => {
   console.log(method, path);
   const url = apiUrl + path;
@@ -127,7 +132,7 @@ export const API: RqbitAPI & { getVersion: () => Promise<string> } = {
       {
         only_files: files,
       },
-      true,
+      true
     );
   },
 
@@ -153,7 +158,7 @@ export const API: RqbitAPI & { getVersion: () => Promise<string> } = {
   getTorrentStreamUrl: (
     index: number,
     file_id: number,
-    filename?: string | null,
+    filename?: string | null
   ) => {
     let url = apiUrl + `/torrents/${index}/stream/${file_id}`;
     if (!!filename) {


### PR DESCRIPTION
This is related to features mentioned in https://github.com/ikatson/rqbit/issues/296

This allows you to put rqbit Web UI behind a proxy server under a different path, and it'll still work.

E.g. for nginx

```
        # Proxy requests to /rqbit/ to rqbit at http://localhost:3030
        location /rqbit/ {
            proxy_pass http://localhost:3030/;
            proxy_http_version 1.1;

            proxy_set_header Host $host;
            proxy_set_header X-Real-IP $remote_addr;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        }
```

Then open URL/rqbit/web/ in your HTTP server

CC @mpmc