### PR TITLE
Respect configurable listen interface for UDP tracker #381

### DIFF
--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -628,14 +628,10 @@ impl Session {
                 blocklist::Blocklist::empty()
             };
 
-            let udp_tracker_client = UdpTrackerClient::new(
-                listen_result
-                    .as_ref()
-                    .map_or((std::net::Ipv4Addr::LOCALHOST, 0).into(), |l| l.addr),
-                token.clone(),
-            )
-            .await
-            .context("error creating UDP tracker client")?;
+            let udp_tracker_client =
+                UdpTrackerClient::new(listen_result.as_ref().map(|l| l.addr), token.clone())
+                    .await
+                    .context("error creating UDP tracker client")?;
 
             let session = Arc::new(Self {
                 persistence,

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -628,10 +628,14 @@ impl Session {
                 blocklist::Blocklist::empty()
             };
 
-            let udp_tracker_client =
-                UdpTrackerClient::new(listen_result.as_ref().map(|l| l.addr), token.clone())
-                    .await
-                    .context("error creating UDP tracker client")?;
+            let udp_tracker_client = UdpTrackerClient::new(
+                listen_result
+                    .as_ref()
+                    .map_or((std::net::Ipv4Addr::UNSPECIFIED, 0).into(), |l| l.addr),
+                token.clone(),
+            )
+            .await
+            .context("error creating UDP tracker client")?;
 
             let session = Arc::new(Self {
                 persistence,

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -628,10 +628,14 @@ impl Session {
                 blocklist::Blocklist::empty()
             };
 
-            let udp_tracker_client =
-                UdpTrackerClient::new(opts.listen.unwrap_or_default().listen_addr, token.clone())
-                    .await
-                    .context("error creating UDP tracker client")?;
+            let udp_tracker_client = UdpTrackerClient::new(
+                listen_result
+                    .as_ref()
+                    .map_or((std::net::Ipv4Addr::LOCALHOST, 0).into(), |l| l.addr),
+                token.clone(),
+            )
+            .await
+            .context("error creating UDP tracker client")?;
 
             let session = Arc::new(Self {
                 persistence,

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -628,9 +628,10 @@ impl Session {
                 blocklist::Blocklist::empty()
             };
 
-            let udp_tracker_client = UdpTrackerClient::new(token.clone())
-                .await
-                .context("error creating UDP tracker client")?;
+            let udp_tracker_client =
+                UdpTrackerClient::new(opts.listen.unwrap_or_default().listen_addr, token.clone())
+                    .await
+                    .context("error creating UDP tracker client")?;
 
             let session = Arc::new(Self {
                 persistence,

--- a/crates/tracker_comms/src/tracker_comms_udp.rs
+++ b/crates/tracker_comms/src/tracker_comms_udp.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{HashMap, hash_map::Entry},
     ffi::CStr,
-    net::{Ipv4Addr, SocketAddrV4},
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -260,11 +260,8 @@ impl Drop for TransactionIdGuard<'_> {
 }
 
 impl UdpTrackerClient {
-    pub async fn new(
-        address: core::net::SocketAddr,
-        cancel_token: CancellationToken,
-    ) -> anyhow::Result<Self> {
-        let sock = tokio::net::UdpSocket::bind(address)
+    pub async fn new(addr: SocketAddr, cancel_token: CancellationToken) -> anyhow::Result<Self> {
+        let sock = tokio::net::UdpSocket::bind(addr)
             .await
             .context("error binding UDP for tracker")?;
         let client = Self {

--- a/crates/tracker_comms/src/tracker_comms_udp.rs
+++ b/crates/tracker_comms/src/tracker_comms_udp.rs
@@ -260,8 +260,11 @@ impl Drop for TransactionIdGuard<'_> {
 }
 
 impl UdpTrackerClient {
-    pub async fn new(cancel_token: CancellationToken) -> anyhow::Result<Self> {
-        let sock = tokio::net::UdpSocket::bind("0.0.0.0:0")
+    pub async fn new(
+        address: core::net::SocketAddr,
+        cancel_token: CancellationToken,
+    ) -> anyhow::Result<Self> {
+        let sock = tokio::net::UdpSocket::bind(address)
             .await
             .context("error binding UDP for tracker")?;
         let client = Self {

--- a/crates/tracker_comms/src/tracker_comms_udp.rs
+++ b/crates/tracker_comms/src/tracker_comms_udp.rs
@@ -260,11 +260,8 @@ impl Drop for TransactionIdGuard<'_> {
 }
 
 impl UdpTrackerClient {
-    pub async fn new(
-        addr: Option<SocketAddr>,
-        cancel_token: CancellationToken,
-    ) -> anyhow::Result<Self> {
-        let sock = tokio::net::UdpSocket::bind(addr.unwrap_or((Ipv4Addr::UNSPECIFIED, 0).into()))
+    pub async fn new(addr: SocketAddr, cancel_token: CancellationToken) -> anyhow::Result<Self> {
+        let sock = tokio::net::UdpSocket::bind(addr)
             .await
             .context("error binding UDP for tracker")?;
         let client = Self {

--- a/crates/tracker_comms/src/tracker_comms_udp.rs
+++ b/crates/tracker_comms/src/tracker_comms_udp.rs
@@ -260,8 +260,11 @@ impl Drop for TransactionIdGuard<'_> {
 }
 
 impl UdpTrackerClient {
-    pub async fn new(addr: SocketAddr, cancel_token: CancellationToken) -> anyhow::Result<Self> {
-        let sock = tokio::net::UdpSocket::bind(addr)
+    pub async fn new(
+        addr: Option<SocketAddr>,
+        cancel_token: CancellationToken,
+    ) -> anyhow::Result<Self> {
+        let sock = tokio::net::UdpSocket::bind(addr.unwrap_or((Ipv4Addr::UNSPECIFIED, 0).into()))
             .await
             .context("error binding UDP for tracker")?;
         let client = Self {


### PR DESCRIPTION
According to https://github.com/ikatson/rqbit/issues/381#issuecomment-2952742738

I'm new in `rqbit` but I think this implementation is correct.

I'm also not sure how to properly implement a multi-interface listener (in parallel mode) as it is typically done in other BitTorrent clients. At the top level, the daemon should run both IPv4 and IPv6 interfaces simultaneously.

P.s. this solution has not been tested; it is primarily a draft implementation. It also requires an update to the crate version upon merging, as it includes changes to method arguments.