### PR TITLE
[feature] allow creating torrents via HTTP API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,6 +388,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-extra"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45bf463831f5131b7d3c756525b305d40f1185b688565648a92e1392ca35713d"
+dependencies = [
+ "axum 0.8.4",
+ "axum-core 0.5.2",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_html_form",
+ "serde_path_to_error",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "backon"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2808,6 +2833,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum 0.8.4",
+ "axum-extra",
  "backon",
  "base64 0.22.1",
  "bincode 2.0.1",
@@ -4993,6 +5019,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "serde_html_form"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d2de91cf02bbc07cde38891769ccd5d4f073d22a40683aa4bc7a95781aaa2c4"
+dependencies = [
+ "form_urlencoded",
+ "indexmap 2.9.0",
+ "itoa 1.0.15",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/crates/librqbit/Cargo.toml
+++ b/crates/librqbit/Cargo.toml
@@ -130,6 +130,7 @@ arc-swap = "1.7.1"
 intervaltree = "0.2.7"
 async-compression = { version = "0.4.18", features = ["tokio", "gzip"] }
 librqbit-utp = { version = "0.3.0", features = ["export-metrics"] }
+axum-extra = { version = "0.10.1", features = ["query"] }
 
 [build-dependencies]
 anyhow = "1"

--- a/crates/librqbit/src/http_api/handlers/mod.rs
+++ b/crates/librqbit/src/http_api/handlers/mod.rs
@@ -122,7 +122,8 @@ pub fn make_api_router(state: ApiState) -> Router {
                 "/torrents/{id}/update_only_files",
                 post(torrents::h_torrent_action_update_only_files),
             )
-            .route("/torrents/{id}/add_peers", post(torrents::h_add_peers));
+            .route("/torrents/{id}/add_peers", post(torrents::h_add_peers))
+            .route("/torrents/create", post(torrents::h_create_torrent));
     }
 
     api_router.with_state(state)

--- a/crates/librqbit/src/http_api/handlers/torrents.rs
+++ b/crates/librqbit/src/http_api/handlers/torrents.rs
@@ -293,6 +293,13 @@ pub async fn h_create_torrent(
     axum_extra::extract::Query(opts): axum_extra::extract::Query<HttpCreateTorrentOptions>,
     body: Bytes,
 ) -> Result<impl IntoResponse> {
+    if !state.opts.allow_create {
+        return Err(ApiError::new_from_text(
+            StatusCode::FORBIDDEN,
+            "creating torrents not allowed. Enable through CLI options",
+        ));
+    }
+
     let path = std::path::Path::new(
         std::str::from_utf8(body.as_ref())
             .map_err(|_| ApiError::new_from_text(StatusCode::BAD_REQUEST, "invalid utf-8"))?,

--- a/crates/librqbit/src/http_api/handlers/torrents.rs
+++ b/crates/librqbit/src/http_api/handlers/torrents.rs
@@ -6,13 +6,16 @@ use axum::{
     response::IntoResponse,
 };
 use bytes::Bytes;
-use http::StatusCode;
+use http::{
+    HeaderMap, HeaderValue, StatusCode,
+    header::{CONTENT_DISPOSITION, CONTENT_TYPE},
+};
 use librqbit_core::magnet::Magnet;
 use serde::{Deserialize, Serialize};
 
 use super::ApiState;
 use crate::{
-    AddTorrent, ApiError, SUPPORTED_SCHEMES,
+    AddTorrent, ApiError, CreateTorrentOptions, SUPPORTED_SCHEMES,
     api::{ApiTorrentListOpts, Result, TorrentIdOrHash},
     http_api::timeout::Timeout,
     http_api_types::TorrentAddQueryParams,
@@ -265,4 +268,82 @@ pub async fn h_add_peers(
     }
 
     Ok(axum::Json(AddPeersResult { added: count }))
+}
+
+#[derive(Default, Deserialize, Debug)]
+enum CreateTorrentOutput {
+    #[default]
+    #[serde(rename = "magnet")]
+    Magnet,
+    #[serde(rename = "torrent")]
+    Torrent,
+}
+
+#[derive(Default, Deserialize, Debug)]
+pub struct HttpCreateTorrentOptions {
+    #[serde(default)]
+    output: CreateTorrentOutput,
+    #[serde(default)]
+    trackers: Vec<String>,
+    name: Option<String>,
+}
+
+pub async fn h_create_torrent(
+    State(state): State<ApiState>,
+    axum_extra::extract::Query(opts): axum_extra::extract::Query<HttpCreateTorrentOptions>,
+    body: Bytes,
+) -> Result<impl IntoResponse> {
+    let path = std::path::Path::new(
+        std::str::from_utf8(body.as_ref())
+            .map_err(|_| ApiError::new_from_text(StatusCode::BAD_REQUEST, "invalid utf-8"))?,
+    );
+
+    let create_opts = CreateTorrentOptions {
+        name: opts.name.as_deref(),
+        trackers: opts.trackers,
+        piece_length: None,
+    };
+
+    let (torrent, handle) = state
+        .api
+        .session()
+        .create_and_serve_torrent(path, create_opts)
+        .await?;
+
+    let mut headers = HeaderMap::new();
+    if let Ok(v) = HeaderValue::from_str(&handle.id().to_string()) {
+        headers.insert("torrent-id", v);
+    }
+    if let Ok(v) = HeaderValue::from_str(&torrent.info_hash().as_string()) {
+        headers.insert("torrent-info-hash", v);
+    }
+
+    match opts.output {
+        CreateTorrentOutput::Magnet => {
+            let magnet = torrent.as_magnet();
+            Ok(magnet.to_string().into_response())
+        }
+        CreateTorrentOutput::Torrent => {
+            let name = torrent
+                .as_info()
+                .info
+                .name
+                .as_ref()
+                .and_then(|b| std::str::from_utf8(b.as_ref()).ok())
+                .unwrap_or("torrent");
+
+            headers.insert(
+                CONTENT_TYPE,
+                HeaderValue::from_static("application/x-bittorrent"),
+            );
+
+            if let Ok(h) =
+                HeaderValue::from_str(&format!("attachment; filename=\"{}.torrent\"", name))
+            {
+                headers.insert(CONTENT_DISPOSITION, h);
+            }
+
+            Ok((headers, torrent.as_bytes()?).into_response())
+        }
+    }
 }

--- a/crates/librqbit/src/http_api/mod.rs
+++ b/crates/librqbit/src/http_api/mod.rs
@@ -35,6 +35,8 @@ pub struct HttpApi {
 pub struct HttpApiOptions {
     pub read_only: bool,
     pub basic_auth: Option<(String, String)>,
+    // Allow creating torrents via API.
+    pub allow_create: bool,
     #[cfg(feature = "prometheus")]
     pub prometheus_handle: Option<metrics_exporter_prometheus::PrometheusHandle>,
 }

--- a/crates/librqbit/src/tests/e2e_stream.rs
+++ b/crates/librqbit/src/tests/e2e_stream.rs
@@ -20,6 +20,7 @@ async fn e2e_stream() -> anyhow::Result<()> {
         CreateTorrentOptions {
             name: None,
             piece_length: Some(1024),
+            ..Default::default()
         },
     )
     .await?;

--- a/crates/rqbit/src/main.rs
+++ b/crates/rqbit/src/main.rs
@@ -99,6 +99,10 @@ struct Opts {
     )]
     http_api_listen_addr: SocketAddr,
 
+    /// Allow creating torrents via HTTP API
+    #[arg(long = "http-api-allow-create", env = "RQBIT_HTTP_API_ALLOW_CREATE")]
+    http_api_allow_create: bool,
+
     /// Set this flag if you want to use tokio's single threaded runtime.
     /// It MAY perform better, but the main purpose is easier debugging, as time
     /// profilers work better with this one.
@@ -841,6 +845,7 @@ async fn async_main(opts: Opts, cancel: CancellationToken) -> anyhow::Result<()>
                     Some(HttpApiOptions {
                         read_only: true,
                         basic_auth: http_api_basic_auth,
+                        allow_create: opts.http_api_allow_create,
                         ..Default::default()
                     }),
                 );


### PR DESCRIPTION
Add an API to allow creating and serving torrents

Usage:

```rqbit --http-api-allow-create server start ...```

```
POST /torrents/create[&name=...][&trackers=tracker1][&trackers=tracker2]
/path/to/serve
```