### PR TITLE
[fix] upnp + IPv6: disable link-local responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2851,7 +2851,7 @@ dependencies = [
  "librqbit-clone-to-owned",
  "librqbit-core",
  "librqbit-dht",
- "librqbit-dualstack-sockets 0.6.3",
+ "librqbit-dualstack-sockets 0.6.4",
  "librqbit-lsd",
  "librqbit-peer-protocol",
  "librqbit-sha1-wrapper",
@@ -2964,7 +2964,7 @@ dependencies = [
  "librqbit-buffers",
  "librqbit-clone-to-owned",
  "librqbit-core",
- "librqbit-dualstack-sockets 0.6.3",
+ "librqbit-dualstack-sockets 0.6.4",
  "parking_lot",
  "rand 0.9.1",
  "serde",
@@ -2990,9 +2990,9 @@ dependencies = [
 
 [[package]]
 name = "librqbit-dualstack-sockets"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a0d2e4869ef8d016a7893d840a22cbf56b9aa321400bace56bc64ad01ecab56"
+checksum = "441b43e269e8a5dda2c137cb551471f1960c780f5fd5f840f7152fe3448319ba"
 dependencies = [
  "axum 0.8.4",
  "backon",
@@ -3015,7 +3015,7 @@ dependencies = [
  "governor",
  "httparse",
  "librqbit-core",
- "librqbit-dualstack-sockets 0.6.3",
+ "librqbit-dualstack-sockets 0.6.4",
  "librqbit-sha1-wrapper",
  "parking_lot",
  "rand 0.9.1",
@@ -3064,7 +3064,7 @@ dependencies = [
  "librqbit-bencode",
  "librqbit-buffers",
  "librqbit-core",
- "librqbit-dualstack-sockets 0.6.3",
+ "librqbit-dualstack-sockets 0.6.4",
  "parking_lot",
  "rand 0.9.1",
  "reqwest",
@@ -3107,7 +3107,7 @@ dependencies = [
  "http",
  "httparse",
  "librqbit-core",
- "librqbit-dualstack-sockets 0.6.3",
+ "librqbit-dualstack-sockets 0.6.4",
  "librqbit-sha1-wrapper",
  "librqbit-upnp",
  "mime_guess",
@@ -4821,7 +4821,7 @@ dependencies = [
  "gethostname",
  "libc",
  "librqbit",
- "librqbit-dualstack-sockets 0.6.3",
+ "librqbit-dualstack-sockets 0.6.4",
  "librqbit-upnp-serve",
  "metrics-exporter-prometheus",
  "openssl",
@@ -4849,7 +4849,7 @@ dependencies = [
  "gethostname",
  "http",
  "librqbit",
- "librqbit-dualstack-sockets 0.6.3",
+ "librqbit-dualstack-sockets 0.6.4",
  "metrics-exporter-prometheus",
  "parking_lot",
  "serde",

--- a/crates/dht/Cargo.toml
+++ b/crates/dht/Cargo.toml
@@ -42,7 +42,7 @@ librqbit-core = { path = "../librqbit_core", default-features = false, version =
 chrono = { version = "0.4.31", features = ["serde"] }
 tokio-util = "0.7.10"
 bytes = "1.7.1"
-librqbit-dualstack-sockets = { version = "0.6.3" }
+librqbit-dualstack-sockets = "0.6.4"
 
 [dev-dependencies]
 tracing-subscriber = "0.3"

--- a/crates/librqbit/Cargo.toml
+++ b/crates/librqbit/Cargo.toml
@@ -132,7 +132,7 @@ intervaltree = "0.2.7"
 async-compression = { version = "0.4.18", features = ["tokio", "gzip"] }
 librqbit-utp = { version = "0.5.3", features = ["export-metrics"] }
 axum-extra = { version = "0.10.1", features = ["query"] }
-librqbit-dualstack-sockets = { version = "0.6.2", features = ["axum"] }
+librqbit-dualstack-sockets = { version = "0.6.4", features = ["axum"] }
 socket2 = "0.5.10"
 nix = { version = "0.30.1", features = ["uio"] }
 

--- a/crates/librqbit_lsd/Cargo.toml
+++ b/crates/librqbit_lsd/Cargo.toml
@@ -13,7 +13,7 @@ sha1-ring = ["librqbit-sha1-wrapper/sha1-ring", "librqbit-core/sha1-ring"]
 
 [dependencies]
 anyhow = "1.0.98"
-librqbit-dualstack-sockets = { version = "0.6.3" }
+librqbit-dualstack-sockets = "0.6.4"
 tokio = { version = "1.45.1", features = ["time"] }
 tokio-util = "0.7.15"
 librqbit-sha1-wrapper = { path = "../sha1w", version = "4", default-features = false }

--- a/crates/rqbit/Cargo.toml
+++ b/crates/rqbit/Cargo.toml
@@ -55,7 +55,7 @@ signal-hook = "0.3.17"
 tokio-util = "0.7.11"
 gethostname = "1"
 url = "2"
-librqbit-dualstack-sockets = { version = "0.6.3" }
+librqbit-dualstack-sockets = "0.6.4"
 
 [dev-dependencies]
 futures = { version = "0.3" }

--- a/crates/tracker_comms/Cargo.toml
+++ b/crates/tracker_comms/Cargo.toml
@@ -34,7 +34,7 @@ bencode = { path = "../bencode", default-features = false, package = "librqbit-b
 url = { version = "2", default-features = false }
 parking_lot = "0.12.3"
 tokio-util = "0.7.13"
-librqbit-dualstack-sockets = { version = "0.6.3" }
+librqbit-dualstack-sockets = "0.6.4"
 backon = "1.5.1"
 itertools = "0.14.0"
 serde_with = "3.13.0"

--- a/crates/upnp-serve/Cargo.toml
+++ b/crates/upnp-serve/Cargo.toml
@@ -38,7 +38,7 @@ reqwest = { version = "0.12.7", default-features = false }
 quick-xml = { version = "0.37.1", features = ["serialize"] }
 network-interface = "2.0.0"
 futures = "0.3.30"
-librqbit-dualstack-sockets = { version = "0.6.3" }
+librqbit-dualstack-sockets = "0.6.4"
 
 [dev-dependencies]
 tracing-subscriber = "0.3.18"

--- a/crates/upnp-serve/src/services/content_directory.rs
+++ b/crates/upnp-serve/src/services/content_directory.rs
@@ -279,7 +279,7 @@ pub(crate) async fn http_handler(
             let http_hostname = headers
                 .get("host")
                 .and_then(|h| std::str::from_utf8(h.as_bytes()).ok())
-                .and_then(|h| h.split(':').next());
+                .and_then(|h| h.rsplit_once(':').map(|(host, _)| host));
             let http_hostname = match http_hostname {
                 Some(h) => h,
                 None => return StatusCode::BAD_REQUEST.into_response(),

--- a/crates/upnp-serve/src/services/content_directory.rs
+++ b/crates/upnp-serve/src/services/content_directory.rs
@@ -276,11 +276,10 @@ pub(crate) async fn http_handler(
     };
     match action.as_ref() {
         SOAP_ACTION_CONTENT_DIRECTORY_BROWSE => {
-            let http_hostname = headers
+            let http_host = headers
                 .get("host")
-                .and_then(|h| std::str::from_utf8(h.as_bytes()).ok())
-                .and_then(|h| h.rsplit_once(':').map(|(host, _)| host));
-            let http_hostname = match http_hostname {
+                .and_then(|h| std::str::from_utf8(h.as_bytes()).ok());
+            let http_hostname = match http_host {
                 Some(h) => h,
                 None => return StatusCode::BAD_REQUEST.into_response(),
             };

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -34,7 +34,7 @@ parking_lot = "0.12.1"
 gethostname = "1"
 tauri-plugin-shell = "2"
 metrics-exporter-prometheus = { version = "0.16", default-features = false }
-librqbit-dualstack-sockets = { version = "0.6.3" }
+librqbit-dualstack-sockets = "0.6.4"
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem


### PR DESCRIPTION
VLC doesn't seem to work with link-local IPv6 addresses. If it happens to query rqbit through link-local first, it then won't be able to play the resulting streams.
Thus disabled it as it's extremely niche, and interferes with normal operation