### PR TITLE
Add buttons to pause and resume all torrents

### DIFF
--- a/crates/librqbit/webui/src/components/Header.tsx
+++ b/crates/librqbit/webui/src/components/Header.tsx
@@ -1,5 +1,7 @@
 import { FileInput } from "./buttons/FileInput";
 import { MagnetInput } from "./buttons/MagnetInput";
+import { PauseButton } from "./buttons/PauseButton";
+import { ResumeButton } from "./buttons/ResumeButton";
 
 // @ts-ignore
 import Logo from "../../assets/logo.svg?react";
@@ -23,6 +25,8 @@ export const Header = ({
         </h1>
       </div>
       <div className="flex flex-wrap gap-1 m-2">
+        <PauseButton className="flex-grow justify-center dark:text-white" />
+        <ResumeButton className="flex-grow justify-center dark:text-white" />
         <MagnetInput className="flex-grow justify-center dark:text-white" />
         <FileInput className="flex-grow justify-center dark:text-white" />
       </div>

--- a/crates/librqbit/webui/src/components/buttons/PauseButton.tsx
+++ b/crates/librqbit/webui/src/components/buttons/PauseButton.tsx
@@ -1,0 +1,40 @@
+import { useContext, useState } from "react";
+import {
+  ErrorDetails as ApiErrorDetails,
+} from "../../api-types";
+import { APIContext } from "../../context";
+import { ErrorWithLabel } from "../../rqbit-web";
+import { Button } from "./Button";
+import { FaPause, FaPlay } from "react-icons/fa";
+
+export const PauseButton = ({ className }: { className?: string }) => {
+  const [pauseAllTorrentsError, setPauseAllTorrentsError] =
+    useState<ErrorWithLabel | null>(null);
+
+  const API = useContext(APIContext);
+
+  const pause = async () => {
+    try {
+      const listTorrentsResponse = await API.listTorrents();
+      await Promise.all(
+        listTorrentsResponse.torrents.map(async (torrent_id) => {
+          await API.pause(torrent_id.id);
+        })
+      );
+    } catch (e) {
+      setPauseAllTorrentsError({
+        text: "Error pausing all torrents",
+        details: e as ApiErrorDetails,
+      });
+    }
+  };
+
+  return (
+    <>
+      <Button onClick={pause} className={`group ${className}`}>
+        <FaPause className="text-blue-500 group-hover:text-white dark:text-white" />
+        <div>Pause all</div>
+      </Button>
+    </>
+  );
+};

--- a/crates/librqbit/webui/src/components/buttons/ResumeButton.tsx
+++ b/crates/librqbit/webui/src/components/buttons/ResumeButton.tsx
@@ -1,0 +1,40 @@
+import { useContext, useState } from "react";
+import {
+  ErrorDetails as ApiErrorDetails,
+} from "../../api-types";
+import { APIContext } from "../../context";
+import { ErrorWithLabel } from "../../rqbit-web";
+import { Button } from "./Button";
+import { FaPlay } from "react-icons/fa";
+
+export const ResumeButton = ({ className }: { className?: string }) => {
+  const [resumeAllTorrentsError, setResumeAllTorrentsError] =
+    useState<ErrorWithLabel | null>(null);
+
+  const API = useContext(APIContext);
+
+  const resume = async () => {
+    try {
+      const listTorrentsResponse = await API.listTorrents();
+      await Promise.all(
+        listTorrentsResponse.torrents.map(async (torrent_id) => {
+          await API.start(torrent_id.id)
+        })
+      );
+    } catch (e) {
+      setResumeAllTorrentsError({
+        text: "Error resuming all torrents",
+        details: e as ApiErrorDetails,
+      });
+    }
+  };
+
+  return (
+    <>
+      <Button onClick={resume} className={`group ${className}`}>
+        <FaPlay className="text-blue-500 group-hover:text-white dark:text-white" />
+        <div>Resume all</div>
+      </Button>
+    </>
+  );
+};


### PR DESCRIPTION
Apologies, I don't really know what I'm doing with react.

It works, but it takes a second to update the torrents, I'm guessing there's some callback or something I need to be doing to trigger that correctly.

Could be done with two new HTTP endpoints, the current method requires `N+1` requests. 

I think a single button that toggles between pausing and resuming all would be nice.