### PR TITLE
[feature] support filenames that are invalid utf-8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3053,6 +3053,7 @@ dependencies = [
  "rand 0.9.1",
  "serde",
  "serde_json",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-util",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3048,6 +3048,7 @@ dependencies = [
  "librqbit-buffers",
  "librqbit-clone-to-owned",
  "librqbit-sha1-wrapper",
+ "memchr",
  "parking_lot",
  "rand 0.9.1",
  "serde",

--- a/crates/librqbit/src/api.rs
+++ b/crates/librqbit/src/api.rs
@@ -555,7 +555,7 @@ fn make_torrent_details(
             .context("error iterating filenames and lengths")?
             .enumerate()
             .map(|(idx, d)| {
-                let name = match d.filename.to_string() {
+                let name = match d.filename.to_string_lossy() {
                     Ok(s) => s,
                     Err(err) => {
                         warn!(
@@ -568,7 +568,7 @@ fn make_torrent_details(
                         "<INVALID NAME>".to_string()
                     }
                 };
-                let components = d.filename.to_vec().unwrap_or_default();
+                let components = d.filename.to_vec_lossy().unwrap_or_default();
                 let included = only_files.map(|o| o.contains(&idx)).unwrap_or(true);
                 TorrentDetailsResponseFile {
                     name,
@@ -602,10 +602,10 @@ fn torrent_file_mime_type(
         .nth(file_idx)
         .and_then(|d| {
             d.filename
-                .iter_components()
+                .iter_components_lossy()
                 .last()
                 .and_then(|r| r.ok())
-                .and_then(|s| mime_guess::from_path(s).first_raw())
+                .and_then(|s| mime_guess::from_path(&*s).first_raw())
         })
         .ok_or((
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/librqbit/src/http_api/handlers/playlist.rs
+++ b/crates/librqbit/src/http_api/handlers/playlist.rs
@@ -23,7 +23,7 @@ fn torrent_playlist_items(handle: &ManagedTorrent) -> Result<Vec<(usize, String)
         .iter_file_details()?
         .enumerate()
         .filter_map(|(file_idx, file_details)| {
-            let filename = file_details.filename.to_vec().ok()?.join("/");
+            let filename = file_details.filename.to_vec_lossy().ok()?.join("/");
             let is_playable = mime_guess::from_path(&filename)
                 .first()
                 .map(|mime| {

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -178,7 +178,7 @@ fn compute_only_files_regex<ByteBuf: AsRef<[u8]>>(
     for (idx, fd) in torrent.iter_file_details()?.enumerate() {
         let full_path = fd
             .filename
-            .to_pathbuf()
+            .to_pathbuf_lossy()
             .with_context(|| format!("filename of file {idx} is not valid utf8"))?;
         if filename_re.is_match(full_path.to_str().unwrap()) {
             only_files.push(idx);
@@ -1082,7 +1082,7 @@ impl Session {
     ) -> anyhow::Result<Option<PathBuf>> {
         let files = info
             .iter_file_details()?
-            .map(|fd| Ok((fd.filename.to_pathbuf()?, fd.len)))
+            .map(|fd| Ok((fd.filename.to_pathbuf_lossy()?, fd.len)))
             .collect::<anyhow::Result<Vec<(PathBuf, u64)>>>()?;
         if files.len() < 2 {
             return Ok(None);

--- a/crates/librqbit/src/upnp_server_adapter.rs
+++ b/crates/librqbit/src/upnp_server_adapter.rs
@@ -69,7 +69,7 @@ impl TorrentFileTreeNode {
                     .iter_file_details()
                     .ok()
                     .and_then(|mut it| it.nth(fid))
-                    .and_then(|fd| fd.filename.to_vec().ok())
+                    .and_then(|fd| fd.filename.to_vec_lossy().ok())
                     .map(|components| {
                         components
                             .into_iter()
@@ -108,7 +108,7 @@ fn is_single_file_at_root(info: &TorrentMetaV1Info<ByteBufOwned>) -> bool {
     info.iter_file_details()
         .into_iter()
         .flatten()
-        .flat_map(move |fd| fd.filename.iter_components())
+        .flat_map(move |fd| fd.filename.iter_components_lossy())
         .nth(1)
         .is_none()
 }
@@ -121,11 +121,11 @@ impl TorrentFileTree {
                 .next()
                 .context("bug")?
                 .filename
-                .iter_components()
+                .iter_components_lossy()
                 .last()
                 .context("bug")??;
             let root_node = TorrentFileTreeNode {
-                title: filename.to_owned(),
+                title: filename.into_owned(),
                 parent_id: None,
                 children: vec![],
                 real_torrent_file_id: Some(0),
@@ -151,7 +151,7 @@ impl TorrentFileTree {
         let mut name_cache = HashMap::new();
 
         for (fid, fd) in info.iter_file_details()?.enumerate() {
-            let components = match fd.filename.to_vec() {
+            let components = match fd.filename.to_vec_lossy() {
                 Ok(v) => v,
                 Err(_) => continue,
             };

--- a/crates/librqbit_core/Cargo.toml
+++ b/crates/librqbit_core/Cargo.toml
@@ -32,6 +32,7 @@ directories = "6"
 tokio-util = "0.7.10"
 data-encoding = "2.6.0"
 bytes = "1.7.1"
+memchr = "2.7.5"
 
 [dev-dependencies]
 serde_json = "1"

--- a/crates/librqbit_core/Cargo.toml
+++ b/crates/librqbit_core/Cargo.toml
@@ -33,6 +33,7 @@ tokio-util = "0.7.10"
 data-encoding = "2.6.0"
 bytes = "1.7.1"
 memchr = "2.7.5"
+thiserror = "2.0.12"
 
 [dev-dependencies]
 serde_json = "1"

--- a/crates/librqbit_core/src/error.rs
+++ b/crates/librqbit_core/src/error.rs
@@ -1,0 +1,15 @@
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("expected multi-file torrent to have at least one file")]
+    BadTorrentMultiFileEmpty,
+    #[error("torrent can't be both in single and multi-file mode")]
+    BadTorrentBothSingleAndMultiFile,
+    #[error("path traversal detected, \"..\" in filename")]
+    BadTorrentPathTraversal,
+    #[error("suspicios separator in filename")]
+    BadTorrentSeparatorInName,
+    #[error("torrent with 0 length is useless")]
+    BadTorrentZeroLength,
+    #[error("invalid piece index {0}")]
+    InvalidPieceInex(u32),
+}

--- a/crates/librqbit_core/src/lib.rs
+++ b/crates/librqbit_core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod compact_ip;
 pub mod constants;
 pub mod directories;
+mod error;
 pub mod hash_id;
 pub mod lengths;
 pub mod magnet;
@@ -8,5 +9,7 @@ pub mod peer_id;
 pub mod spawn_utils;
 pub mod speed_estimator;
 pub mod torrent_metainfo;
-
 pub use hash_id::Id20;
+
+pub use error::Error;
+pub type Result<T> = std::result::Result<T, Error>;


### PR DESCRIPTION
Addresses https://github.com/ikatson/rqbit/issues/452

It doesn't guess filename encoding, but instead just uses String::from_utf8_lossy everywhere. Invalid bits will look like ```����� �������```