### PR TITLE
[perf] don't use tokio::io::split

### DIFF
--- a/crates/librqbit/src/http_api/handlers/mod.rs
+++ b/crates/librqbit/src/http_api/handlers/mod.rs
@@ -26,7 +26,7 @@ async fn h_api_root(parts: Parts) -> impl IntoResponse {
             .headers
             .get("Accept")
             .and_then(|h| h.to_str().ok())
-            .map_or(false, |h| h.contains("text/html"))
+            .is_some_and(|h| h.contains("text/html"))
         {
             return Redirect::temporary("./web/").into_response();
         }

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -996,7 +996,7 @@ impl Session {
             name,
         } = add_res;
 
-        let private = metadata.as_ref().map_or(false, |m| m.info.private);
+        let private = metadata.as_ref().is_some_and(|m| m.info.private);
 
         let make_peer_rx = || {
             self.make_peer_rx(

--- a/crates/librqbit/src/torrent_state/live/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/mod.rs
@@ -1253,10 +1253,7 @@ impl PeerHandler {
     ///
     /// If this returns, an existing in-flight piece was marked to be ours.
     fn try_steal_old_slow_piece(&self, threshold: f64) -> Option<ValidPieceIndex> {
-        let my_avg_time = match self.counters.average_piece_download_time() {
-            Some(t) => t,
-            None => return None,
-        };
+        let my_avg_time = self.counters.average_piece_download_time()?;
 
         let (stolen_idx, from_peer) = {
             let mut g = self.state.lock_write("try_steal_old_slow_piece");

--- a/crates/librqbit/src/torrent_state/live/peer/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/peer/mod.rs
@@ -263,8 +263,6 @@ impl LivePeerState {
     }
 
     pub fn has_full_torrent(&self, total_pieces: usize) -> bool {
-        self.bitfield
-            .get(0..total_pieces)
-            .map_or(false, |s| s.all())
+        self.bitfield.get(0..total_pieces).is_some_and(|s| s.all())
     }
 }


### PR DESCRIPTION
tokio::io::split has a Mutex inside, this uses the actual stream's split instead