### PR TITLE
[feature] List of trackers from file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4436,6 +4436,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/crates/librqbit/Cargo.toml
+++ b/crates/librqbit/Cargo.toml
@@ -98,7 +98,9 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
 ], optional = true }
 uuid = { version = "1.2", features = ["v4"] }
 futures = "0.3"
-url = { version = "=2.5.2", default-features = false } # can't upgrade yet until min version is Rust 1.81, see https://github.com/servo/rust-url/issues/992
+url = { version = "=2.5.2", default-features = false, features = [
+    "serde",
+] } # can't upgrade yet until min version is Rust 1.81, see https://github.com/servo/rust-url/issues/992
 
 hex = "0.4"
 backoff = "0.4.0"
@@ -119,7 +121,7 @@ notify = { version = "7", optional = true }
 walkdir = "2.5.0"
 arc-swap = "1.7.1"
 intervaltree = "0.2.7"
-async-compression = {version="0.4.18", features= ["tokio", "gzip"] }
+async-compression = { version = "0.4.18", features = ["tokio", "gzip"] }
 
 [build-dependencies]
 anyhow = "1"

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -422,6 +422,9 @@ pub struct SessionOptions {
 
     pub blocklist_url: Option<String>,
 
+    // The list of tracker URLs to always use for each torrent.
+    pub trackers: HashSet<url::Url>,
+
     #[cfg(feature = "disable-upload")]
     pub disable_upload: bool,
 }

--- a/crates/librqbit/src/session_persistence/postgres.rs
+++ b/crates/librqbit/src/session_persistence/postgres.rs
@@ -114,7 +114,7 @@ impl SessionPersistenceStore for PostgresSessionStorage {
                     .shared()
                     .trackers
                     .iter()
-                    .cloned()
+                    .map(|t| t.to_string())
                     .collect::<Vec<_>>(),
             )
             .bind(

--- a/crates/librqbit/src/torrent_state/mod.rs
+++ b/crates/librqbit/src/torrent_state/mod.rs
@@ -188,7 +188,7 @@ pub struct ManagedTorrentShared {
     pub id: TorrentId,
     pub info_hash: Id20,
     pub(crate) spawner: BlockingSpawner,
-    pub trackers: HashSet<String>,
+    pub trackers: HashSet<url::Url>,
     pub peer_id: Id20,
     pub span: tracing::Span,
     pub(crate) options: ManagedTorrentOptions,

--- a/crates/rqbit/Cargo.toml
+++ b/crates/rqbit/Cargo.toml
@@ -52,6 +52,7 @@ libc = "0.2.158"
 signal-hook = "0.3.17"
 tokio-util = "0.7.11"
 gethostname = "0.5.0"
+url = "2"
 
 [dev-dependencies]
 futures = { version = "0.3" }


### PR DESCRIPTION
This adds a feature where you can have a list of trackers that are added to every torrent by default.

Usage:

```RQBIT_TRACKERS_FILENAME=~/Documents/trackers_all.txt rqbit server start ...```