### PR TITLE
implement whitelist option #495

### DIFF
--- a/crates/librqbit/src/allowlist.rs
+++ b/crates/librqbit/src/allowlist.rs
@@ -13,7 +13,7 @@ use tokio_util::io::StreamReader;
 use tracing::trace;
 use url::Url;
 
-pub struct Whitelist {
+pub struct Allowlist {
     // We could store only one interval tree, but splitting them takes less memory,
     // as IpAddr is 17 bytes, Ipv4Addr is only 4 bytes (the majority of ranges).
     v4: IntervalTreeWithSize<Ipv4Addr>,
@@ -34,7 +34,7 @@ fn interval_tree<T: Clone + Ord>(it: impl Iterator<Item = Range<T>>) -> Interval
     IntervalTreeWithSize { t, len }
 }
 
-impl Whitelist {
+impl Allowlist {
     pub fn empty() -> Self {
         Self {
             v4: interval_tree(empty()),
@@ -69,9 +69,9 @@ impl Whitelist {
 
         let response = reqwest::get(parsed_url)
             .await
-            .context("error fetching whitelist")?;
+            .context("error fetching allowlist")?;
         if !response.status().is_success() {
-            anyhow::bail!("error fetching whitelist: HTTP {}", response.status());
+            anyhow::bail!("error fetching allowlist: HTTP {}", response.status());
         }
 
         let mut reader = StreamReader::new(response.bytes_stream().map_err(std::io::Error::other));
@@ -185,64 +185,64 @@ mod tests {
     use async_compression::tokio::write::GzipEncoder;
     use tokio::io::AsyncWriteExt;
 
-    const WHITELIST: &[u8] = br#"
+    const ALLOWLIST: &[u8] = br#"
     # test
     local:192.168.1.1-192.168.1.255
     localv6:2001:db8::1-2001:db8::ffff
     "#;
 
     #[tokio::test]
-    async fn test_whitelist_gzipped() -> Result<()> {
-        let mut gzipped_whitelist = Vec::new();
+    async fn test_allowlist_gzipped() -> Result<()> {
+        let mut gzipped_allowlist = Vec::new();
         {
-            let mut encoder = GzipEncoder::new(&mut gzipped_whitelist);
-            encoder.write_all(WHITELIST).await.unwrap();
+            let mut encoder = GzipEncoder::new(&mut gzipped_allowlist);
+            encoder.write_all(ALLOWLIST).await.unwrap();
             encoder.flush().await.unwrap();
             encoder.shutdown().await.unwrap();
         }
-        let whitelist = Whitelist::create_from_stream(&mut Cursor::new(gzipped_whitelist)).await?;
-        assert!(whitelist.is_allowed("192.168.1.1".parse().unwrap()));
-        assert!(!whitelist.is_allowed("8.8.8.8".parse().unwrap()));
+        let allowlist = Allowlist::create_from_stream(&mut Cursor::new(gzipped_allowlist)).await?;
+        assert!(allowlist.is_allowed("192.168.1.1".parse().unwrap()));
+        assert!(!allowlist.is_allowed("8.8.8.8".parse().unwrap()));
 
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_whitelist_plaintext() -> Result<()> {
-        let whitelist = Whitelist::create_from_stream(&mut Cursor::new(WHITELIST)).await?;
-        assert!(whitelist.is_allowed("192.168.1.1".parse().unwrap()));
-        assert!(!whitelist.is_allowed("8.8.8.8".parse().unwrap()));
+    async fn test_allowlist_plaintext() -> Result<()> {
+        let allowlist = Allowlist::create_from_stream(&mut Cursor::new(ALLOWLIST)).await?;
+        assert!(allowlist.is_allowed("192.168.1.1".parse().unwrap()));
+        assert!(!allowlist.is_allowed("8.8.8.8".parse().unwrap()));
 
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_whitelist_from_plaintext_file() -> Result<()> {
+    async fn test_allowlist_from_plaintext_file() -> Result<()> {
         // Create a temporary file
-        let mut temp_file = tokio::fs::File::create("temp_whitelist.txt").await?;
-        tokio::io::AsyncWriteExt::write_all(&mut temp_file, WHITELIST).await?;
+        let mut temp_file = tokio::fs::File::create("temp_allowlist.txt").await?;
+        tokio::io::AsyncWriteExt::write_all(&mut temp_file, ALLOWLIST).await?;
         drop(temp_file); // Close the file
 
-        // Load the whitelist from the file
-        let whitelist = Whitelist::load_from_file("temp_whitelist.txt").await?;
+        // Load the allowlist from the file
+        let allowlist = Allowlist::load_from_file("temp_allowlist.txt").await?;
 
-        // Verify the whitelist
-        assert!(whitelist.is_allowed("192.168.1.1".parse().unwrap()));
-        assert!(!whitelist.is_allowed("8.8.8.8".parse().unwrap()));
-        assert!(whitelist.is_allowed("2001:db8::1".parse().unwrap()));
-        assert!(!whitelist.is_allowed("2001:4860:4860::8888".parse().unwrap()));
+        // Verify the allowlist
+        assert!(allowlist.is_allowed("192.168.1.1".parse().unwrap()));
+        assert!(!allowlist.is_allowed("8.8.8.8".parse().unwrap()));
+        assert!(allowlist.is_allowed("2001:db8::1".parse().unwrap()));
+        assert!(!allowlist.is_allowed("2001:4860:4860::8888".parse().unwrap()));
 
         // Clean up the temporary file
-        tokio::fs::remove_file("temp_whitelist.txt").await?;
+        tokio::fs::remove_file("temp_allowlist.txt").await?;
 
         Ok(())
     }
 
     #[test]
-    fn test_whitelist_empty() {
-        let whitelist = Whitelist::empty();
-        assert!(!whitelist.is_allowed("127.0.0.1".parse().unwrap()));
-        assert!(!whitelist.is_allowed("::1".parse().unwrap()));
+    fn test_allowlist_empty() {
+        let allowlist = Allowlist::empty();
+        assert!(!allowlist.is_allowed("127.0.0.1".parse().unwrap()));
+        assert!(!allowlist.is_allowed("::1".parse().unwrap()));
     }
 
     #[test]
@@ -257,21 +257,21 @@ mod tests {
         let end_v6: Ipv6Addr = "2001:db8::ffff".parse().unwrap();
         let ipv6_range = start_v6..end_v6;
 
-        let whitelist = Whitelist::new(Some(ipv4_range), Some(ipv6_range));
+        let allowlist = Allowlist::new(Some(ipv4_range), Some(ipv6_range));
         // Test IPv4 addresses
-        assert!(whitelist.is_allowed("192.168.1.1".parse().unwrap()));
-        assert!(!whitelist.is_allowed("10.0.0.1".parse().unwrap()));
+        assert!(allowlist.is_allowed("192.168.1.1".parse().unwrap()));
+        assert!(!allowlist.is_allowed("10.0.0.1".parse().unwrap()));
 
         // Test IPv6 addresses
-        assert!(whitelist.is_allowed("2001:db8::1".parse().unwrap()));
-        assert!(!whitelist.is_allowed("2001:db9::1".parse().unwrap()));
+        assert!(allowlist.is_allowed("2001:db8::1".parse().unwrap()));
+        assert!(!allowlist.is_allowed("2001:db9::1".parse().unwrap()));
     }
 
     #[ignore]
     #[tokio::test]
-    async fn test_whitelist_real_url() {
+    async fn test_allowlist_real_url() {
         setup_test_logging();
-        let _ = Whitelist::load_from_url("https://raw.githubusercontent.com/Naunter/BT_BlockLists/refs/heads/master/bt_blocklists.gz")
+        let _ = Allowlist::load_from_url("https://raw.githubusercontent.com/Naunter/BT_BlockLists/refs/heads/master/bt_blocklists.gz")
             .await
             .unwrap();
     }

--- a/crates/librqbit/src/lib.rs
+++ b/crates/librqbit/src/lib.rs
@@ -41,6 +41,7 @@ macro_rules! aframe {
 #[macro_use]
 mod stat_gen;
 
+mod allowlist;
 pub mod api;
 mod api_error;
 mod bitv;
@@ -68,7 +69,6 @@ mod session;
 mod session_persistence;
 pub mod session_stats;
 mod spawn_utils;
-mod whitelist;
 
 pub mod storage;
 mod stream_connect;

--- a/crates/librqbit/src/torrent_state/live/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/mod.rs
@@ -605,7 +605,7 @@ impl TorrentStateLive {
             }
 
             if session
-                .whitelist
+                .allowlist
                 .as_ref()
                 .is_some_and(|l| !l.is_allowed(addr.ip()))
             {
@@ -614,7 +614,7 @@ impl TorrentStateLive {
                     .counters
                     .blocked_outgoing
                     .fetch_add(1, Ordering::Relaxed);
-                debug!(?addr, "blocked outgoing connection (by the whitelist)");
+                debug!(?addr, "blocked outgoing connection (by the allowlist)");
                 continue;
             }
 

--- a/crates/rqbit/src/main.rs
+++ b/crates/rqbit/src/main.rs
@@ -254,11 +254,11 @@ struct Opts {
     #[arg(long, env = "RQBIT_BLOCKLIST_URL")]
     blocklist_url: Option<String>,
 
-    /// Downloads a p2p whitelist from this url and blocks ALL connections BUT from/to those peers.
+    /// Downloads a p2p allowlist from this url and blocks ALL connections BUT from/to those peers.
     /// Supports file:/// and http(s):// URLs. Format is newline-delimited "name:start_ip-end_ip"
     /// E.g. https://github.com/Naunter/BT_BlockLists/raw/refs/heads/master/bt_blocklists.gz
-    #[arg(long, env = "RQBIT_WHITELIST_URL")]
-    whitelist_url: Option<String>,
+    #[arg(long, env = "RQBIT_ALLOW_URL")]
+    allowlist_url: Option<String>,
 
     /// The filename with tracker URLs to always use for each torrent. Newline-delimited.
     #[arg(long, env = "RQBIT_TRACKERS_FILENAME")]
@@ -588,7 +588,7 @@ async fn async_main(mut opts: Opts, cancel: CancellationToken) -> anyhow::Result
             download_bps: opts.ratelimit_download_bps,
         },
         blocklist_url: opts.blocklist_url.take(),
-        whitelist_url: opts.whitelist_url.take(),
+        allowlist_url: opts.allowlist_url.take(),
         disable_local_service_discovery: opts.disable_local_peer_discovery,
         disable_trackers: opts.disable_trackers,
         trackers,


### PR DESCRIPTION
#496

Please review, before merge as untested (only passing `cargo test`)

P.S. Why not to use the similar `Option` for the blacklist also, instead of empty struct. Is this updating dynamically somewhere? I think we may have ability to update list without app reload.