### PR TITLE
[feature] TCP and uTP: listen on IPv6 dualstack instead of IPv4 only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2854,6 +2854,7 @@ dependencies = [
  "librqbit-clone-to-owned",
  "librqbit-core",
  "librqbit-dht",
+ "librqbit-dualstack-sockets",
  "librqbit-peer-protocol",
  "librqbit-sha1-wrapper",
  "librqbit-tracker-comms",
@@ -2973,6 +2974,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "librqbit-dualstack-sockets"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b4f7cfae6a4b17a1d2cedaf5dad3314caa2c2a386d8544ff92696dd78089261"
+dependencies = [
+ "anyhow",
+ "socket2",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "librqbit-peer-protocol"
 version = "4.3.0"
 dependencies = [
@@ -3070,15 +3083,16 @@ dependencies = [
 
 [[package]]
 name = "librqbit-utp"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa52ae8343c358d4570542617eedebc0a133dd87c4aa45f9fa7613faf6e9666"
+checksum = "285c11847100e07908dadb148db48541165891c3e8cbde60e251873db3025615"
 dependencies = [
  "anyhow",
  "bitvec",
  "dontfrag",
  "lazy_static",
  "libc",
+ "librqbit-dualstack-sockets",
  "metrics",
  "parking_lot",
  "rand 0.9.1",

--- a/crates/librqbit/Cargo.toml
+++ b/crates/librqbit/Cargo.toml
@@ -129,8 +129,9 @@ walkdir = "2.5.0"
 arc-swap = "1.7.1"
 intervaltree = "0.2.7"
 async-compression = { version = "0.4.18", features = ["tokio", "gzip"] }
-librqbit-utp = { version = "0.3.0", features = ["export-metrics"] }
+librqbit-utp = { version = "0.4.0", features = ["export-metrics"] }
 axum-extra = { version = "0.10.1", features = ["query"] }
+librqbit-dualstack-sockets = { version = "0.1.0" }
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.61.1", features = [

--- a/crates/librqbit/src/listen.rs
+++ b/crates/librqbit/src/listen.rs
@@ -4,11 +4,9 @@ use std::{
 };
 
 use anyhow::Context;
+use librqbit_dualstack_sockets::TcpListener;
 use librqbit_utp::UtpSocketUdp;
-use tokio::{
-    io::{AsyncRead, AsyncWrite},
-    net::TcpListener,
-};
+use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
@@ -83,8 +81,7 @@ impl ListenerOptions {
             if !self.mode.tcp_enabled() {
                 return Ok::<_, anyhow::Error>(None);
             }
-            let listener = TcpListener::bind(self.listen_addr)
-                .await
+            let listener = TcpListener::bind_tcp(self.listen_addr, true)
                 .context("error starting TCP listener")?;
             info!(
                 "Listening on TCP {:?} for incoming peer connections",

--- a/crates/rqbit/src/main.rs
+++ b/crates/rqbit/src/main.rs
@@ -156,8 +156,8 @@ struct Opts {
     )]
     listen_port: u16,
 
-    /// What's the IP to listen on. Default is to listen on all interfaces.
-    #[arg(long = "listen-ip", default_value = "0.0.0.0", env = "RQBIT_LISTEN_IP")]
+    /// What's the IP to listen on. Default is to listen on all interfaces on IPv4 and IPv6.
+    #[arg(long = "listen-ip", default_value = "::", env = "RQBIT_LISTEN_IP")]
     listen_ip: IpAddr,
 
     /// If set, will try to publish the chosen port through upnp on your router.


### PR DESCRIPTION
TCP and uTP listeners now listen on dualstack IPv6 and IPv4, previously it was only IPv4