### PR TITLE
[perf] read vectored

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2978,12 +2978,12 @@ dependencies = [
 
 [[package]]
 name = "librqbit-dualstack-sockets"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbad71c623beb8e8a43e6c9c63ed9eabb11e95026d453398f9105665f2b693d"
+checksum = "32dcef67ab835bbec8360a3f207bb2036710d4e4f88ed00fcea8997cd78cfc60"
 dependencies = [
- "anyhow",
  "socket2",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -3127,22 +3127,23 @@ dependencies = [
 
 [[package]]
 name = "librqbit-utp"
-version = "0.4.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "285c11847100e07908dadb148db48541165891c3e8cbde60e251873db3025615"
+checksum = "9aa32d285517f1738177d6dc818a7456971a13c1954451760d6ee66b4f55d45d"
 dependencies = [
- "anyhow",
  "bitvec",
  "dontfrag",
  "lazy_static",
  "libc",
- "librqbit-dualstack-sockets 0.1.1",
+ "librqbit-dualstack-sockets 0.2.1",
  "metrics",
  "parking_lot",
  "rand 0.9.1",
  "ringbuf",
  "rustc-hash 2.1.1",
  "socket2",
+ "static_assertions",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-util",
  "tracing",

--- a/crates/librqbit/Cargo.toml
+++ b/crates/librqbit/Cargo.toml
@@ -130,7 +130,7 @@ walkdir = "2.5.0"
 arc-swap = "1.7.1"
 intervaltree = "0.2.7"
 async-compression = { version = "0.4.18", features = ["tokio", "gzip"] }
-librqbit-utp = { version = "0.4.0", features = ["export-metrics"] }
+librqbit-utp = { version = "0.5.2", features = ["export-metrics"] }
 axum-extra = { version = "0.10.1", features = ["query"] }
 librqbit-dualstack-sockets = { version = "0.6.2", features = ["axum"] }
 socket2 = "0.5.10"

--- a/crates/librqbit/src/lib.rs
+++ b/crates/librqbit/src/lib.rs
@@ -72,6 +72,7 @@ pub mod tracing_subscriber_config_utils;
 mod type_aliases;
 #[cfg(all(feature = "http-api", feature = "upnp-serve-adapter"))]
 pub mod upnp_server_adapter;
+mod vectored_traits;
 #[cfg(feature = "watch")]
 pub mod watch;
 

--- a/crates/librqbit/src/peer_connection.rs
+++ b/crates/librqbit/src/peer_connection.rs
@@ -28,6 +28,7 @@ use crate::{
     spawn_utils::BlockingSpawner,
     stream_connect::StreamConnector,
     type_aliases::{BoxAsyncRead, BoxAsyncWrite},
+    vectored_traits::AsyncReadVectored,
 };
 
 pub trait PeerConnectionHandler {
@@ -255,7 +256,7 @@ impl<H: PeerConnectionHandler> PeerConnection<H> {
     async fn manage_peer(
         &self,
         args: ManagePeerArgs<
-            impl tokio::io::AsyncRead + Send + Unpin,
+            impl AsyncReadVectored + Send,
             impl tokio::io::AsyncWrite + Send + Unpin,
         >,
     ) -> anyhow::Result<()> {

--- a/crates/librqbit/src/type_aliases.rs
+++ b/crates/librqbit/src/type_aliases.rs
@@ -1,9 +1,9 @@
 use std::net::SocketAddr;
 
 use futures::stream::BoxStream;
-use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::io::AsyncWrite;
 
-use crate::{file_info::FileInfo, storage::TorrentStorage};
+use crate::{file_info::FileInfo, storage::TorrentStorage, vectored_traits::AsyncReadVectored};
 
 // NOTE: Msb0 is used because that's what bittorrent protocol uses for bitfield.
 // Don't change to Lsb0 even though it might be a bit faster (in theory) on LE architectures.
@@ -19,5 +19,5 @@ pub(crate) type FilePriorities = Vec<usize>;
 pub(crate) type DiskWorkQueueItem = Box<dyn FnOnce() + Send + Sync>;
 pub(crate) type DiskWorkQueueSender = tokio::sync::mpsc::Sender<DiskWorkQueueItem>;
 
-pub(crate) type BoxAsyncRead = Box<dyn AsyncRead + Unpin + Send + 'static>;
+pub(crate) type BoxAsyncRead = Box<dyn AsyncReadVectored + Unpin + Send + 'static>;
 pub(crate) type BoxAsyncWrite = Box<dyn AsyncWrite + Unpin + Send + 'static>;

--- a/crates/librqbit/src/vectored_traits.rs
+++ b/crates/librqbit/src/vectored_traits.rs
@@ -10,6 +10,26 @@ pub trait AsyncReadVectored: AsyncRead + Unpin {
     ) -> Poll<std::io::Result<usize>>;
 }
 
+impl<T: ?Sized + AsyncReadVectored> AsyncReadVectored for &mut T {
+    fn poll_read_vectored(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        vec: &mut [IoSliceMut<'_>],
+    ) -> Poll<std::io::Result<usize>> {
+        Pin::new(&mut **self).poll_read_vectored(cx, vec)
+    }
+}
+
+impl<T: ?Sized + AsyncReadVectored> AsyncReadVectored for Box<T> {
+    fn poll_read_vectored(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        vec: &mut [IoSliceMut<'_>],
+    ) -> Poll<std::io::Result<usize>> {
+        Pin::new(&mut **self).poll_read_vectored(cx, vec)
+    }
+}
+
 pub trait AsyncReadVectoredExt {
     async fn read_vectored(&mut self, vec: &mut [IoSliceMut<'_>]) -> std::io::Result<usize>;
 }

--- a/crates/librqbit/src/vectored_traits.rs
+++ b/crates/librqbit/src/vectored_traits.rs
@@ -1,0 +1,86 @@
+use std::{future::poll_fn, io::IoSliceMut, pin::Pin, task::Poll};
+
+use tokio::io::AsyncRead;
+
+pub trait AsyncReadVectored: AsyncRead + Unpin {
+    fn poll_read_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        vec: &mut [IoSliceMut<'_>],
+    ) -> Poll<std::io::Result<usize>>;
+}
+
+pub trait AsyncReadVectoredExt {
+    async fn read_vectored(&mut self, vec: &mut [IoSliceMut<'_>]) -> std::io::Result<usize>;
+}
+
+impl<T: AsyncReadVectored> AsyncReadVectoredExt for T {
+    async fn read_vectored(&mut self, vec: &mut [IoSliceMut<'_>]) -> std::io::Result<usize> {
+        poll_fn(|cx| Pin::new(&mut *self).poll_read_vectored(cx, vec)).await
+    }
+}
+
+impl AsyncReadVectored for tokio::net::tcp::OwnedReadHalf {
+    fn poll_read_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        vec: &mut [IoSliceMut<'_>],
+    ) -> Poll<std::io::Result<usize>> {
+        let this = self.get_mut();
+        loop {
+            std::task::ready!(this.as_ref().poll_read_ready(cx)?);
+            match this.try_read_vectored(vec) {
+                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    continue;
+                }
+                res => return Poll::Ready(res),
+            }
+        }
+    }
+}
+
+pub struct AsyncReadToVectoredCompat<T>(T);
+
+impl<T: AsyncRead + Unpin> AsyncRead for AsyncReadToVectoredCompat<T> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.get_mut().0).poll_read(cx, buf)
+    }
+}
+
+impl<T: AsyncRead + Unpin> AsyncReadVectored for AsyncReadToVectoredCompat<T> {
+    // async fn read_vectored(&mut self, vec: &mut [IoSliceMut<'_>]) -> std::io::Result<usize> {
+    //     let first_non_empty = match vec.iter_mut().find(|s| !s.is_empty()) {
+    //         Some(s) => &mut **s,
+    //         None => return Ok(0),
+    //     };
+    //     self.read(first_non_empty).await
+    // }
+
+    fn poll_read_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        vec: &mut [IoSliceMut<'_>],
+    ) -> Poll<std::io::Result<usize>> {
+        let first_non_empty = match vec.iter_mut().find(|s| !s.is_empty()) {
+            Some(s) => &mut **s,
+            None => return Poll::Ready(Ok(0)),
+        };
+        let mut rbuf = tokio::io::ReadBuf::new(first_non_empty);
+        std::task::ready!(self.poll_read(cx, &mut rbuf)?);
+        Poll::Ready(Ok(rbuf.filled().len()))
+    }
+}
+
+pub trait AsyncReadVectoredIntoCompat: Sized {
+    fn into_vectored_compat(self) -> AsyncReadToVectoredCompat<Self>;
+}
+
+impl<T: AsyncRead + Unpin + Sized> AsyncReadVectoredIntoCompat for T {
+    fn into_vectored_compat(self) -> AsyncReadToVectoredCompat<Self> {
+        AsyncReadToVectoredCompat(self)
+    }
+}


### PR DESCRIPTION
use preadv (vectored_read) when reading from tokio sockets into our ring buffer.