### PR TITLE
watch .magnet files too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.bacon-locations
 /target
 /desktop/src-tauri/gen/
 .DS_Store


### PR DESCRIPTION
Currently only `.torrent` files are being considered when watching a folder.

This PR adds extends that functionality to `.magnet` files too.