### PR TITLE
Allow seeding for read-only files

### DIFF
--- a/crates/librqbit/src/storage/filesystem/mmap.rs
+++ b/crates/librqbit/src/storage/filesystem/mmap.rs
@@ -109,11 +109,11 @@ impl TorrentStorage for MmapFilesystemStorage {
         self.fs.init(shared, metadata)?;
         let mut mmaps = Vec::new();
         for (idx, file) in self.fs.opened_files.iter().enumerate() {
-            let fg = file.file.write();
-            let fg = fg.as_ref().context("file is None")?;
-            fg.set_len(metadata.file_infos[idx].len)
+            let mut fh = file.file_handle.write();
+            let file = &fh.as_mut().context("file is None")?.file;
+            file.set_len(metadata.file_infos[idx].len)
                 .context("mmap storage: error setting length")?;
-            let mmap = unsafe { MmapOptions::new().map_mut(fg) }.context("error mapping file")?;
+            let mmap = unsafe { MmapOptions::new().map_mut(file) }.context("error mapping file")?;
             mmaps.push(RwLock::new(mmap));
         }
 

--- a/crates/librqbit/src/storage/filesystem/opened_file.rs
+++ b/crates/librqbit/src/storage/filesystem/opened_file.rs
@@ -1,7 +1,7 @@
 use std::{
     fs::File,
+    fs::OpenOptions,
     path::PathBuf,
-    sync::atomic::{AtomicBool, Ordering},
 };
 
 use anyhow::Context;
@@ -9,63 +9,74 @@ use anyhow::Context;
 use parking_lot::RwLock;
 
 #[derive(Debug)]
+pub(crate) struct FileHandle {
+    pub file: File,
+    pub is_writeable: bool,
+}
+
+#[derive(Debug)]
 pub(crate) struct OpenedFile {
     pub filename: PathBuf,
-    pub file: RwLock<Option<File>>,
-    pub is_writeable: AtomicBool,
+    pub file_handle: RwLock<Option<FileHandle>>,
 }
 
 impl OpenedFile {
-    pub fn new(filename: PathBuf, f: File, is_writeable: bool) -> Self {
-        Self {
-            filename,
-            file: RwLock::new(Some(f)),
-            is_writeable: AtomicBool::new(is_writeable),
-        }
+    pub fn new(filename: PathBuf, file: File, is_writeable: bool) -> Self {
+        let file_handle = RwLock::new(Some(FileHandle {
+            file,
+            is_writeable,
+        }));
+        Self { filename, file_handle }
     }
 
     pub fn new_dummy() -> Self {
         Self {
             filename: PathBuf::new(),
-            file: RwLock::new(None),
-            is_writeable: AtomicBool::new(false),
+            file_handle: None.into(),
         }
     }
 
     pub fn take(&self) -> anyhow::Result<Option<File>> {
-        let mut f = self.file.write();
-        Ok(f.take())
+        let mut fh = self.file_handle.write();
+        if let Some(file_handle) = fh.take() {
+            Ok(Some(file_handle.file))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn is_writeable(&self) -> bool {
+        self.file_handle.read().as_ref().and_then(|fh| Some(fh.is_writeable)).unwrap_or(false)
     }
 
     pub fn take_clone(&self) -> anyhow::Result<Self> {
-        let f = self.take()?;
+        let file = self.take().unwrap().with_context(|| format!("error taking file for {:?}", self.filename))?;
         Ok(Self {
             filename: self.filename.clone(),
-            file: RwLock::new(f),
-            is_writeable: AtomicBool::new(self.is_writeable.load(Ordering::SeqCst)),
+            file_handle: RwLock::new(
+                Some(FileHandle {
+                    file,
+                    is_writeable: self.is_writeable(),
+                })
+            ),
         })
     }
 
     pub fn ensure_writeable(&self) -> anyhow::Result<()> {
-        match self
-            .is_writeable
-            .compare_exchange(false, true, Ordering::SeqCst, Ordering::Relaxed)
-        {
-            Ok(_) => {
-                // Updated, need to reopen writeable
-                let mut g = self.file.write();
-                let new_file = std::fs::OpenOptions::new()
+        let mut fh = self.file_handle.write();
+        if let Some(file_handle) = fh.as_mut() {
+            if !file_handle.is_writeable {
+                let new_file = OpenOptions::new()
                     .write(true)
                     .create(false)
                     .open(&self.filename)
                     .with_context(|| format!("error opening {:?} in write mode", self.filename))?;
-                *g = Some(new_file);
-            }
-            Err(_) => {
-                // Didn't update, no need to reopen
+                *file_handle = FileHandle {
+                    file: new_file,
+                    is_writeable: true,
+                };
             }
         }
-
         Ok(())
     }
 }


### PR DESCRIPTION
This is a re implementation of a previous un-merged commit: d980e295b2a9b90efe84b10115829d3774155224 for issue #136

Full disclosure; while these changes are working for me so far with version 8.0.0, I'm a complete novice at working with Rust.

Most of these changes where assisted by use of an LLM, and I'm completely fine with some one taking over and doing a complete re-write as I'm not sure I followed best practices for my implementation.

If anyone does take this on, I would recommend starting from a05fd8b30920fff1b52ac7890269988bcd584222 as it mostly contains previous changes by @ikatson from branch: [seed-read-only](/ikatson/rqbit/tree/seed-read-only)