### PR TITLE
[perf] decrease CPU usage due to disabling tracing in several places

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /AGENTS.md
 /CLAUDE.md
 /GEMINI.md
+/perf.data*
+/flamegraph.svg

--- a/.zed/debug.json
+++ b/.zed/debug.json
@@ -1,0 +1,17 @@
+// Project-local debug tasks
+//
+// For more documentation on how to configure debug tasks,
+// see: https://zed.dev/docs/debugger
+[
+  {
+    "label": "debug rqbit server start",
+    "build": {
+      "command": "cargo",
+      "args": ["build"]
+    },
+    "program": "$ZED_WORKTREE_ROOT/target/debug/rqbit",
+    "args": ["server", "start", "/tmp/scratch"],
+    "request": "launch",
+    "adapter": "CodeLLDB" // GDB is available on non arm macs as well as linux
+  }
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3245,9 +3245,9 @@ dependencies = [
 
 [[package]]
 name = "librqbit-utp"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8645d13297b6a38aa00c57d6de69085757a5fcb7e04debbdfa6cd07d1258e8e"
+checksum = "a41d1c4ec460ae628289a8f8fff479aae03ed0813b6d522f70beb970529fa8c7"
 dependencies = [
  "bitvec",
  "dontfrag",

--- a/crates/dht/src/dht.rs
+++ b/crates/dht/src/dht.rs
@@ -41,7 +41,7 @@ use serde::Serialize;
 use tokio::sync::mpsc::{Sender, UnboundedReceiver, UnboundedSender, channel, unbounded_channel};
 
 use tokio_util::sync::CancellationToken;
-use tracing::{Instrument, debug, debug_span, error, error_span, info, trace, trace_span, warn};
+use tracing::{Instrument, debug, debug_span, error, info, trace, trace_span, warn};
 
 fn now() -> Instant {
     Instant::now()
@@ -1138,7 +1138,7 @@ impl DhtWorker {
                                 debug!("error: {e:#}");
                             }
                         }
-                    }.instrument(error_span!("ping", addr=addr.to_string())))
+                    }.instrument(debug_span!("ping", addr=addr.to_string())))
                 },
                 _ = futs.next(), if !futs.is_empty() => {},
             }
@@ -1226,15 +1226,15 @@ impl DhtWorker {
         }
         .instrument(debug_span!("dht_responese_reader"));
 
-        let pinger_v4 = self.pinger(true).instrument(error_span!("pinger_v4"));
+        let pinger_v4 = self.pinger(true).instrument(debug_span!("pinger_v4"));
         let bucket_refresher_v4 = self
             .bucket_refresher(true)
-            .instrument(error_span!("bucket_refresher_v4"));
+            .instrument(debug_span!("bucket_refresher_v4"));
 
-        let pinger_v6 = self.pinger(false).instrument(error_span!("pinger_v6"));
+        let pinger_v6 = self.pinger(false).instrument(debug_span!("pinger_v6"));
         let bucket_refresher_v6 = self
             .bucket_refresher(false)
-            .instrument(error_span!("bucket_refresher_v6"));
+            .instrument(debug_span!("bucket_refresher_v6"));
 
         tokio::pin!(framer);
         tokio::pin!(bootstrap);
@@ -1325,7 +1325,7 @@ impl DhtState {
                 token,
             ));
 
-            spawn_with_cancel(error_span!("dht"), state.cancellation_token.clone(), {
+            spawn_with_cancel(debug_span!("dht"), state.cancellation_token.clone(), {
                 let state = state.clone();
                 async move {
                     let worker = DhtWorker { socket, dht: state };

--- a/crates/dht/src/dht.rs
+++ b/crates/dht/src/dht.rs
@@ -41,7 +41,7 @@ use serde::Serialize;
 use tokio::sync::mpsc::{Sender, UnboundedReceiver, UnboundedSender, channel, unbounded_channel};
 
 use tokio_util::sync::CancellationToken;
-use tracing::{Instrument, debug, debug_span, error, info, trace, trace_span, warn};
+use tracing::{Instrument, debug, debug_span, error, info, trace, warn};
 
 fn now() -> Instant {
     Instant::now()
@@ -283,7 +283,7 @@ impl RecursiveRequest<RecursiveRequestCallbacksFindNodes> {
                     debug!("error: {e:#}");
                     e
                 })
-                .instrument(trace_span!(
+                .instrument(debug_span!(
                     "find_node",
                     target = format!("{target:?}"),
                     addr = addr.to_string()
@@ -1011,9 +1011,9 @@ impl DhtWorker {
         (|| self.bootstrap_hostname(addr))
             .retry(backoff)
             .notify(|error, retry_in| {
-                warn!(?retry_in, "error in bootstrap: {error:#}");
+                warn!(?retry_in, ?addr, "error in bootstrap: {error:#}");
             })
-            .instrument(trace_span!("bootstrap", hostname = addr))
+            .instrument(debug_span!("bootstrap", hostname = addr))
             .await
     }
 
@@ -1083,7 +1083,7 @@ impl DhtWorker {
                     futs.push(
                         RecursiveRequest::find_node_for_routing_table(
                             self.dht.clone(), random_id, addrs.into_iter()
-                        ).instrument(trace_span!("refresh_bucket"))
+                        ).instrument(debug_span!("refresh_bucket"))
                     );
                 },
                 _ = futs.next(), if !futs.is_empty() => {},

--- a/crates/dht/src/dht.rs
+++ b/crates/dht/src/dht.rs
@@ -357,7 +357,7 @@ impl RecursiveRequest<RecursiveRequestCallbacksGetPeers> {
                                 Ok(n) if n < 8 => REQUERY_INTERVAL / 8 * (n as u32),
                                 Ok(_) => REQUERY_INTERVAL,
                                 Err(e) => {
-                                    error!("error in get_peers_root(): {e:#}");
+                                    error!("dht: error in get_peers_root(): {e:#}");
                                     return Err::<(), crate::Error>(e);
                                 }
                             };
@@ -641,9 +641,8 @@ impl DhtState {
                 trace!("received {r:?}");
                 r
             }),
-            Ok(Err(e)) => {
+            Ok(Err(_)) => {
                 self.inflight_by_transaction_id.remove(&key);
-                warn!("recv error, did not expect this: {:?}", e);
                 Err(Error::DhtDead)
             }
             Err(_) => {

--- a/crates/dht/src/dht.rs
+++ b/crates/dht/src/dht.rs
@@ -344,6 +344,7 @@ impl RecursiveRequest<RecursiveRequestCallbacksGetPeers> {
         let this = self.clone();
         spawn(
             debug_span!(parent: None, "get_peers", is_v4, info_hash = format!("{:?}", self.info_hash)),
+            "get_peers",
             async move {
                 let this = &this;
                 // Looper adds root nodes to the queue every 60 seconds.
@@ -1324,13 +1325,18 @@ impl DhtState {
                 token,
             ));
 
-            spawn_with_cancel(debug_span!("dht"), state.cancellation_token.clone(), {
-                let state = state.clone();
-                async move {
-                    let worker = DhtWorker { socket, dht: state };
-                    worker.start(in_rx, &bootstrap_addrs).await
-                }
-            });
+            spawn_with_cancel(
+                debug_span!("dht"),
+                "dht",
+                state.cancellation_token.clone(),
+                {
+                    let state = state.clone();
+                    async move {
+                        let worker = DhtWorker { socket, dht: state };
+                        worker.start(in_rx, &bootstrap_addrs).await
+                    }
+                },
+            );
             Ok(state)
         }
         .boxed()

--- a/crates/dht/src/persistence.rs
+++ b/crates/dht/src/persistence.rs
@@ -13,7 +13,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 
-use tracing::{error, error_span, info, trace, warn};
+use tracing::{debug_span, error, info, trace, warn};
 
 use crate::peer_store::PeerStore;
 use crate::routing_table::RoutingTable;
@@ -152,7 +152,7 @@ impl PersistentDht {
             };
             let dht = DhtState::with_config(dht_config).await?;
             spawn_with_cancel::<anyhow::Error>(
-                error_span!("dht_persistence"),
+                debug_span!("dht_persistence"),
                 dht.cancellation_token().clone(),
                 {
                     let dht = dht.clone();

--- a/crates/dht/src/persistence.rs
+++ b/crates/dht/src/persistence.rs
@@ -122,7 +122,7 @@ impl PersistentDht {
                         Err(e) => {
                             warn!(
                                 filename=?config_filename,
-                                "cannot deserialize routing table: {:#}",
+                                "DHT: cannot deserialize routing table: {:#}",
                                 e
                             );
                             None

--- a/crates/dht/src/persistence.rs
+++ b/crates/dht/src/persistence.rs
@@ -153,6 +153,7 @@ impl PersistentDht {
             let dht = DhtState::with_config(dht_config).await?;
             spawn_with_cancel::<anyhow::Error>(
                 debug_span!("dht_persistence"),
+                "dht_persistence",
                 dht.cancellation_token().clone(),
                 {
                     let dht = dht.clone();

--- a/crates/librqbit/Cargo.toml
+++ b/crates/librqbit/Cargo.toml
@@ -123,7 +123,7 @@ walkdir = "2.5.0"
 arc-swap = "1.7.1"
 intervaltree = "0.2.7"
 async-compression = { version = "0.4.18", features = ["tokio", "gzip"] }
-librqbit-utp = { version = "0.5.3", features = ["export-metrics"] }
+librqbit-utp = { version = "0.5.4", features = ["export-metrics"] }
 axum-extra = { version = "0.10.1", features = ["query"] }
 librqbit-dualstack-sockets = { version = "0.6.5", features = ["axum"] }
 socket2 = "0.5.10"

--- a/crates/librqbit/src/api.rs
+++ b/crates/librqbit/src/api.rs
@@ -558,7 +558,13 @@ fn make_torrent_details(
                 let name = match d.filename.to_string() {
                     Ok(s) => s,
                     Err(err) => {
-                        warn!("error reading filename: {:?}", err);
+                        warn!(
+                            ?info_hash,
+                            ?id,
+                            file_id = idx,
+                            "error reading filename: {:#}",
+                            err
+                        );
                         "<INVALID NAME>".to_string()
                     }
                 };

--- a/crates/librqbit/src/http_api/mod.rs
+++ b/crates/librqbit/src/http_api/mod.rs
@@ -10,7 +10,7 @@ use http::{HeaderMap, StatusCode};
 use librqbit_dualstack_sockets::TcpListener;
 use std::sync::Arc;
 use tower_http::trace::{DefaultOnFailure, DefaultOnResponse, OnFailure};
-use tracing::{Span, debug, error_span, info};
+use tracing::{Span, debug, debug_span, info};
 
 use axum::Router;
 
@@ -176,9 +176,9 @@ impl HttpApi {
                             .extensions()
                             .get::<ConnectInfo<librqbit_dualstack_sockets::WrappedSocketAddr>>()
                         {
-                            error_span!("request", %method, %uri, addr=%addr.0)
+                            debug_span!("request", %method, %uri, addr=%addr.0)
                         } else {
-                            error_span!("request", %method, %uri)
+                            debug_span!("request", %method, %uri)
                         }
                     })
                     .on_request(|req: &Request, _: &Span| {

--- a/crates/librqbit/src/lib.rs
+++ b/crates/librqbit/src/lib.rs
@@ -83,13 +83,13 @@ pub use api::Api;
 pub use api_error::{ApiError, WithStatus, WithStatusError};
 pub use create_torrent_file::{CreateTorrentOptions, create_torrent};
 pub use dht;
+pub use librqbit_core::spawn_utils::spawn as librqbit_spawn;
 pub use listen::{ListenerMode, ListenerOptions};
 pub use peer_connection::PeerConnectionOptions;
 pub use session::{
     AddTorrent, AddTorrentOptions, AddTorrentResponse, ListOnlyResponse, SUPPORTED_SCHEMES,
     Session, SessionOptions, SessionPersistenceConfig,
 };
-pub use spawn_utils::spawn as librqbit_spawn;
 pub use stream_connect::ConnectionOptions;
 pub use torrent_state::{
     ManagedTorrent, ManagedTorrentShared, ManagedTorrentState, TorrentMetadata, TorrentStats,

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -65,7 +65,7 @@ use peer_binary_protocol::Handshake;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Notify;
 use tokio_util::sync::{CancellationToken, DropGuard};
-use tracing::{Instrument, debug, error, error_span, info, trace, warn};
+use tracing::{Instrument, debug, debug_span, error, info, trace, warn};
 use tracker_comms::{TrackerComms, UdpTrackerClient};
 
 pub const SUPPORTED_SCHEMES: [&str; 3] = ["http:", "https:", "magnet:"];
@@ -700,7 +700,7 @@ impl Session {
 
             if let Some(mut disk_write_rx) = disk_write_rx {
                 session.spawn(
-                    error_span!(parent: session.rs(), "disk_writer"),
+                    debug_span!(parent: session.rs(), "disk_writer"),
                     async move {
                         while let Some(work) = disk_write_rx.recv().await {
                             trace!(disk_write_rx_queue_len = disk_write_rx.len());
@@ -714,7 +714,7 @@ impl Session {
             if let Some(mut listen) = listen_result {
                 if let Some(tcp) = listen.tcp_socket.take() {
                     session.spawn(
-                        error_span!(parent: session.rs(), "tcp_listen", addr = ?listen.addr),
+                        debug_span!(parent: session.rs(), "tcp_listen", addr = ?listen.addr),
                         {
                             let this = session.clone();
                             async move { this.task_listener(tcp).await }
@@ -723,7 +723,7 @@ impl Session {
                 }
                 if let Some(utp) = listen.utp_socket.take() {
                     session.spawn(
-                        error_span!(parent: session.rs(), "utp_listen", addr = ?listen.addr),
+                        debug_span!(parent: session.rs(), "utp_listen", addr = ?listen.addr),
                         {
                             let this = session.clone();
                             async move { this.task_listener(utp).await }
@@ -734,7 +734,7 @@ impl Session {
                     if listen.enable_upnp_port_forwarding {
                         info!(port = announce_port, "starting UPnP port forwarder");
                         session.spawn(
-                            error_span!(parent: session.rs(), "upnp_forward", port = announce_port),
+                            debug_span!(parent: session.rs(), "upnp_forward", port = announce_port),
                             Self::task_upnp_port_forwarder(announce_port),
                         );
                     }
@@ -751,7 +751,7 @@ impl Session {
                 while !added_all || !futs.is_empty() {
                     // NOTE: this closure exists purely to workaround rustfmt screwing up when inlining it.
                     let add_torrent_span = |info_hash: &Id20| -> tracing::Span {
-                        error_span!(parent: session.rs(), "add_torrent", info_hash=?info_hash)
+                        debug_span!(parent: session.rs(), "add_torrent", info_hash=?info_hash)
                     };
                     tokio::select! {
                         Some(res) = futs.next(), if !futs.is_empty() => {
@@ -851,7 +851,7 @@ impl Session {
                         Ok((addr, (read, write))) => {
                             trace!("accepted connection from {addr}");
                             let session = session.upgrade().context("session is dead")?;
-                            let span = error_span!(parent: session.rs(), "incoming", addr=%addr);
+                            let span = debug_span!(parent: session.rs(), "incoming", addr=%addr);
                             futs.push(
                                 session.check_incoming_connection(addr, A::KIND, Box::new(read), Box::new(write))
                                     .map_err(|e| {
@@ -1031,7 +1031,7 @@ impl Session {
 
             self.add_torrent_internal(add_res, opts).await
         }
-        .instrument(error_span!(parent: self.rs(), "add_torrent"))
+        .instrument(debug_span!(parent: self.rs(), "add_torrent"))
         .boxed()
     }
 
@@ -1196,7 +1196,7 @@ impl Session {
                 return Ok(AddTorrentResponse::AlreadyManaged(id, handle));
             }
 
-            let span = error_span!(parent: self.rs(), "torrent", id);
+            let span = debug_span!(parent: self.rs(), "torrent", id);
             let peer_opts = self.merge_peer_opts(opts.peer_opts);
             let metadata = Arc::new(metadata);
             let minfo = Arc::new(ManagedTorrentShared {

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -1317,7 +1317,7 @@ impl Session {
                     .pause()
                     // inspect_err not available in 1.75
                     .map_err(|e| {
-                        warn!("error pausing torrent: {e:#}");
+                        warn!(?id, "error pausing torrent: {e:#}");
                         e
                     })
                     .ok()
@@ -1334,7 +1334,10 @@ impl Session {
 
         if let Some(p) = self.persistence.as_ref() {
             if let Err(e) = p.delete(id).await {
-                error!(error=?e, "error deleting torrent from persistence database");
+                error!(
+                    ?id,
+                    "error deleting torrent from persistence database: {e:#}"
+                );
             } else {
                 debug!(?id, "deleted torrent from persistence database")
             }
@@ -1348,6 +1351,7 @@ impl Session {
                 if removed.shared().options.output_folder != self.output_folder {
                     if let Err(e) = storage.remove_directory_if_empty(Path::new("")) {
                         warn!(
+                            ?id,
                             "error removing {:?}: {e:#}",
                             removed.shared().options.output_folder
                         )
@@ -1410,7 +1414,10 @@ impl Session {
         }
 
         if is_private && trackers.len() > 1 {
-            warn!("private trackers are not fully implemented, so using only the first tracker");
+            warn!(
+                ?info_hash,
+                "private trackers are not fully implemented, so using only the first tracker"
+            );
             trackers.truncate(1);
         } else if !self.disable_trackers {
             trackers.extend(self.trackers.iter().cloned());

--- a/crates/librqbit/src/session_persistence/postgres.rs
+++ b/crates/librqbit/src/session_persistence/postgres.rs
@@ -8,7 +8,7 @@ use anyhow::Context;
 use futures::{StreamExt, stream::BoxStream};
 use librqbit_core::Id20;
 use sqlx::{Pool, Postgres};
-use tracing::error_span;
+use tracing::debug_span;
 
 use super::{SerializedTorrent, SessionPersistenceStore};
 
@@ -218,7 +218,7 @@ impl BitV for PgBitfield {
         // TODO: make flush async, and don't spawn this, to avoid allocations and capture the result.
         crate::spawn_utils::spawn(
             "pg",
-            error_span!("pg_update_bitfield", id=?self.torrent_id),
+            debug_span!("pg_update_bitfield", id=?self.torrent_id),
             {
                 let hb = self.as_bytes().to_owned();
                 let pool = self.pool.clone();

--- a/crates/librqbit/src/session_persistence/postgres.rs
+++ b/crates/librqbit/src/session_persistence/postgres.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use anyhow::Context;
 use futures::{StreamExt, stream::BoxStream};
-use librqbit_core::Id20;
+use librqbit_core::{Id20, spawn_utils::spawn};
 use sqlx::{Pool, Postgres};
 use tracing::debug_span;
 
@@ -216,9 +216,9 @@ impl BitV for PgBitfield {
 
     fn flush(&mut self) -> anyhow::Result<()> {
         // TODO: make flush async, and don't spawn this, to avoid allocations and capture the result.
-        crate::spawn_utils::spawn(
-            "pg",
+        spawn(
             debug_span!("pg_update_bitfield", id=?self.torrent_id),
+            "pg_update_bitfield",
             {
                 let hb = self.as_bytes().to_owned();
                 let pool = self.pool.clone();
@@ -254,7 +254,7 @@ impl BitV for PgBitfield {
                             )?;
                         }
                     };
-                    Ok(())
+                    Ok::<_, anyhow::Error>(())
                 }
             },
         );

--- a/crates/librqbit/src/session_stats/mod.rs
+++ b/crates/librqbit/src/session_stats/mod.rs
@@ -40,24 +40,28 @@ impl Default for SessionStats {
 
 impl Session {
     pub(crate) fn start_speed_estimator_updater(self: &Arc<Self>) {
-        self.spawn(debug_span!(parent: self.rs(), "speed_estimator"), {
-            let s = Arc::downgrade(self);
+        self.spawn(
+            debug_span!(parent: self.rs(), "speed_estimator"),
+            "speed_estimator",
+            {
+                let s = Arc::downgrade(self);
 
-            async move {
-                let mut i = tokio::time::interval(Duration::from_secs(1));
-                loop {
-                    i.tick().await;
-                    let s = s.upgrade().context("session is dead")?;
-                    let now = Instant::now();
-                    let fetched = s.stats.atomic.fetched_bytes.load(Ordering::Relaxed);
-                    let uploaded = s.stats.atomic.uploaded_bytes.load(Ordering::Relaxed);
-                    s.stats
-                        .down_speed_estimator
-                        .add_snapshot(fetched, None, now);
-                    s.stats.up_speed_estimator.add_snapshot(uploaded, None, now);
+                async move {
+                    let mut i = tokio::time::interval(Duration::from_secs(1));
+                    loop {
+                        i.tick().await;
+                        let s = s.upgrade().context("session is dead")?;
+                        let now = Instant::now();
+                        let fetched = s.stats.atomic.fetched_bytes.load(Ordering::Relaxed);
+                        let uploaded = s.stats.atomic.uploaded_bytes.load(Ordering::Relaxed);
+                        s.stats
+                            .down_speed_estimator
+                            .add_snapshot(fetched, None, now);
+                        s.stats.up_speed_estimator.add_snapshot(uploaded, None, now);
+                    }
                 }
-            }
-        })
+            },
+        )
     }
 
     pub fn stats_snapshot(&self) -> SessionStatsSnapshot {

--- a/crates/librqbit/src/session_stats/mod.rs
+++ b/crates/librqbit/src/session_stats/mod.rs
@@ -7,7 +7,7 @@ use anyhow::Context;
 use atomic::AtomicSessionStats;
 use librqbit_core::speed_estimator::SpeedEstimator;
 use snapshot::SessionStatsSnapshot;
-use tracing::error_span;
+use tracing::debug_span;
 
 use crate::Session;
 
@@ -40,7 +40,7 @@ impl Default for SessionStats {
 
 impl Session {
     pub(crate) fn start_speed_estimator_updater(self: &Arc<Self>) {
-        self.spawn(error_span!(parent: self.rs(), "speed_estimator"), {
+        self.spawn(debug_span!(parent: self.rs(), "speed_estimator"), {
             let s = Arc::downgrade(self);
 
             async move {

--- a/crates/librqbit/src/spawn_utils.rs
+++ b/crates/librqbit/src/spawn_utils.rs
@@ -1,14 +1,3 @@
-/// Spawn a future inside a tracing span, while logging it's start,
-/// finish and periodically logging if it's still alive.
-#[track_caller]
-pub fn spawn(
-    _name: &str,
-    span: tracing::Span,
-    fut: impl std::future::Future<Output = anyhow::Result<()>> + Send + 'static,
-) -> tokio::task::JoinHandle<()> {
-    librqbit_core::spawn_utils::spawn(span, fut)
-}
-
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct BlockingSpawner {
     allow_tokio_block_in_place: bool,

--- a/crates/librqbit/src/torrent_state/live/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/mod.rs
@@ -397,7 +397,7 @@ impl TorrentStateLive {
         atomic_inc(&counters.incoming_connections);
 
         self.spawn(
-            error_span!(
+            debug_span!(
                 parent: self.shared.span.clone(),
                 "manage_incoming_peer",
                 addr = %checked_peer.addr
@@ -592,7 +592,7 @@ impl TorrentStateLive {
 
             let permit = state.peer_semaphore.clone().acquire_owned().await?;
             state.spawn(
-                error_span!(parent: state.shared.span.clone(), "manage_peer", peer = addr.to_string()),
+                debug_span!(parent: state.shared.span.clone(), "manage_peer", peer = addr.to_string()),
                 aframe!(state.clone().task_manage_outgoing_peer(addr, permit)),
             );
         }
@@ -1073,7 +1073,7 @@ impl PeerConnectionHandler for PeerHandler {
     fn on_extended_handshake(&self, hs: &ExtendedHandshake<ByteBuf>) -> anyhow::Result<()> {
         if !self.state.metadata.info.private && hs.m.ut_pex.is_some() {
             spawn_with_cancel(
-                error_span!(
+                debug_span!(
                     parent: self.state.shared.span.clone(),
                     "sending_pex_to_peer",
                     peer = self.addr.to_string()
@@ -1215,7 +1215,7 @@ impl PeerHandler {
                 return Ok(());
             }
             self.state.clone().spawn(
-                error_span!(
+                debug_span!(
                     parent: self.state.shared.span.clone(),
                     "wait_for_peer",
                     peer = handle.to_string(),
@@ -1851,7 +1851,7 @@ impl PeerHandler {
             let piece = piece.clone_to_owned(None);
             let tx = self.tx.clone();
 
-            let span = tracing::error_span!("deferred_write");
+            let span = tracing::debug_span!("deferred_write");
             let work = move || {
                 span.in_scope(|| {
                     if let Err(e) =

--- a/crates/librqbit/src/torrent_state/live/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/mod.rs
@@ -80,7 +80,7 @@ use tokio::sync::{
     mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel},
 };
 use tokio_util::sync::CancellationToken;
-use tracing::{Instrument, debug, debug_span, error, error_span, info, trace, warn};
+use tracing::{Instrument, debug, debug_span, error, info, trace, warn};
 
 use crate::{
     Error,

--- a/crates/librqbit/src/torrent_state/live/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/mod.rs
@@ -80,7 +80,7 @@ use tokio::sync::{
     mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel},
 };
 use tokio_util::sync::CancellationToken;
-use tracing::{Instrument, debug, error, error_span, info, trace, warn};
+use tracing::{Instrument, debug, debug_span, error, error_span, info, trace, warn};
 
 use crate::{
     Error,
@@ -293,7 +293,7 @@ impl TorrentStateLive {
         });
 
         state.spawn(
-            error_span!(parent: state.shared.span.clone(), "speed_estimator_updater"),
+            debug_span!(parent: state.shared.span.clone(), "speed_estimator_updater"),
             {
                 let state = Arc::downgrade(&state);
                 async move {
@@ -319,12 +319,12 @@ impl TorrentStateLive {
         );
 
         state.spawn(
-            error_span!(parent: state.shared.span.clone(), "peer_adder"),
+            debug_span!(parent: state.shared.span.clone(), "peer_adder"),
             state.clone().task_peer_adder(peer_queue_rx),
         );
 
         state.spawn(
-            error_span!(parent: state.shared.span.clone(), "upload_scheduler"),
+            debug_span!(parent: state.shared.span.clone(), "upload_scheduler"),
             state.clone().task_upload_scheduler(ratelimit_upload_rx),
         );
         Ok(state)
@@ -535,12 +535,12 @@ impl TorrentStateLive {
         let requester = aframe!(
             handler
                 .task_peer_chunk_requester()
-                .instrument(error_span!("chunk_requester"))
+                .instrument(debug_span!("chunk_requester"))
         );
         let conn_manager = aframe!(
             peer_connection
                 .manage_peer_outgoing(rx, state.have_broadcast_tx.subscribe())
-                .instrument(error_span!("peer_connection"))
+                .instrument(debug_span!("peer_connection"))
         );
 
         handler

--- a/crates/librqbit/src/torrent_state/mod.rs
+++ b/crates/librqbit/src/torrent_state/mod.rs
@@ -347,6 +347,7 @@ impl ManagedTorrent {
 
                     spawn_with_cancel(
                         debug_span!(parent: span.clone(), "initialize_and_start"),
+                        "initialize_and_start",
                         token.clone(),
                         async move {
                             let concurrent_init_semaphore =
@@ -624,6 +625,7 @@ fn spawn_fatal_errors_receiver(
     let state = Arc::downgrade(state);
     spawn_with_cancel::<&'static str>(
         debug_span!(parent: span, "fatal_errors_receiver"),
+        "fatal_errors_receiver",
         token,
         async move {
             let e = match rx.await {
@@ -647,6 +649,7 @@ fn spawn_fatal_errors_receiver(
 fn spawn_peer_adder(live: &Arc<TorrentStateLive>, mut peer_rx: PeerStream) {
     live.spawn(
         debug_span!(parent: live.torrent().span.clone(), "external_peer_adder"),
+        format!("[{}]external_peer_adder", live.shared.id),
         {
             let live = live.clone();
             async move {

--- a/crates/librqbit/src/torrent_state/mod.rs
+++ b/crates/librqbit/src/torrent_state/mod.rs
@@ -33,7 +33,7 @@ use tokio::time::timeout;
 use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 use tracing::debug;
-use tracing::error_span;
+use tracing::debug_span;
 use tracing::trace;
 use tracing::warn;
 
@@ -340,7 +340,7 @@ impl ManagedTorrent {
                     let token = token.clone();
 
                     spawn_with_cancel(
-                        error_span!(parent: span.clone(), "initialize_and_start"),
+                        debug_span!(parent: span.clone(), "initialize_and_start"),
                         token.clone(),
                         async move {
                             let concurrent_init_semaphore =
@@ -615,7 +615,7 @@ fn spawn_fatal_errors_receiver(
     let span = state.shared.span.clone();
     let state = Arc::downgrade(state);
     spawn_with_cancel::<&'static str>(
-        error_span!(parent: span, "fatal_errors_receiver"),
+        debug_span!(parent: span, "fatal_errors_receiver"),
         token,
         async move {
             let e = match rx.await {
@@ -634,7 +634,7 @@ fn spawn_fatal_errors_receiver(
 
 fn spawn_peer_adder(live: &Arc<TorrentStateLive>, mut peer_rx: PeerStream) {
     live.spawn(
-        error_span!(parent: live.torrent().span.clone(), "external_peer_adder"),
+        debug_span!(parent: live.torrent().span.clone(), "external_peer_adder"),
         {
             let live = live.clone();
             async move {

--- a/crates/librqbit/src/tracing_subscriber_config_utils.rs
+++ b/crates/librqbit/src/tracing_subscriber_config_utils.rs
@@ -89,11 +89,11 @@ pub fn init_logging(opts: InitLoggingOptions) -> anyhow::Result<InitLoggingResul
                 .fmt_fields(tracing_subscriber::fmt::format::JsonFields::new())
                 .event_format(fmt::format().with_ansi(false).json())
                 .with_writer(line_sub)
+                .with_filter(EnvFilter::builder().parse("info,librqbit=debug").unwrap())
                 .with_filter(tracing_subscriber::filter::filter_fn({
                     let line_broadcast = line_broadcast.clone();
                     move |_| line_broadcast.receiver_count() > 0
-                }))
-                .with_filter(EnvFilter::builder().parse("info,librqbit=debug").unwrap()),
+                })),
         );
 
     #[cfg(feature = "tokio-console")]

--- a/crates/librqbit/src/tracing_subscriber_config_utils.rs
+++ b/crates/librqbit/src/tracing_subscriber_config_utils.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use bytes::Bytes;
 use librqbit_core::spawn_utils::spawn;
 use tracing::debug_span;
-use tracing_subscriber::fmt::MakeWriter;
+use tracing_subscriber::{filter::FilterExt, fmt::MakeWriter};
 
 struct Subscriber {
     tx: tokio::sync::broadcast::Sender<Bytes>,
@@ -89,11 +89,13 @@ pub fn init_logging(opts: InitLoggingOptions) -> anyhow::Result<InitLoggingResul
                 .fmt_fields(tracing_subscriber::fmt::format::JsonFields::new())
                 .event_format(fmt::format().with_ansi(false).json())
                 .with_writer(line_sub)
-                .with_filter(EnvFilter::builder().parse("info,librqbit=debug").unwrap())
-                .with_filter(tracing_subscriber::filter::filter_fn({
-                    let line_broadcast = line_broadcast.clone();
-                    move |_| line_broadcast.receiver_count() > 0
-                })),
+                .with_filter(
+                    tracing_subscriber::filter::filter_fn({
+                        let line_broadcast = line_broadcast.clone();
+                        move |_| line_broadcast.receiver_count() > 0
+                    })
+                    .and(EnvFilter::builder().parse("info,librqbit=debug").unwrap()),
+                ),
         );
 
     #[cfg(feature = "tokio-console")]

--- a/crates/librqbit/src/tracing_subscriber_config_utils.rs
+++ b/crates/librqbit/src/tracing_subscriber_config_utils.rs
@@ -3,7 +3,7 @@ use std::io::LineWriter;
 use anyhow::Context;
 use bytes::Bytes;
 use librqbit_core::spawn_utils::spawn;
-use tracing::error_span;
+use tracing::debug_span;
 use tracing_subscriber::fmt::MakeWriter;
 
 struct Subscriber {
@@ -129,7 +129,7 @@ pub fn init_logging(opts: InitLoggingOptions) -> anyhow::Result<InitLoggingResul
     }
 
     let (reload_tx, mut reload_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
-    spawn::<&'static str>(error_span!("fmt_filter_reloader"), async move {
+    spawn::<&'static str>(debug_span!("fmt_filter_reloader"), async move {
         while let Some(rust_log) = reload_rx.recv().await {
             let stderr_env_filter = match EnvFilter::builder().parse(&rust_log) {
                 Ok(f) => f,

--- a/crates/librqbit/src/vectored_traits.rs
+++ b/crates/librqbit/src/vectored_traits.rs
@@ -48,9 +48,9 @@ impl AsyncReadVectored for tokio::net::tcp::OwnedReadHalf {
     ) -> Poll<std::io::Result<usize>> {
         let this = self.get_mut();
         loop {
-            std::task::ready!(this.as_ref().poll_read_ready(cx)?);
             match this.try_read_vectored(vec) {
                 Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    std::task::ready!(this.as_ref().poll_read_ready(cx)?);
                     continue;
                 }
                 res => return Poll::Ready(res),

--- a/crates/librqbit/src/watch.rs
+++ b/crates/librqbit/src/watch.rs
@@ -92,7 +92,7 @@ fn watch_thread(
             .context("error opening")?
             .read_to_string(&mut url)
             .context("error reading")?;
-        warn!("validating {url}");
+        debug!("validating {url}");
         Magnet::parse(&url)?;
         Ok(AddTorrent::Url(url.into()))
     }

--- a/crates/librqbit_core/src/torrent_metainfo.rs
+++ b/crates/librqbit_core/src/torrent_metainfo.rs
@@ -151,6 +151,7 @@ where
         }
         Ok(buf)
     }
+
     pub fn to_pathbuf(&self) -> anyhow::Result<PathBuf> {
         let mut buf = PathBuf::new();
         for bit in self.iter_components() {

--- a/crates/librqbit_lsd/src/lib.rs
+++ b/crates/librqbit_lsd/src/lib.rs
@@ -16,7 +16,7 @@ use librqbit_dualstack_sockets::MulticastUdpSocket;
 use parking_lot::RwLock;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error_span, trace};
+use tracing::{debug, debug_span, trace};
 
 const LSD_PORT: u16 = 6771;
 const LSD_IPV4: SocketAddrV4 = SocketAddrV4::new(Ipv4Addr::new(239, 192, 152, 143), LSD_PORT);
@@ -101,7 +101,7 @@ impl LocalServiceDiscovery {
         };
 
         spawn_with_cancel(
-            error_span!("lsd"),
+            debug_span!("lsd"),
             opts.cancel_token,
             lsd.clone().task_monitor_recv(),
         );
@@ -272,7 +272,7 @@ cookie: {cookie}\r
         if let Some(announce_port) = announce_port {
             let cancel_token = self.inner.cancel_token.child_token();
             spawn_with_cancel(
-                error_span!(parent: None, "lsd-announce", ?info_hash, port=announce_port),
+                debug_span!(parent: None, "lsd-announce", ?info_hash, port=announce_port),
                 cancel_token,
                 self.clone()
                     .task_announce_periodically(info_hash, announce_port),

--- a/crates/librqbit_lsd/src/lib.rs
+++ b/crates/librqbit_lsd/src/lib.rs
@@ -102,6 +102,7 @@ impl LocalServiceDiscovery {
 
         spawn_with_cancel(
             debug_span!("lsd"),
+            "lsd",
             opts.cancel_token,
             lsd.clone().task_monitor_recv(),
         );
@@ -273,6 +274,7 @@ cookie: {cookie}\r
             let cancel_token = self.inner.cancel_token.child_token();
             spawn_with_cancel(
                 debug_span!(parent: None, "lsd-announce", ?info_hash, port=announce_port),
+                "lsd-announce",
                 cancel_token,
                 self.clone()
                     .task_announce_periodically(info_hash, announce_port),

--- a/crates/rqbit/Cargo.toml
+++ b/crates/rqbit/Cargo.toml
@@ -40,7 +40,7 @@ console-subscriber = { version = "0.4", optional = true }
 anyhow = "1"
 clap = { version = "4.5", features = ["derive", "deprecated", "env"] }
 clap_complete = "4.5"
-tracing = { version = "0.1" }
+tracing = { version = "0.1", features = ["release_max_level_off"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 regex = "1"
 futures = "0.3"

--- a/crates/rqbit/Cargo.toml
+++ b/crates/rqbit/Cargo.toml
@@ -40,7 +40,7 @@ console-subscriber = { version = "0.4", optional = true }
 anyhow = "1"
 clap = { version = "4.5", features = ["derive", "deprecated", "env"] }
 clap_complete = "4.5"
-tracing = { version = "0.1", features = ["release_max_level_off"] }
+tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 regex = "1"
 futures = "0.3"

--- a/crates/rqbit/src/main.rs
+++ b/crates/rqbit/src/main.rs
@@ -651,6 +651,8 @@ async fn async_main(opts: Opts, cancel: CancellationToken) -> anyhow::Result<()>
                 });
             tokio::time::sleep(Duration::from_secs(1)).await;
         }
+        #[allow(unreachable_code)]
+        Ok::<_, &'static str>(())
     };
 
     match opts.subcommand {
@@ -708,8 +710,8 @@ async fn async_main(opts: Opts, cancel: CancellationToken) -> anyhow::Result<()>
                         .await
                         .context("error initializing rqbit session")?;
                 librqbit_spawn(
-                    "stats_printer",
                     trace_span!("stats_printer"),
+                    "stats_printer",
                     stats_printer(session.clone()),
                 );
 
@@ -816,8 +818,8 @@ async fn async_main(opts: Opts, cancel: CancellationToken) -> anyhow::Result<()>
             .context("error initializing rqbit session")?;
 
             librqbit_spawn(
-                "stats_printer",
                 trace_span!("stats_printer"),
+                "stats_printer",
                 stats_printer(session.clone()),
             );
 
@@ -1004,8 +1006,8 @@ fn start_ephemeral_http_api(
     let http_api_listen_addr = listener.bind_addr();
     info!("started HTTP API at http://{http_api_listen_addr}");
     librqbit_spawn(
-        "http_api",
         debug_span!("http_api"),
+        "http_api",
         http_api.make_http_api_and_run(listener, None),
     );
     Ok(())

--- a/crates/rqbit/src/main.rs
+++ b/crates/rqbit/src/main.rs
@@ -699,7 +699,7 @@ async fn async_main(opts: Opts, cancel: CancellationToken) -> anyhow::Result<()>
                         http_api_opts.prometheus_handle = Some(handle);
                     }
                     Err(e) => {
-                        warn!("error installting prometheus recorder: {e:#}");
+                        warn!("error installing prometheus recorder: {e:#}");
                     }
                 }
 

--- a/crates/rqbit/src/main.rs
+++ b/crates/rqbit/src/main.rs
@@ -28,7 +28,7 @@ use librqbit::{
 use librqbit_dualstack_sockets::TcpListener;
 use size_format::SizeFormatterBinary as SF;
 use tokio_util::sync::CancellationToken;
-use tracing::{error, error_span, info, trace_span, warn};
+use tracing::{debug_span, error, info, trace_span, warn};
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
 enum LogLevel {
@@ -1005,7 +1005,7 @@ fn start_ephemeral_http_api(
     info!("started HTTP API at http://{http_api_listen_addr}");
     librqbit_spawn(
         "http_api",
-        error_span!("http_api"),
+        debug_span!("http_api"),
         http_api.make_http_api_and_run(listener, None),
     );
     Ok(())

--- a/crates/tracker_comms/src/tracker_comms_udp.rs
+++ b/crates/tracker_comms/src/tracker_comms_udp.rs
@@ -12,7 +12,7 @@ use librqbit_dualstack_sockets::UdpSocket;
 use parking_lot::RwLock;
 use rand::Rng;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error_span, trace, warn};
+use tracing::{debug, debug_span, trace, warn};
 
 const ACTION_CONNECT: u32 = 0;
 const ACTION_ANNOUNCE: u32 = 1;
@@ -277,7 +277,7 @@ impl UdpTrackerClient {
             }),
         };
 
-        spawn_with_cancel(error_span!("udp_tracker"), cancel_token, {
+        spawn_with_cancel(debug_span!("udp_tracker"), cancel_token, {
             let client = client.clone();
             async move { client.run().await }
         });

--- a/crates/tracker_comms/src/tracker_comms_udp.rs
+++ b/crates/tracker_comms/src/tracker_comms_udp.rs
@@ -277,7 +277,7 @@ impl UdpTrackerClient {
             }),
         };
 
-        spawn_with_cancel(debug_span!("udp_tracker"), cancel_token, {
+        spawn_with_cancel(debug_span!("udp_tracker"), "udp_tracker", cancel_token, {
             let client = client.clone();
             async move { client.run().await }
         });

--- a/crates/upnp-serve/src/state.rs
+++ b/crates/upnp-serve/src/state.rs
@@ -55,6 +55,7 @@ impl UpnpServerStateInner {
 
         spawn_with_cancel::<anyhow::Error>(
             debug_span!(parent: span, "system_update_id_updater"),
+            "system_update_id_updater",
             cancel_token,
             {
                 let state = Arc::downgrade(&state);

--- a/crates/upnp-serve/src/state.rs
+++ b/crates/upnp-serve/src/state.rs
@@ -10,7 +10,7 @@ use anyhow::Context;
 use axum::body::Bytes;
 use librqbit_core::spawn_utils::spawn_with_cancel;
 use tokio_util::sync::CancellationToken;
-use tracing::{Span, error_span};
+use tracing::{Span, debug_span};
 
 use crate::{ContentDirectoryBrowseProvider, subscriptions::Subscriptions};
 
@@ -40,7 +40,7 @@ impl UpnpServerStateInner {
         let cancel_token = cancellation_token.child_token();
         let drop_guard = cancel_token.clone().drop_guard();
         let (btx, _) = tokio::sync::broadcast::channel(32);
-        let span = error_span!(parent: None, "upnp-server");
+        let span = debug_span!(parent: None, "upnp-server");
         let state = Arc::new(Self {
             rendered_root_description,
             provider,
@@ -54,7 +54,7 @@ impl UpnpServerStateInner {
         });
 
         spawn_with_cancel::<anyhow::Error>(
-            error_span!(parent: span, "system_update_id_updater"),
+            debug_span!(parent: span, "system_update_id_updater"),
             cancel_token,
             {
                 let state = Arc::downgrade(&state);

--- a/crates/upnp-serve/src/subscriptions.rs
+++ b/crates/upnp-serve/src/subscriptions.rs
@@ -308,6 +308,7 @@ impl UpnpServerStateInner {
 
         spawn_with_cancel::<anyhow::Error>(
             debug_span!(parent: pspan, "subscription-manager", sid, %url, service="ContentDirectory"),
+            "upnp-subscription-manager:ContentDirectory",
             token,
             subscription_manager,
         );
@@ -356,6 +357,7 @@ impl UpnpServerStateInner {
 
         spawn_with_cancel::<anyhow::Error>(
             debug_span!(parent: pspan, "subscription-manager", sid, %url, service="ConnectionManager"),
+            "upnp-subscription-manager:ConnectionManager",
             token,
             subscription_manager,
         );

--- a/crates/upnp-serve/src/subscriptions.rs
+++ b/crates/upnp-serve/src/subscriptions.rs
@@ -10,7 +10,7 @@ use std::{
     time::Duration,
 };
 use tokio::sync::{Notify, broadcast::error::RecvError};
-use tracing::{Instrument, debug, error_span, trace, warn};
+use tracing::{Instrument, debug, debug_span, trace, warn};
 
 pub struct Subscription {
     #[allow(dead_code)]
@@ -280,7 +280,7 @@ impl UpnpServerStateInner {
                         }
                     }
                 }
-                .instrument(error_span!("system-update-id-notifier"));
+                .instrument(debug_span!("system-update-id-notifier"));
 
                 let timeout_notifier = async {
                     let mut timeout = timeout;
@@ -297,7 +297,7 @@ impl UpnpServerStateInner {
                             }
                         }
                     }
-                }.instrument(error_span!("timeout-killer"));
+                }.instrument(debug_span!("timeout-killer"));
 
                 tokio::select! {
                     r = system_update_id_notifier => r,
@@ -307,7 +307,7 @@ impl UpnpServerStateInner {
         };
 
         spawn_with_cancel::<anyhow::Error>(
-            error_span!(parent: pspan, "subscription-manager", sid, %url, service="ContentDirectory"),
+            debug_span!(parent: pspan, "subscription-manager", sid, %url, service="ContentDirectory"),
             token,
             subscription_manager,
         );
@@ -348,14 +348,14 @@ impl UpnpServerStateInner {
                             }
                         }
                     }
-                }.instrument(error_span!("timeout-killer"));
+                }.instrument(debug_span!("timeout-killer"));
 
                 timeout_notifier.await
             }
         };
 
         spawn_with_cancel::<anyhow::Error>(
-            error_span!(parent: pspan, "subscription-manager", sid, %url, service="ConnectionManager"),
+            debug_span!(parent: pspan, "subscription-manager", sid, %url, service="ConnectionManager"),
             token,
             subscription_manager,
         );

--- a/crates/upnp/src/lib.rs
+++ b/crates/upnp/src/lib.rs
@@ -10,7 +10,7 @@ use std::{
     time::Duration,
 };
 use tokio::sync::mpsc::{UnboundedSender, unbounded_channel};
-use tracing::{Instrument, Span, debug, debug_span, error_span, trace, warn};
+use tracing::{Instrument, Span, debug, debug_span, trace, warn};
 use url::Url;
 
 const SERVICE_TYPE_WAN_IP_CONNECTION: &str = "urn:schemas-upnp-org:service:WANIPConnection:1";
@@ -445,7 +445,7 @@ impl UpnpPortForwarder {
     async fn manage_service(&self, control_url: Url, local_ip: IpAddr) -> anyhow::Result<()> {
         futures::future::join_all(self.ports.iter().cloned().map(|port| {
             self.manage_port(control_url.clone(), local_ip, port)
-                .instrument(error_span!("manage_port", port = port))
+                .instrument(debug_span!("manage_port", port = port))
         }))
         .await;
         Ok(())

--- a/crates/upnp/src/lib.rs
+++ b/crates/upnp/src/lib.rs
@@ -348,7 +348,7 @@ pub async fn discover_once(
                         tx.send(r)?;
                         discovered += 1;
                     },
-                    Err(e) => warn!(error=?e, response=?BStr::new(response), "failed to parse SSDP response"),
+                    Err(e) => warn!(response=?BStr::new(response), "failed to parse SSDP response: {e:#}"),
                 };
             },
         }
@@ -423,7 +423,7 @@ impl UpnpPortForwarder {
         loop {
             discover_interval.tick().await;
             if let Err(e) = self.discover_once(&tx).await {
-                warn!("failed to run discovery: {e:#}");
+                warn!("failed to run SSDP/UPNP discovery: {e:#}");
             }
         }
     }

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -153,7 +153,7 @@ async fn api_from_config(
                 .await
                 .context("error starting UPnP server")?;
             let router = upnp_adapter.take_router()?;
-            session.spawn(debug_span!("ssdp"), async move {
+            session.spawn(debug_span!("ssdp"), "ssdp", async move {
                 upnp_adapter.run_ssdp_forever().await
             });
             Some(router)
@@ -168,7 +168,7 @@ async fn api_from_config(
                 .await
         };
 
-        session.spawn(debug_span!("http_api"), http_api_task);
+        session.spawn(debug_span!("http_api"), "http_api", http_api_task);
     }
     Ok(api)
 }

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -153,7 +153,7 @@ async fn api_from_config(
                 .await
                 .context("error starting UPnP server")?;
             let router = upnp_adapter.take_router()?;
-            session.spawn(error_span!("ssdp"), async move {
+            session.spawn(debug_span!("ssdp"), async move {
                 upnp_adapter.run_ssdp_forever().await
             });
             Some(router)
@@ -168,7 +168,7 @@ async fn api_from_config(
                 .await
         };
 
-        session.spawn(error_span!("http_api"), http_api_task);
+        session.spawn(debug_span!("http_api"), http_api_task);
     }
     Ok(api)
 }

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -27,7 +27,7 @@ use librqbit::{
 use librqbit_dualstack_sockets::TcpListener;
 use parking_lot::RwLock;
 use serde::Serialize;
-use tracing::{error, error_span, info, warn};
+use tracing::{debug_span, error, info, warn};
 
 struct StateShared {
     config: config::RqbitDesktopConfig,


### PR DESCRIPTION
Profiling in llinux perf showed a couple hotspots in tracing crate, which boiled down to a couple things:

1. error_span!() was used everywhere, which is very convenient - it makes all log messages contain useful metadata, e.g. peer's address would be printed in every log line printed from the peer's task. However this causes overhead even when there's no logging at all seemingly. So I changed them all to lower level and manually propagated needed context to info!, warn! and error! log messages.
2. the order of filters seems to matter for performance. The (99.9% of the time) useless HTTP log layer was causing tracing overhead simply because the order of filters was suboptimal.