### PR TITLE
Initial support for interface binding

### DIFF
--- a/crates/tracker_comms/src/tracker_comms_udp.rs
+++ b/crates/tracker_comms/src/tracker_comms_udp.rs
@@ -184,11 +184,13 @@ impl UdpTrackerRequester {
     pub async fn new(addr: impl ToSocketAddrs) -> anyhow::Result<Self> {
         let sock = tokio::net::UdpSocket::bind("0.0.0.0:0")
             .await
-            .context("error binding UDP socket")?;
+            .context("error binding UDP socket for tracker")?;
+
+        //TODO: Figure out how to set this nicely
+        //sock.bind_device(Some(b"INTERFACE-NAME")).context("error setting UDP socket to interface")?;
         sock.connect(addr)
             .await
-            .context("error connecting UDP socket")?;
-
+            .context("error connecting UDP socket for tracker")?;
         let tid = new_transaction_id();
         let mut write_buf = Vec::new();
         let mut read_buf = vec![0u8; 4096];


### PR DESCRIPTION
Currently a draft, this is "working" sort of when you pass the interface to the tracker, without passing the interface and binding to it, it announces the wrong thing. As such setting initial-peer will work, but no trackers will see the client.

I haven't really proof read any of the changes yet, this is just so I can get help with the main issue.

Additionally this PR makes changes to how tcp port binding works. if a user wishes to select a single port (IE. port forwarding) we can easily do this by passing the port..port + 1 due to how ranges work. the changes are purely convenience. Min port being greater then max port will give a range with nothing in it, so doing this will at least pass a single port, but perhaps throwing a warning or even an error would be better.

- [ ] don't clone so much
- [ ] figure out how pass interface to tracker

the second one I am really struggling with as it seems like it may require quite a bit of things to change.