### PR TITLE
[bugfix] WebUI: padding files are not checked by default

### DIFF
--- a/crates/librqbit/webui/src/components/FileListInput.tsx
+++ b/crates/librqbit/webui/src/components/FileListInput.tsx
@@ -25,13 +25,13 @@ type FileTree = {
 
 const newFileTree = (
   torrentDetails: TorrentDetails,
-  stats: TorrentStats | null,
+  stats: TorrentStats | null
 ): FileTree => {
   const newFileTreeInner = (
     name: string,
     id: string,
     files: TorrentFileForCheckbox[],
-    depth: number,
+    depth: number
   ): FileTree => {
     let directFiles: TorrentFileForCheckbox[] = [];
     let groups: FileTree[] = [];
@@ -54,7 +54,7 @@ const newFileTree = (
 
     let sortedGroupsByName = sortBy(
       Object.entries(groupsByName),
-      ([k, _]) => k,
+      ([k, _]) => k
     );
 
     let childId = 0;
@@ -87,7 +87,7 @@ const newFileTree = (
         };
       })
       .filter((f) => f !== null),
-    0,
+    0
   );
 };
 
@@ -177,7 +177,7 @@ const FileTreeComponent: React.FC<{
           label={`${
             tree.name ? tree.name + ", " : ""
           } ${getTotalSelectedFiles()} files, ${formatBytes(
-            getTotalSelectedBytes(),
+            getTotalSelectedBytes()
           )}`}
           name={tree.id}
           onChange={handleToggleTree}
@@ -253,7 +253,7 @@ export const FileListInput: React.FC<{
 }) => {
   let fileTree = useMemo(
     () => newFileTree(torrentDetails, torrentStats),
-    [torrentDetails, torrentStats],
+    [torrentDetails, torrentStats]
   );
 
   return (

--- a/crates/librqbit/webui/src/components/modal/FileSelectionModal.tsx
+++ b/crates/librqbit/webui/src/components/modal/FileSelectionModal.tsx
@@ -39,7 +39,15 @@ export const FileSelectionModal = (props: {
 
   useEffect(() => {
     setSelectedFiles(
-      new Set(listTorrentResponse?.details.files.map((_, i) => i)),
+      new Set(
+        listTorrentResponse?.details.files.flatMap((file, idx) => {
+          if (file.attributes.padding) {
+            return [];
+          } else {
+            return [idx];
+          }
+        })
+      )
     );
     setOutputFolder(listTorrentResponse?.output_folder || "");
   }, [listTorrentResponse]);
@@ -79,7 +87,7 @@ export const FileSelectionModal = (props: {
         },
         (e) => {
           setUploadError({ text: "Error starting torrent", details: e });
-        },
+        }
       )
       .finally(() => setUploading(false));
   };


### PR DESCRIPTION
This works around one of the issues mentioned in https://github.com/ikatson/rqbit/issues/342

The proper fix should also be in the backend - so that even if you try to select padding files nothing will happen.