### PR TITLE
Make Session ratelimits accessible from outside of crate

### DIFF
--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -123,7 +123,7 @@ pub struct Session {
 
     // Limits and throttling
     pub(crate) concurrent_initialize_semaphore: Arc<tokio::sync::Semaphore>,
-    pub(crate) ratelimits: Limits,
+    pub ratelimits: Limits,
 
     // Monitoring / tracing / logging
     pub(crate) stats: SessionStats,


### PR DESCRIPTION
I'm using the `librqbit` crate directly as a part of my codebase, and would like to be able to change the rate limits while a session is active.

As far as I can see this is currently only possible via the HTTP API? This PR simply makes the `ratelimits` field public, such that it's possible to change it directly if you're a consumer of the crate.