### PR TITLE
Use `serde_derive` dependency instead of `serde/derive` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2908,6 +2908,7 @@ dependencies = [
  "reqwest",
  "rlimit",
  "serde",
+ "serde_derive",
  "serde_json",
  "serde_urlencoded",
  "serde_with",
@@ -2942,6 +2943,7 @@ dependencies = [
  "librqbit-buffers",
  "librqbit-clone-to-owned",
  "serde",
+ "serde_derive",
  "thiserror 2.0.17",
 ]
 
@@ -2952,6 +2954,7 @@ dependencies = [
  "bytes",
  "librqbit-clone-to-owned",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -2981,6 +2984,7 @@ dependencies = [
  "parking_lot",
  "rand 0.9.2",
  "serde",
+ "serde_derive",
  "serde_json",
  "thiserror 2.0.17",
  "tokio",
@@ -3009,6 +3013,7 @@ dependencies = [
  "parking_lot",
  "rand 0.9.2",
  "serde",
+ "serde_derive",
  "serde_json",
  "thiserror 2.0.17",
  "tokio",
@@ -3070,6 +3075,7 @@ dependencies = [
  "librqbit-clone-to-owned",
  "librqbit-core",
  "serde",
+ "serde_derive",
  "thiserror 2.0.17",
  "tracing",
 ]
@@ -3101,6 +3107,7 @@ dependencies = [
  "rand 0.9.2",
  "reqwest",
  "serde",
+ "serde_derive",
  "serde_with",
  "tokio",
  "tokio-util",
@@ -3122,6 +3129,7 @@ dependencies = [
  "quick-xml",
  "reqwest",
  "serde",
+ "serde_derive",
  "socket2",
  "tokio",
  "tracing",
@@ -3150,6 +3158,7 @@ dependencies = [
  "rand 0.9.2",
  "reqwest",
  "serde",
+ "serde_derive",
  "tokio",
  "tokio-util",
  "tower-http",
@@ -4909,6 +4918,7 @@ dependencies = [
  "parse_duration",
  "regex",
  "serde",
+ "serde_derive",
  "serde_json",
  "signal-hook",
  "size_format",
@@ -4933,6 +4943,7 @@ dependencies = [
  "metrics-exporter-prometheus",
  "parking_lot",
  "serde",
+ "serde_derive",
  "serde_json",
  "serde_with",
  "tauri",

--- a/crates/bencode/Cargo.toml
+++ b/crates/bencode/Cargo.toml
@@ -9,7 +9,8 @@ repository = "https://github.com/ikatson/rqbit"
 readme = "README.md"
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
+serde = "1"
+serde_derive = "1"
 buffers = { path = "../buffers", package = "librqbit-buffers", version = "4.2" }
 clone_to_owned = { path = "../clone_to_owned", package = "librqbit-clone-to-owned", version = "3" }
 bytes = "1.7.1"

--- a/crates/buffers/Cargo.toml
+++ b/crates/buffers/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
+serde = "1"
+serde_derive = "1"
 clone_to_owned = { path = "../clone_to_owned", package = "librqbit-clone-to-owned", version = "3" }
 bytes = "1"

--- a/crates/dht/Cargo.toml
+++ b/crates/dht/Cargo.toml
@@ -16,7 +16,8 @@ tokio = { version = "1", features = [
     "sync",
 ] }
 tokio-stream = { version = "0.1", features = ["sync"] }
-serde = { version = "1", features = ["derive"] }
+serde = "1"
+serde_derive = "1"
 leaky-bucket = "1.1"
 serde_json = "1"
 librqbit-buffers = { path = "../buffers", version = "4.2.0" }

--- a/crates/librqbit/Cargo.toml
+++ b/crates/librqbit/Cargo.toml
@@ -71,7 +71,8 @@ console-subscriber = { version = "0.5", optional = true }
 axum = { version = "0.8", optional = true }
 tower-http = { version = "0.6", features = ["cors", "trace"], optional = true }
 tokio-stream = "0.1"
-serde = { version = "1", features = ["derive", "rc"] }
+serde = { version = "1", features = ["rc"] }
+serde_derive = "1"
 serde_json = "1"
 serde_urlencoded = "0.7"
 anyhow = "1"

--- a/crates/librqbit_core/Cargo.toml
+++ b/crates/librqbit_core/Cargo.toml
@@ -22,7 +22,8 @@ anyhow = "1"
 url = { version = "2", default-features = false }
 rand = "0.9"
 parking_lot = "0.12"
-serde = { version = "1", features = ["derive"] }
+serde = "1"
+serde_derive = "1"
 buffers = { path = "../buffers", package = "librqbit-buffers", version = "4.2" }
 bencode = { path = "../bencode", default-features = false, package = "librqbit-bencode", version = "3.1" }
 clone_to_owned = { path = "../clone_to_owned", package = "librqbit-clone-to-owned", version = "3" }

--- a/crates/peer_binary_protocol/Cargo.toml
+++ b/crates/peer_binary_protocol/Cargo.toml
@@ -10,7 +10,8 @@ readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-serde = { version = "1", features = ["derive"] }
+serde = "1"
+serde_derive = "1"
 byteorder = "1"
 buffers = { path = "../buffers", package = "librqbit-buffers", version = "4.2" }
 bencode = { path = "../bencode", default-features = false, package = "librqbit-bencode", version = "3.1" }

--- a/crates/rqbit/Cargo.toml
+++ b/crates/rqbit/Cargo.toml
@@ -46,7 +46,8 @@ regex = "1"
 futures = "0.3"
 parse_duration = "2"
 parking_lot = { version = "0.12" }
-serde = { version = "1", features = ["derive"] }
+serde = "1"
+serde_derive = "1"
 serde_json = "1"
 size_format = "1"
 bytes = "1.5.0"

--- a/crates/tracker_comms/Cargo.toml
+++ b/crates/tracker_comms/Cargo.toml
@@ -17,7 +17,8 @@ async-stream = "0.3.5"
 buffers = { path = "../buffers", package = "librqbit-buffers", version = "4.2" }
 librqbit-core = { path = "../librqbit_core", default-features = false, version = "5" }
 byteorder = "1.5"
-serde = { version = "1", features = ["derive"] }
+serde = "1"
+serde_derive = "1"
 urlencoding = "2"
 rand = "0.9"
 tracing = "0.1.40"

--- a/crates/upnp-serve/Cargo.toml
+++ b/crates/upnp-serve/Cargo.toml
@@ -14,7 +14,8 @@ axum = { version = "0.8", features = ["tokio"] }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1.40"
 bstr = "1.10.0"
-serde = { version = "1", features = ["derive"] }
+serde = "1"
+serde_derive = "1"
 http = "1.1.0"
 httparse = "1.9.4"
 uuid = { version = "1.10.0", features = ["v4"] }

--- a/crates/upnp/Cargo.toml
+++ b/crates/upnp/Cargo.toml
@@ -15,7 +15,8 @@ readme = "README.md"
 tracing = "0.1"
 anyhow = "1"
 reqwest = { version = "0.12", default-features = false }
-serde = { version = "1", features = ["derive"] }
+serde = "1"
+serde_derive = "1"
 tokio = { version = "1", features = ["macros"] }
 futures = "0.3"
 url = { version = "2", default-features = false }

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -13,7 +13,8 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 tauri = { version = "2", features = [] }
-serde = { version = "1.0", features = ["derive"] }
+serde = "1"
+serde_derive = "1"
 serde_json = "1.0"
 librqbit = { path = "../../crates/librqbit", features = [
     "tracing-subscriber-utils",


### PR DESCRIPTION
See https://github.com/serde-rs/serde/pull/2588 for more details.
This speeds up compilation of workspace (excluding `rqbit-desktop`) from 76.3s to 71.4s.
(Tested with cranelift on workspace members + mold)

[cargo-timings-before.html](https://github.com/user-attachments/files/23336971/cargo-timings-before.html)
[cargo-timings-after.html](https://github.com/user-attachments/files/23336973/cargo-timings-after.html)
