### PR TITLE
[refactor] bencode: remove the hack for info hash computation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3019,7 +3019,6 @@ dependencies = [
  "bytes",
  "librqbit-buffers",
  "librqbit-clone-to-owned",
- "librqbit-sha1-wrapper",
  "serde",
  "thiserror 2.0.12",
 ]
@@ -3054,6 +3053,7 @@ dependencies = [
  "librqbit-bencode",
  "librqbit-buffers",
  "librqbit-clone-to-owned",
+ "librqbit-sha1-wrapper",
  "parking_lot",
  "rand 0.9.1",
  "serde",

--- a/crates/bencode/Cargo.toml
+++ b/crates/bencode/Cargo.toml
@@ -8,17 +8,10 @@ documentation = "https://docs.rs/librqbit-bencode"
 repository = "https://github.com/ikatson/rqbit"
 readme = "README.md"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-[features]
-default = ["sha1-crypto-hash"]
-sha1-crypto-hash = ["sha1w/sha1-crypto-hash"]
-sha1-ring = ["sha1w/sha1-ring"]
-
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 buffers = { path = "../buffers", package = "librqbit-buffers", version = "4.2" }
 clone_to_owned = { path = "../clone_to_owned", package = "librqbit-clone-to-owned", version = "3" }
-sha1w = { path = "../sha1w", default-features = false, optional = true, package = "librqbit-sha1-wrapper", version = "4.1" }
 bytes = "1.7.1"
 atoi = "2.0.0"
 thiserror = "2.0.12"

--- a/crates/bencode/src/deserialize.rs
+++ b/crates/bencode/src/deserialize.rs
@@ -1,6 +1,11 @@
+use std::marker::PhantomData;
+
 use arrayvec::ArrayVec;
 use atoi::FromRadix10;
 use buffers::ByteBuf;
+use serde::{Deserialize, forward_to_deserialize_any};
+
+use crate::raw_value::TAG;
 
 pub struct BencodeDeserializer<'de> {
     buf: &'de [u8],
@@ -329,12 +334,18 @@ impl<'de> serde::de::Deserializer<'de> for &mut BencodeDeserializer<'de> {
 
     fn deserialize_newtype_struct<V>(
         self,
-        _name: &'static str,
-        _visitor: V,
+        name: &'static str,
+        visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
+        if name == TAG {
+            return visitor.visit_seq(WithRawValueDeserializer {
+                de: self,
+                buf: None,
+            });
+        }
         Err(Error::NotSupported)
     }
 
@@ -481,12 +492,121 @@ impl<'de> serde::de::SeqAccess<'de> for SeqAccess<'_, 'de> {
     }
 }
 
+struct WithRawValueDeserializer<'a, 'de> {
+    de: &'a mut BencodeDeserializer<'de>,
+    buf: Option<&'de [u8]>,
+}
+
+impl<'a, 'de> serde::de::SeqAccess<'de> for WithRawValueDeserializer<'a, 'de> {
+    type Error = Error;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+    where
+        T: serde::de::DeserializeSeed<'de>,
+    {
+        let buf = match self.buf {
+            None => {
+                let buf_before = self.de.buf;
+                let el = seed.deserialize(&mut *self.de)?;
+                let buf_after = self.de.buf;
+                let consumed = buf_before.len() - buf_after.len();
+                self.buf = Some(&buf_before[..consumed]);
+                return Ok(Some(el));
+            }
+            Some(buf) => buf,
+        };
+
+        struct RawValueDe<'a>(&'a [u8]);
+
+        impl<'de> serde::de::Deserializer<'de> for RawValueDe<'de> {
+            type Error = Error;
+
+            fn deserialize_any<V>(self, _: V) -> Result<V::Value, Self::Error>
+            where
+                V: serde::de::Visitor<'de>,
+            {
+                Err(Error::InvalidValue)
+            }
+
+            fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+            where
+                V: serde::de::Visitor<'de>,
+            {
+                visitor.visit_borrowed_bytes(self.0)
+            }
+
+            forward_to_deserialize_any! {
+                bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+                byte_buf option unit unit_struct newtype_struct seq tuple
+                tuple_struct map struct enum identifier ignored_any
+            }
+        }
+
+        let buf = seed.deserialize(RawValueDe(buf))?;
+        Ok(Some(buf))
+    }
+}
+
+#[derive(Debug)]
+pub struct WithRawBytes<T, Buf> {
+    pub data: T,
+    pub raw_bytes: Buf,
+}
+
+impl<'de, T, Buf> Deserialize<'de> for WithRawBytes<T, Buf>
+where
+    T: Deserialize<'de>,
+    Buf: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor<T, Buf>(PhantomData<(T, Buf)>);
+        impl<'de, T, Buf> serde::de::Visitor<'de> for Visitor<T, Buf>
+        where
+            T: Deserialize<'de>,
+            Buf: Deserialize<'de>,
+        {
+            type Value = WithRawBytes<T, Buf>;
+
+            fn expecting(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+                fmt.write_str("WithRawBytes only works with librqbit_bencode")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let data: T = match seq.next_element()? {
+                    Some(v) => v,
+                    None => {
+                        return Err(<A::Error as serde::de::Error>::custom(
+                            "expecting T as first element",
+                        ));
+                    }
+                };
+                let raw_bytes: Buf = match seq.next_element()? {
+                    Some(b) => b,
+                    None => {
+                        return Err(<A::Error as serde::de::Error>::custom(
+                            "expecting buf as second element",
+                        ));
+                    }
+                };
+                Ok(WithRawBytes { data, raw_bytes })
+            }
+        }
+        deserializer.deserialize_newtype_struct(TAG, Visitor(Default::default()))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use buffers::ByteBuf;
     use serde::Deserialize;
 
-    use crate::from_bytes;
+    use crate::{WithRawBytes, from_bytes};
 
     #[test]
     fn test_deserialize_error_context() {
@@ -567,5 +687,24 @@ mod tests {
             from_bytes::<Vec<ByteBuf<'_>>>(b"l5:hello2:mee").unwrap(),
             vec![ByteBuf(b"hello"), ByteBuf(b"me")]
         );
+    }
+
+    #[test]
+    fn test_with_raw_bytes() {
+        #[derive(Deserialize, Debug)]
+        struct TorrentInfo<'a> {
+            #[serde(borrow)]
+            name: ByteBuf<'a>,
+        }
+
+        #[derive(Deserialize, Debug)]
+        struct Torrent<'a> {
+            #[serde(borrow)]
+            info: WithRawBytes<TorrentInfo<'a>, ByteBuf<'a>>,
+        }
+
+        let t: Torrent = from_bytes(&b"d4:infod4:name5:helloee"[..]).unwrap();
+        assert_eq!(t.info.data.name, ByteBuf(b"hello"));
+        assert_eq!(t.info.raw_bytes, ByteBuf(b"d4:name5:helloe"));
     }
 }

--- a/crates/bencode/src/lib.rs
+++ b/crates/bencode/src/lib.rs
@@ -6,7 +6,7 @@ mod serialize;
 pub use bencode_value::*;
 pub use deserialize::{
     BencodeDeserializer, Error as DeserializeError,
-    ErrorWithContext as DeserializeErrorWithContext, from_bytes,
+    ErrorWithContext as DeserializeErrorWithContext, WithRawBytes, from_bytes,
 };
 pub use serialize::{Error as SerializeError, bencode_serialize_to_writer};
 

--- a/crates/dht/Cargo.toml
+++ b/crates/dht/Cargo.toml
@@ -8,14 +8,6 @@ documentation = "https://docs.rs/librqbit-dht"
 repository = "https://github.com/ikatson/rqbit"
 readme = "README.md"
 
-[features]
-default = ["sha1-crypto-hash"]
-sha1-crypto-hash = [
-    "bencode/sha1-crypto-hash",
-    "librqbit-core/sha1-crypto-hash",
-]
-sha1-ring = ["bencode/sha1-ring", "librqbit-core/sha1-ring"]
-
 [dependencies]
 tokio = { version = "1", features = [
     "macros",

--- a/crates/librqbit/Cargo.toml
+++ b/crates/librqbit/Cargo.toml
@@ -26,12 +26,7 @@ default-tls = [
     "librqbit-core/sha1-crypto-hash",
 ]
 prometheus = ["metrics-exporter-prometheus"]
-rust-tls = [
-    "reqwest/rustls-tls",
-    "sha1w/sha1-ring",
-    "sha1w/sha1-ring",
-    "librqbit-core/sha1-ring",
-]
+rust-tls = ["reqwest/rustls-tls", "sha1w/sha1-ring", "librqbit-core/sha1-ring"]
 storage_middleware = ["lru"]
 storage_examples = []
 tracing-subscriber-utils = ["tracing-subscriber"]

--- a/crates/librqbit/Cargo.toml
+++ b/crates/librqbit/Cargo.toml
@@ -23,7 +23,6 @@ timed_existence = []
 default-tls = [
     "reqwest/default-tls",
     "sha1w/sha1-crypto-hash",
-    "bencode/sha1-crypto-hash",
     "librqbit-core/sha1-crypto-hash",
 ]
 prometheus = ["metrics-exporter-prometheus"]
@@ -31,7 +30,6 @@ rust-tls = [
     "reqwest/rustls-tls",
     "sha1w/sha1-ring",
     "sha1w/sha1-ring",
-    "bencode/sha1-ring",
     "librqbit-core/sha1-ring",
 ]
 storage_middleware = ["lru"]

--- a/crates/librqbit/src/create_torrent_file.rs
+++ b/crates/librqbit/src/create_torrent_file.rs
@@ -240,7 +240,6 @@ pub async fn create_torrent<'a>(
 
 #[cfg(test)]
 mod tests {
-    use buffers::{ByteBuf, ByteBufOwned};
     use librqbit_core::torrent_metainfo::torrent_from_bytes;
 
     use crate::create_torrent;
@@ -260,10 +259,7 @@ mod tests {
 
         let bytes = torrent.as_bytes().unwrap();
 
-        let deserialized = torrent_from_bytes::<ByteBuf>(&bytes).unwrap();
-        assert_eq!(torrent.info_hash(), deserialized.info_hash);
-
-        let deserialized = torrent_from_bytes::<ByteBufOwned>(&bytes).unwrap();
+        let deserialized = torrent_from_bytes(&bytes).unwrap();
         assert_eq!(torrent.info_hash(), deserialized.info_hash);
     }
 }

--- a/crates/librqbit/src/http_api/handlers/torrents.rs
+++ b/crates/librqbit/src/http_api/handlers/torrents.rs
@@ -334,6 +334,7 @@ pub async fn h_create_torrent(
             let name = torrent
                 .as_info()
                 .info
+                .data
                 .name
                 .as_ref()
                 .and_then(|b| std::str::from_utf8(b.as_ref()).ok())

--- a/crates/librqbit/src/read_buf.rs
+++ b/crates/librqbit/src/read_buf.rs
@@ -337,7 +337,7 @@ mod tests {
 
             for piece in 0..ITERATIONS {
                 let msg = rb
-                    .read_message(&mut reader, Duration::from_millis(10))
+                    .read_message(&mut reader, Duration::from_millis(100))
                     .await
                     .unwrap();
                 let utdata = match msg {

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -79,7 +79,7 @@ fn torrent_from_bytes(bytes: Bytes) -> anyhow::Result<ParsedTorrentFile> {
         "all fields in torrent: {:#?}",
         bencode::dyn_from_bytes::<ByteBuf>(&bytes)
     );
-    let parsed = librqbit_core::torrent_metainfo::torrent_from_bytes_ext::<ByteBuf>(&bytes)?;
+    let parsed = librqbit_core::torrent_metainfo::torrent_from_bytes(&bytes)?;
     Ok(ParsedTorrentFile {
         meta: parsed.clone_to_owned(Some(&bytes)),
         torrent_bytes: bytes,
@@ -1653,7 +1653,7 @@ impl tracker_comms::TorrentStatsProvider for PeerRxTorrentInfo {
 mod tests {
     use buffers::ByteBuf;
     use itertools::Itertools;
-    use librqbit_core::torrent_metainfo::{TorrentMetaV1, torrent_from_bytes_ext};
+    use librqbit_core::torrent_metainfo::{TorrentMetaV1, torrent_from_bytes};
 
     use super::torrent_file_from_info_bytes;
 
@@ -1668,13 +1668,12 @@ mod tests {
 
         let orig_full_torrent =
             include_bytes!("../resources/ubuntu-21.04-desktop-amd64.iso.torrent");
-        let parsed = torrent_from_bytes_ext::<ByteBuf>(&orig_full_torrent[..]).unwrap();
+        let parsed = torrent_from_bytes(&orig_full_torrent[..]).unwrap();
         let parsed_trackers = get_trackers(&parsed);
 
         let generated_torrent =
             torrent_file_from_info_bytes(parsed.info.raw_bytes.as_ref(), &parsed_trackers).unwrap();
-        let generated_parsed =
-            torrent_from_bytes_ext::<ByteBuf>(generated_torrent.as_ref()).unwrap();
+        let generated_parsed = torrent_from_bytes(generated_torrent.as_ref()).unwrap();
         assert_eq!(parsed.info_hash, generated_parsed.info_hash);
         assert_eq!(parsed.info, generated_parsed.info);
         assert_eq!(parsed_trackers, get_trackers(&generated_parsed));

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -70,8 +70,7 @@ pub const SUPPORTED_SCHEMES: [&str; 3] = ["http:", "https:", "magnet:"];
 pub type TorrentId = usize;
 
 struct ParsedTorrentFile {
-    info: TorrentMetaV1Owned,
-    info_bytes: Bytes,
+    meta: TorrentMetaV1Owned,
     torrent_bytes: Bytes,
 }
 
@@ -82,8 +81,7 @@ fn torrent_from_bytes(bytes: Bytes) -> anyhow::Result<ParsedTorrentFile> {
     );
     let parsed = librqbit_core::torrent_metainfo::torrent_from_bytes_ext::<ByteBuf>(&bytes)?;
     Ok(ParsedTorrentFile {
-        info: parsed.meta.clone_to_owned(Some(&bytes)),
-        info_bytes: parsed.info_bytes.clone_to_owned(Some(&bytes)).0,
+        meta: parsed.clone_to_owned(Some(&bytes)),
         torrent_bytes: bytes,
     })
 }
@@ -994,7 +992,7 @@ impl Session {
                     };
 
                     let mut trackers = torrent
-                        .info
+                        .meta
                         .iter_announce()
                         .unique()
                         .filter_map(|tracker| match std::str::from_utf8(tracker.as_ref()) {
@@ -1010,11 +1008,11 @@ impl Session {
                     }
 
                     InternalAddResult {
-                        info_hash: torrent.info.info_hash,
+                        info_hash: torrent.meta.info_hash,
                         metadata: Some(TorrentMetadata::new(
-                            torrent.info.info,
+                            torrent.meta.info.data,
                             torrent.torrent_bytes,
-                            torrent.info_bytes,
+                            torrent.meta.info.raw_bytes.0,
                         )?),
                         trackers: trackers
                             .iter()
@@ -1671,15 +1669,14 @@ mod tests {
         let orig_full_torrent =
             include_bytes!("../resources/ubuntu-21.04-desktop-amd64.iso.torrent");
         let parsed = torrent_from_bytes_ext::<ByteBuf>(&orig_full_torrent[..]).unwrap();
-        let parsed_trackers = get_trackers(&parsed.meta);
+        let parsed_trackers = get_trackers(&parsed);
 
         let generated_torrent =
-            torrent_file_from_info_bytes(parsed.info_bytes.as_ref(), &parsed_trackers).unwrap();
+            torrent_file_from_info_bytes(parsed.info.raw_bytes.as_ref(), &parsed_trackers).unwrap();
         let generated_parsed =
             torrent_from_bytes_ext::<ByteBuf>(generated_torrent.as_ref()).unwrap();
-        assert_eq!(parsed.meta.info_hash, generated_parsed.meta.info_hash);
-        assert_eq!(parsed.meta.info, generated_parsed.meta.info);
-        assert_eq!(parsed.info_bytes, generated_parsed.info_bytes);
-        assert_eq!(parsed_trackers, get_trackers(&generated_parsed.meta));
+        assert_eq!(parsed.info_hash, generated_parsed.info_hash);
+        assert_eq!(parsed.info, generated_parsed.info);
+        assert_eq!(parsed_trackers, get_trackers(&generated_parsed));
     }
 }

--- a/crates/librqbit/src/upnp_server_adapter.rs
+++ b/crates/librqbit/src/upnp_server_adapter.rs
@@ -403,28 +403,31 @@ mod tests {
         TorrentMetaV1Owned {
             announce: None,
             announce_list: vec![],
-            info: TorrentMetaV1Info {
-                name: name.map(|n| n.as_bytes().into()),
-                pieces: b""[..].into(),
-                piece_length: 1,
-                length: None,
-                md5sum: None,
-                files: Some(
-                    files
-                        .iter()
-                        .map(|f| TorrentMetaV1File {
-                            length: 1,
-                            path: f.split("/").map(|f| f.as_bytes().into()).collect(),
-                            attr: None,
-                            sha1: None,
-                            symlink_path: None,
-                        })
-                        .collect(),
-                ),
-                attr: None,
-                sha1: None,
-                symlink_path: None,
-                private: false,
+            info: bencode::WithRawBytes {
+                data: TorrentMetaV1Info {
+                    name: name.map(|n| n.as_bytes().into()),
+                    pieces: b""[..].into(),
+                    piece_length: 1,
+                    length: None,
+                    md5sum: None,
+                    files: Some(
+                        files
+                            .iter()
+                            .map(|f| TorrentMetaV1File {
+                                length: 1,
+                                path: f.split("/").map(|f| f.as_bytes().into()).collect(),
+                                attr: None,
+                                sha1: None,
+                                symlink_path: None,
+                            })
+                            .collect(),
+                    ),
+                    attr: None,
+                    sha1: None,
+                    symlink_path: None,
+                    private: false,
+                },
+                raw_bytes: Default::default(),
             },
             comment: None,
             created_by: None,
@@ -439,7 +442,7 @@ mod tests {
     #[test]
     fn test_torrent_file_tree_single() -> anyhow::Result<()> {
         let t = create_torrent(Some("test t"), &["file0"]);
-        let tree = TorrentFileTree::build(0, &t.info)?;
+        let tree = TorrentFileTree::build(0, &t.info.data)?;
         assert_eq!(
             &tree.nodes,
             &[TorrentFileTreeNode {
@@ -456,7 +459,7 @@ mod tests {
     #[test]
     fn test_torrent_file_tree_flat() -> anyhow::Result<()> {
         let t = create_torrent(Some("test t"), &["file0", "file1"]);
-        let tree = TorrentFileTree::build(0, &t.info)?;
+        let tree = TorrentFileTree::build(0, &t.info.data)?;
         assert_eq!(
             &tree.nodes,
             &[
@@ -490,7 +493,7 @@ mod tests {
             Some("test t"),
             &["file0", "file1", "dir0/file2", "dir0/dir1/file3"],
         );
-        let tree = TorrentFileTree::build(0, &t.info)?;
+        let tree = TorrentFileTree::build(0, &t.info.data)?;
         assert_eq!(
             &tree.nodes,
             &[

--- a/crates/librqbit/src/watch.rs
+++ b/crates/librqbit/src/watch.rs
@@ -6,7 +6,6 @@ use std::{
 
 use crate::Magnet;
 use anyhow::{Context, bail};
-use buffers::ByteBuf;
 use librqbit_core::torrent_metainfo::torrent_from_bytes;
 use notify::Watcher;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
@@ -104,7 +103,7 @@ fn watch_thread(
             .context("error opening")?
             .read_to_end(&mut buf)
             .context("error reading")?;
-        torrent_from_bytes::<ByteBuf>(&buf).context("invalid .torrent file")?;
+        torrent_from_bytes(&buf).context("invalid .torrent file")?;
         Ok(AddTorrent::from_bytes(buf))
     }
 

--- a/crates/librqbit_core/Cargo.toml
+++ b/crates/librqbit_core/Cargo.toml
@@ -11,8 +11,8 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 default = ["sha1-crypto-hash"]
-sha1-crypto-hash = ["bencode/sha1-crypto-hash"]
-sha1-ring = ["bencode/sha1-ring"]
+sha1-crypto-hash = ["sha1w/sha1-crypto-hash"]
+sha1-ring = ["sha1w/sha1-ring"]
 
 [dependencies]
 tracing = "0.1.40"
@@ -26,6 +26,7 @@ serde = { version = "1", features = ["derive"] }
 buffers = { path = "../buffers", package = "librqbit-buffers", version = "4.2" }
 bencode = { path = "../bencode", default-features = false, package = "librqbit-bencode", version = "3.1" }
 clone_to_owned = { path = "../clone_to_owned", package = "librqbit-clone-to-owned", version = "3" }
+sha1w = { path = "../sha1w", package = "librqbit-sha1-wrapper", version = "4.1", default-features = false }
 itertools = "0.14"
 directories = "6"
 tokio-util = "0.7.10"

--- a/crates/librqbit_lsd/Cargo.toml
+++ b/crates/librqbit_lsd/Cargo.toml
@@ -3,14 +3,6 @@ name = "librqbit-lsd"
 version = "0.1.0"
 edition = "2024"
 
-[features]
-default = ["sha1-crypto-hash"]
-sha1-crypto-hash = [
-    "librqbit-sha1-wrapper/sha1-crypto-hash",
-    "librqbit-core/sha1-crypto-hash",
-]
-sha1-ring = ["librqbit-sha1-wrapper/sha1-ring", "librqbit-core/sha1-ring"]
-
 [dependencies]
 anyhow = "1.0.98"
 librqbit-dualstack-sockets = "0.6.4"

--- a/crates/librqbit_lsd/Cargo.toml
+++ b/crates/librqbit_lsd/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 anyhow = "1.0.98"
-librqbit-dualstack-sockets = "0.6.4"
+librqbit-dualstack-sockets = "0.6.5"
 tokio = { version = "1.45.1", features = ["time"] }
 tokio-util = "0.7.15"
 librqbit-sha1-wrapper = { path = "../sha1w", version = "4", default-features = false }

--- a/crates/peer_binary_protocol/Cargo.toml
+++ b/crates/peer_binary_protocol/Cargo.toml
@@ -8,14 +8,6 @@ documentation = "https://docs.rs/librqbit-peer-protocol"
 repository = "https://github.com/ikatson/rqbit"
 readme = "README.md"
 
-[features]
-default = ["sha1-crypto-hash"]
-sha1-crypto-hash = [
-    "bencode/sha1-crypto-hash",
-    "librqbit-core/sha1-crypto-hash",
-]
-sha1-ring = ["bencode/sha1-ring", "librqbit-core/sha1-ring"]
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/crates/tracker_comms/Cargo.toml
+++ b/crates/tracker_comms/Cargo.toml
@@ -9,14 +9,6 @@ repository = "https://github.com/ikatson/rqbit"
 readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-[features]
-default = ["sha1-crypto-hash"]
-sha1-crypto-hash = [
-    "bencode/sha1-crypto-hash",
-    "librqbit-core/sha1-crypto-hash",
-]
-sha1-ring = ["bencode/sha1-ring", "librqbit-core/sha1-ring"]
-
 [dependencies]
 tokio = "1"
 anyhow = "1"

--- a/crates/upnp-serve/Cargo.toml
+++ b/crates/upnp-serve/Cargo.toml
@@ -8,14 +8,6 @@ documentation = "https://docs.rs/librqbit-upnp-serve"
 repository = "https://github.com/ikatson/rqbit"
 readme = "README.md"
 
-[features]
-default = ["sha1-crypto-hash"]
-sha1-crypto-hash = [
-    "librqbit-sha1-wrapper/sha1-crypto-hash",
-    "librqbit-core/sha1-crypto-hash",
-]
-sha1-ring = ["librqbit-sha1-wrapper/sha1-ring", "librqbit-core/sha1-ring"]
-
 [dependencies]
 anyhow = "1.0.86"
 axum = { version = "0.8", features = ["tokio"] }


### PR DESCRIPTION
This removes a nasty hack in bencode crate where we needed to compute torrent info_hash from the serializer.

Now it's a special type WithRawValue that contains both the inner data and the raw bytes.