### PR TITLE
Allow specifying DHT bootstrap nodes from commandline or environment

### DIFF
--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -395,6 +395,8 @@ pub struct SessionOptions {
     /// Pass in to configure DHT persistence filename. This can be used to run multiple
     /// librqbit instances at a time.
     pub dht_config: Option<PersistentDhtConfig>,
+    /// A list o DHT bootstrap nodes as strings of the form host:port or ip:port
+    pub dht_bootstrap_addrs: Option<Vec<String>>,
 
     /// What network device to bind to for DHT, BT-UDP, BT-TCP, trackers and LSD.
     /// On OSX will use IP(V6)_BOUND_IF, on Linux will use SO_BINDTODEVICE.
@@ -539,6 +541,7 @@ impl Session {
             } else {
                 let dht = if opts.disable_dht_persistence {
                     DhtBuilder::with_config(DhtConfig {
+                        bootstrap_addrs: opts.dht_bootstrap_addrs.clone(),
                         cancellation_token: Some(token.child_token()),
                         bind_device: bind_device.as_ref(),
                         ..Default::default()

--- a/crates/rqbit/src/main.rs
+++ b/crates/rqbit/src/main.rs
@@ -119,6 +119,11 @@ struct Opts {
     )]
     disable_dht_persistence: bool,
 
+    /// Set DHT bootstrap addrs
+    /// A comma separated list of host:port or ip:port
+    #[arg(long = "dht-bootstrap-addrs", env = "RQBIT_DHT_BOOTSTRAP")]
+    dht_bootstrap_addrs: Option<String>,
+
     /// The connect timeout, e.g. 1s, 1.5s, 100ms etc.
     #[arg(long = "peer-connect-timeout", value_parser = parse_duration::parse, default_value="2s", env="RQBIT_PEER_CONNECT_TIMEOUT")]
     peer_connect_timeout: Duration,
@@ -536,6 +541,10 @@ async fn async_main(mut opts: Opts, cancel: CancellationToken) -> anyhow::Result
     let mut sopts = SessionOptions {
         disable_dht: opts.disable_dht,
         disable_dht_persistence: opts.disable_dht_persistence,
+        dht_bootstrap_addrs: match opts.dht_bootstrap_addrs {
+            None => None,
+            Some(ref s) => Some(s.split(",").map(|v| v.to_string()).collect()),
+        },
         dht_config: None,
         // This will be overridden by "server start" below if needed.
         persistence: None,


### PR DESCRIPTION
Use the argument --dht-bootstrap-addrs or environment variable RQBIT_DHT_BOOTSTRAP to pass a comma separated list of ip:port or host:port values. This has been useful for me when the hostnames of the default bootstrap nodes to not resolve.