### PR TITLE
[WIP] Use workspace dependencies and try to unify duplicates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,38 +285,11 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
-dependencies = [
- "async-trait",
- "axum-core 0.4.5",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "itoa",
- "matchit 0.7.3",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper",
- "tower 0.5.2",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a18ed336352031311f4e0b4dd2ff392d4fbb370777c9d18d7fc9d7359f73871"
 dependencies = [
- "axum-core 0.5.5",
+ "axum-core",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -326,7 +299,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit 0.8.4",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
@@ -337,30 +310,10 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower 0.5.2",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -388,8 +341,8 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9963ff19f40c6102c76756ef0a46004c0d58957d87259fc9208ff8441c12ab96"
 dependencies = [
- "axum 0.8.6",
- "axum-core 0.5.5",
+ "axum",
+ "axum-core",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -899,22 +852,23 @@ dependencies = [
 
 [[package]]
 name = "console-api"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8030735ecb0d128428b64cd379809817e620a40e5001c54465b99ec5feec2857"
+checksum = "e8599749b6667e2f0c910c1d0dff6901163ff698a52d5a39720f61b5be4b20d3"
 dependencies = [
  "futures-core",
  "prost",
  "prost-types",
  "tonic",
+ "tonic-prost",
  "tracing-core",
 ]
 
 [[package]]
 name = "console-subscriber"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6539aa9c6a4cd31f4b1c040f860a1eac9aa80e7df6b05d506a6e7179936d6a01"
+checksum = "fb4915b7d8dd960457a1b6c380114c2944f728e7c65294ab247ae6b6f1f37592"
 dependencies = [
  "console-api",
  "crossbeam-channel",
@@ -2415,7 +2369,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -2912,7 +2866,7 @@ dependencies = [
  "async-compression",
  "async-stream",
  "async-trait",
- "axum 0.8.6",
+ "axum",
  "axum-extra",
  "backon",
  "base64 0.22.1",
@@ -2958,7 +2912,7 @@ dependencies = [
  "serde_urlencoded",
  "serde_with",
  "size_format",
- "socket2 0.6.1",
+ "socket2",
  "sqlx",
  "tempfile",
  "thiserror 2.0.17",
@@ -3070,12 +3024,12 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52135d1583bc772b74d5dc72a75ca8ed810463159c028d0b28609f597fffa816"
 dependencies = [
- "axum 0.8.6",
+ "axum",
  "backon",
  "futures",
  "libc",
  "network-interface",
- "socket2 0.6.1",
+ "socket2",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -3168,7 +3122,7 @@ dependencies = [
  "quick-xml",
  "reqwest",
  "serde",
- "socket2 0.6.1",
+ "socket2",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3180,7 +3134,7 @@ name = "librqbit-upnp-serve"
 version = "1.0.1"
 dependencies = [
  "anyhow",
- "axum 0.8.6",
+ "axum",
  "bstr",
  "futures",
  "gethostname",
@@ -3221,7 +3175,7 @@ dependencies = [
  "rand 0.9.2",
  "ringbuf",
  "rustc-hash 2.1.1",
- "socket2 0.6.1",
+ "socket2",
  "thiserror 2.0.17",
  "tokio",
  "tokio-util",
@@ -3328,12 +3282,6 @@ name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
-
-[[package]]
-name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matchit"
@@ -4508,9 +4456,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -4518,9 +4466,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.5"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -4531,9 +4479,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.13.5"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
 dependencies = [
  "prost",
 ]
@@ -4576,7 +4524,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.6.1",
+ "socket2",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -4613,7 +4561,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4895,7 +4843,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
- "tower 0.5.2",
+ "tower",
  "tower-http",
  "tower-service",
  "url",
@@ -5516,16 +5464,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6306,7 +6244,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.1",
+ "socket2",
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
@@ -6491,13 +6429,12 @@ checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
 dependencies = [
- "async-stream",
  "async-trait",
- "axum 0.7.9",
+ "axum",
  "base64 0.22.1",
  "bytes",
  "h2",
@@ -6509,34 +6446,25 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost",
- "socket2 0.5.10",
+ "socket2",
+ "sync_wrapper",
  "tokio",
  "tokio-stream",
- "tower 0.4.13",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
 ]
 
 [[package]]
-name = "tower"
-version = "0.4.13"
+name = "tonic-prost"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
 dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.5",
- "slab",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
+ "bytes",
+ "prost",
+ "tonic",
 ]
 
 [[package]]
@@ -6547,9 +6475,12 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.11.4",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -6568,7 +6499,7 @@ dependencies = [
  "http-body",
  "iri-string",
  "pin-project-lite",
- "tower 0.5.2",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,119 @@ lto = false
 [profile.release-debug]
 inherits = "release"
 debug = true
+
+[workspace.dependencies]
+anyhow = "1"
+arc-swap = "1.7.1"
+arrayvec = "0.7.6"
+assert_cfg = "0.1.0"
+async-backtrace = "0.2"
+async-compression = { version = "0.4.18", features = ["tokio", "gzip"] }
+async-stream = "0.3.5"
+async-trait = "0.1.81"
+atoi = "2.0.0"
+aws-lc-rs = "1.12"
+axum = { version = "0.8", features = ["tokio"] }
+# axum = { version = "0.8", optional = true }
+axum-extra = { version = "0.10.1", features = ["query"] }
+backon = { version = "1.5", features = ["tokio-sleep"] }
+base64 = "0.22"
+bencode = { path = "crates/bencode", default-features = false, package = "librqbit-bencode", version = "3.1" }
+bincode = "2"
+bitvec = "1"
+bstr = "1.12.0"
+buffers = { path = "crates/buffers", package = "librqbit-buffers", version = "4.2" }
+byteorder = "1"
+bytes = "1"
+chardetng = "0.1.17"
+chrono = { version = "0.4.31", features = ["serde"] }
+clap = { version = "4.5", features = ["derive", "deprecated", "env"] }
+clap_complete = "4.5"
+clone_to_owned = { path = "crates/clone_to_owned", package = "librqbit-clone-to-owned", version = "3" }
+console-subscriber = "0.5"
+criterion = "0.7.0"
+crypto-hash = "0.3"
+dashmap = { version = "6", features = ["serde"] }
+data-encoding = "2.6.0"
+dht = { path = "crates/dht", package = "librqbit-dht", default-features = false, version = "5.3.0" }
+directories = "6"
+encoding_rs = "0.8.35"
+futures = "0.3"
+gethostname = "1"
+governor = "0.10"
+hex = "0.4"
+http = "1"
+httparse = "1.10.1"
+indexmap = "2"
+intervaltree = "0.2.7"
+itertools = "0.14"
+leaky-bucket = "1.1"
+libc = "0.2.158"
+librqbit = { version = "9.0.0-beta.1", path = "crates/librqbit", default-features = false, features = [ "http-api", "http-api-client", "tracing-subscriber-utils", "upnp-serve-adapter", "watch", ] }
+librqbit-buffers = { path = "crates/buffers", version = "4.2.0" }
+librqbit-core = { path = "crates/librqbit_core", default-features = false, version = "5" }
+# librqbit-dualstack-sockets = "0.6.11"
+librqbit-dualstack-sockets = { version = "0.6.11", features = ["axum"] }
+librqbit-lsd = { path = "crates/librqbit_lsd", default-features = false, package = "librqbit-lsd", version = "0.1.0" }
+# librqbit-sha1-wrapper = { path = "crates/sha1w", version = "4", default-features = false }
+librqbit-upnp = { path = "crates/upnp", version = "1" }
+librqbit-utp = { version = "0.6.2", features = ["export-metrics"] }
+lru = "0.16"
+memchr = "2.7.5"
+memmap2 = { version = "0.9.4" }
+metrics-exporter-prometheus = { version = "0.17", default-features = false }
+mime_guess = { version = "2.0.5", default-features = false }
+network-interface = "2"
+nix = { version = "0.30.1", features = ["uio"] }
+notify = "8"
+openssl = { version = "0.10" }
+parking_lot = "0.12"
+parse_duration = "2"
+peer_binary_protocol = { path = "crates/peer_binary_protocol", default-features = false, package = "librqbit-peer-protocol", version = "4.3" }
+quick-xml = { version = "0.38.3", features = ["serialize"] }
+rand = "0.9"
+regex = "1"
+# reqwest = { version = "0.12", default-features = false }
+reqwest = { version = "0.12", default-features = false, features = [ "json", "socks", "stream", ] }
+# reqwest = { version = "0.12", default-features = false, features = ["json"] }
+rlimit = "0.10.1"
+serde = { version = "1", features = ["derive", "rc"] }
+# serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde_urlencoded = "0.7"
+serde_with = "3.13.0"
+sha1w = { path = "crates/sha1w", package = "librqbit-sha1-wrapper", version = "4.1" }
+# sha1w = { path = "crates/sha1w", default-features = false, package = "librqbit-sha1-wrapper", version = "4.1" }
+# sha1w = { path = "crates/sha1w", package = "librqbit-sha1-wrapper", version = "4.1", default-features = false, optional = true }
+signal-hook = "0.3.17"
+size_format = "1"
+socket2 = "0.6"
+tempfile = "3"
+thiserror = "2.0.12"
+tokio = { version = "1", default-features = false }
+tokio-socks = "0.5.2"
+tokio-stream = { version = "0.1", features = ["sync"] }
+tokio-test = "0.4"
+tokio-util = { version = "0.7.15", features = ["io"] }
+tower-http = { version = "0.6", features = ["cors", "trace"] }
+# tower-http = { version = "0.6.2", features = ["trace"] }
+tracing = "0.1"
+# tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", default-features = false, features = [ "json", "fmt", "env-filter", ] }
+# tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracker_comms = { path = "crates/tracker_comms", default-features = false, package = "librqbit-tracker-comms", version = "3" }
+upnp-serve = { path = "crates/upnp-serve", default-features = false, version = "1", package = "librqbit-upnp-serve" }
+# upnp-serve = { path = "crates/upnp-serve", package = "librqbit-upnp-serve", default-features = false, version = "1", optional = true }
+# url = "2"
+# url = { version = "2", default-features = false }
+urlencoding = "2"
+uuid = { version = "1.10.0", features = ["v4"] }
+# uuid = { version = "1.2", features = ["v4"] }
+walkdir = "2.5.0"
+
+# sqlx and home are pinned so that we can compile on older Rusts
+sqlx = { version = "0.8", features = [ "runtime-tokio", "macros", "postgres", ], default-features = false }
+home = "0.5"
+url = { version = "^2.5.2", default-features = false, features = [
+    "serde",
+] } # can't upgrade yet until min version is Rust 1.81, see https://github.com/servo/rust-url/issues/992

--- a/crates/bencode/Cargo.toml
+++ b/crates/bencode/Cargo.toml
@@ -9,11 +9,11 @@ repository = "https://github.com/ikatson/rqbit"
 readme = "README.md"
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
-buffers = { path = "../buffers", package = "librqbit-buffers", version = "4.2" }
-clone_to_owned = { path = "../clone_to_owned", package = "librqbit-clone-to-owned", version = "3" }
-bytes = "1.7.1"
-atoi = "2.0.0"
-thiserror = "2.0.12"
-arrayvec = "0.7.6"
-anyhow = "1.0.98"
+serde.workspace = true
+buffers.workspace = true
+clone_to_owned.workspace = true
+bytes.workspace = true
+atoi.workspace = true
+thiserror.workspace = true
+arrayvec.workspace = true
+anyhow.workspace = true

--- a/crates/buffers/Cargo.toml
+++ b/crates/buffers/Cargo.toml
@@ -7,9 +7,7 @@ license = "Apache-2.0"
 documentation = "https://docs.rs/librqbit-buffers"
 readme = "README.md"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-serde = { version = "1", features = ["derive"] }
-clone_to_owned = { path = "../clone_to_owned", package = "librqbit-clone-to-owned", version = "3" }
-bytes = "1"
+bytes.workspace = true 
+clone_to_owned.workspace = true
+serde.workspace = true

--- a/crates/clone_to_owned/Cargo.toml
+++ b/crates/clone_to_owned/Cargo.toml
@@ -7,7 +7,5 @@ license = "Apache-2.0"
 documentation = "https://docs.rs/librqbit-clone-to-owned"
 readme = "README.md"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-bytes = "1.10"
+bytes.workspace = true

--- a/crates/dht/Cargo.toml
+++ b/crates/dht/Cargo.toml
@@ -9,33 +9,29 @@ repository = "https://github.com/ikatson/rqbit"
 readme = "README.md"
 
 [dependencies]
-tokio = { version = "1", features = [
-    "macros",
-    "rt-multi-thread",
-    "net",
-    "sync",
-] }
-tokio-stream = { version = "0.1", features = ["sync"] }
-serde = { version = "1", features = ["derive"] }
-leaky-bucket = "1.1"
-serde_json = "1"
-librqbit-buffers = { path = "../buffers", version = "4.2.0" }
-bencode = { path = "../bencode", default-features = false, package = "librqbit-bencode", version = "3.1" }
-anyhow = "1"
-parking_lot = "0.12"
-tracing = "0.1"
-backon = { version = "1.5", features = ["tokio-sleep"] }
-futures = "0.3"
-rand = "0.9"
-indexmap = "2"
-dashmap = { version = "6", features = ["serde"] }
-clone_to_owned = { path = "../clone_to_owned", package = "librqbit-clone-to-owned", version = "3" }
-librqbit-core = { path = "../librqbit_core", default-features = false, version = "5" }
-chrono = { version = "0.4.31", features = ["serde"] }
-tokio-util = "0.7.10"
-bytes = "1.7.1"
-librqbit-dualstack-sockets = "0.6.11"
-thiserror = "2.0.12"
+librqbit-core.workspace = true
+librqbit-buffers.workspace = true
+librqbit-dualstack-sockets.workspace = true
+
+anyhow.workspace = true
+backon.workspace = true
+bencode.workspace = true
+bytes.workspace = true
+chrono.workspace = true
+clone_to_owned.workspace = true
+dashmap.workspace = true
+futures.workspace = true
+indexmap.workspace = true
+leaky-bucket.workspace = true
+parking_lot.workspace = true
+rand.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tokio-stream.workspace = true
+tokio-util.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "net", "sync"] }
+tracing.workspace = true
 
 [dev-dependencies]
-tracing-subscriber = "0.3"
+tracing-subscriber.workspace = true

--- a/crates/librqbit/Cargo.toml
+++ b/crates/librqbit/Cargo.toml
@@ -9,15 +9,13 @@ documentation = "https://docs.rs/librqbit"
 repository = "https://github.com/ikatson/rqbit"
 readme = "README.md"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [features]
 default = ["default-tls", "http-api-client"]
 
-tokio-console = ["console-subscriber", "tokio/tracing"]
-http-api = ["axum", "tower-http"]
+tokio-console = ["dep:console-subscriber", "tokio/tracing"]
+http-api = ["dep:axum", "dep:axum-extra", "dep:tower-http"]
 http-api-client = []
-upnp-serve-adapter = ["upnp-serve"]
+upnp-serve-adapter = ["dep:upnp-serve"]
 webui = []
 timed_existence = []
 default-tls = [
@@ -25,14 +23,14 @@ default-tls = [
     "sha1w/sha1-crypto-hash",
     "librqbit-core/sha1-crypto-hash",
 ]
-prometheus = ["metrics-exporter-prometheus"]
+prometheus = ["dep:metrics-exporter-prometheus"]
 rust-tls = ["reqwest/rustls-tls", "sha1w/sha1-ring", "librqbit-core/sha1-ring"]
-storage_middleware = ["lru"]
+storage_middleware = ["dep:lru"]
 storage_examples = []
-tracing-subscriber-utils = ["tracing-subscriber"]
-postgres = ["sqlx", "home"]
-async-bt = ["async-backtrace"]
-watch = ["notify"]
+tracing-subscriber-utils = ["dep:tracing-subscriber"]
+postgres = ["dep:sqlx", "dep:home"]
+async-bt = ["dep:async-backtrace"]
+watch = ["dep:notify"]
 disable-upload = []
 
 # These are absolutely useless for people, just for debugging / testing / benchmarking
@@ -40,95 +38,73 @@ _disable_disk_write_net_benchmark = []
 _disable_reconnect_test = []
 
 [dependencies]
-# sqlx and home are pinned so that we can compile on older Rusts
-sqlx = { version = "0.8", features = [
-    "runtime-tokio",
-    "macros",
-    "postgres",
-], default-features = false, optional = true }
-home = { version = "0.5", optional = true }
+librqbit-core.workspace = true
+librqbit-dualstack-sockets.workspace = true
+librqbit-lsd.workspace = true
+librqbit-upnp.workspace = true
+librqbit-utp.workspace = true
 
-bencode = { path = "../bencode", default-features = false, package = "librqbit-bencode", version = "3.1" }
-tracker_comms = { path = "../tracker_comms", default-features = false, package = "librqbit-tracker-comms", version = "3" }
-buffers = { path = "../buffers", package = "librqbit-buffers", version = "4.2" }
-librqbit-core = { path = "../librqbit_core", default-features = false, version = "5" }
-librqbit-lsd = { path = "../librqbit_lsd", default-features = false, package = "librqbit-lsd", version = "0.1.0" }
-clone_to_owned = { path = "../clone_to_owned", package = "librqbit-clone-to-owned", version = "3" }
-peer_binary_protocol = { path = "../peer_binary_protocol", default-features = false, package = "librqbit-peer-protocol", version = "4.3" }
-sha1w = { path = "../sha1w", default-features = false, package = "librqbit-sha1-wrapper", version = "4.1" }
-dht = { path = "../dht", package = "librqbit-dht", default-features = false, version = "5.3.0" }
-librqbit-upnp = { path = "../upnp", version = "1" }
-upnp-serve = { path = "../upnp-serve", package = "librqbit-upnp-serve", default-features = false, version = "1", optional = true }
-
-tokio = { version = "1", features = [
-    "macros",
-    "rt-multi-thread",
-    "fs",
-    "io-util",
-] }
-governor = "0.10"
-console-subscriber = { version = "0.4", optional = true }
-axum = { version = "0.8", optional = true }
-tower-http = { version = "0.6", features = ["cors", "trace"], optional = true }
-tokio-stream = "0.1"
-serde = { version = "1", features = ["derive", "rc"] }
-serde_json = "1"
-serde_urlencoded = "0.7"
-anyhow = "1"
-itertools = "0.14"
-http = "1"
-regex = "1"
-reqwest = { version = "0.12", default-features = false, features = [
-    "json",
-    "socks",
-    "stream",
-] }
-urlencoding = "2"
-byteorder = "1"
-bincode = "2"
-bitvec = "1"
-parking_lot = "0.12"
-tracing = "0.1.40"
-size_format = "1"
-rand = "0.9"
-tracing-subscriber = { version = "0.3", default-features = false, features = [
-    "json",
-    "fmt",
-    "env-filter",
-], optional = true }
-uuid = { version = "1.2", features = ["v4"] }
-futures = "0.3"
-url = { version = "^2.5.2", default-features = false, features = [
-    "serde",
-] } # can't upgrade yet until min version is Rust 1.81, see https://github.com/servo/rust-url/issues/992
-
-hex = "0.4"
-backon = "1.5"
-dashmap = "6"
-base64 = "0.22"
-serde_with = "3.4.0"
-tokio-util = { version = "0.7.10", features = ["io"] }
-metrics-exporter-prometheus = { version = "0.17", optional = true, default-features = false }
-bytes = "1.5.0"
-rlimit = "0.10.1"
-async-stream = "0.3.5"
-memmap2 = { version = "0.9.4" }
-lru = { version = "0.16", optional = true }
-mime_guess = { version = "2.0.5", default-features = false }
-tokio-socks = "0.5.2"
-async-trait = "0.1.81"
-async-backtrace = { version = "0.2", optional = true }
-notify = { version = "8", optional = true }
-walkdir = "2.5.0"
-arc-swap = "1.7.1"
-intervaltree = "0.2.7"
-async-compression = { version = "0.4.18", features = ["tokio", "gzip"] }
-librqbit-utp = { version = "0.6.2", features = ["export-metrics"] }
-axum-extra = { version = "0.10.1", features = ["query"] }
-librqbit-dualstack-sockets = { version = "0.6.11", features = ["axum"] }
-socket2 = "0.6"
-nix = { version = "0.30.1", features = ["uio"] }
-thiserror = "2.0.12"
+anyhow.workspace = true
+arc-swap.workspace = true
+async-backtrace = { workspace = true, optional = true }
+async-compression.workspace = true
+async-stream.workspace = true
+async-trait.workspace = true
+axum = { workspace = true, optional = true }
+axum-extra = { workspace = true, optional = true }
+backon.workspace = true
+base64.workspace = true
+bencode.workspace = true
+bincode.workspace = true
+bitvec.workspace = true
+buffers.workspace = true
+byteorder.workspace = true
+bytes.workspace = true
+clone_to_owned.workspace = true
+console-subscriber = { workspace = true, optional = true }
+dashmap.workspace = true
+dht.workspace = true
+futures.workspace = true
+governor.workspace = true
+hex.workspace = true
+home = { workspace = true, optional = true }
+http.workspace = true
+intervaltree.workspace = true
+itertools.workspace = true
+lru = { workspace = true, optional = true }
+memmap2.workspace = true
+metrics-exporter-prometheus = { workspace = true, optional = true }
+mime_guess.workspace = true
+nix.workspace = true
+notify = { workspace = true, optional = true }
+parking_lot.workspace = true
+peer_binary_protocol.workspace = true
+rand.workspace = true
+regex.workspace = true
+reqwest.workspace = true
+rlimit.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+serde_urlencoded.workspace = true
+serde_with.workspace = true
+sha1w.workspace = true
+size_format.workspace = true
+socket2.workspace = true
+sqlx = { workspace = true, optional = true }
+thiserror.workspace = true
+tokio-socks.workspace = true
+tokio-stream.workspace = true
+tokio-util.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "fs", "io-util"] }
+tower-http = { workspace = true, optional = true }
+tracing-subscriber = { workspace = true, optional = true }
+tracing.workspace = true
+tracker_comms.workspace = true
+upnp-serve = { workspace = true, optional = true }
+url.workspace = true
+urlencoding.workspace = true
+uuid.workspace = true
+walkdir.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.62.1", features = [
@@ -139,9 +115,9 @@ windows = { version = "0.62.1", features = [
 ] }
 
 [build-dependencies]
-anyhow = "1"
+anyhow.workspace = true
 
 [dev-dependencies]
-tracing-subscriber = "0.3"
-tokio-test = "0.4"
-tempfile = "3"
+tempfile.workspace = true
+tokio-test.workspace = true
+tracing-subscriber.workspace = true

--- a/crates/librqbit/webui/package-lock.json
+++ b/crates/librqbit/webui/package-lock.json
@@ -73,6 +73,7 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1470,6 +1471,7 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -1627,6 +1629,7 @@
       "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1841,6 +1844,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -2917,6 +2921,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3095,6 +3100,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3107,6 +3113,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3590,6 +3597,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3629,6 +3637,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3699,6 +3708,7 @@
       "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -3807,6 +3817,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/crates/librqbit_core/Cargo.toml
+++ b/crates/librqbit_core/Cargo.toml
@@ -8,34 +8,33 @@ documentation = "https://docs.rs/librqbit-core"
 repository = "https://github.com/ikatson/rqbit"
 readme = "README.md"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 default = ["sha1-crypto-hash"]
 sha1-crypto-hash = ["sha1w/sha1-crypto-hash"]
 sha1-ring = ["sha1w/sha1-ring"]
 
 [dependencies]
-tracing = "0.1.40"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
-hex = "0.4"
-anyhow = "1"
-url = { version = "2", default-features = false }
-rand = "0.9"
-parking_lot = "0.12"
-serde = { version = "1", features = ["derive"] }
-buffers = { path = "../buffers", package = "librqbit-buffers", version = "4.2" }
-bencode = { path = "../bencode", default-features = false, package = "librqbit-bencode", version = "3.1" }
-clone_to_owned = { path = "../clone_to_owned", package = "librqbit-clone-to-owned", version = "3" }
-sha1w = { path = "../sha1w", package = "librqbit-sha1-wrapper", version = "4.1", default-features = false, optional = true }
-itertools = "0.14"
-directories = "6"
-tokio-util = "0.7.10"
-data-encoding = "2.6.0"
-bytes = "1.7.1"
-memchr = "2.7.5"
-thiserror = "2.0.12"
-chardetng = "0.1.17"
-encoding_rs = "0.8.35"
+anyhow.workspace = true
+bencode.workspace = true
+buffers.workspace = true
+bytes.workspace = true
+chardetng.workspace = true
+clone_to_owned.workspace = true
+data-encoding.workspace = true
+directories.workspace = true
+encoding_rs.workspace = true
+hex.workspace = true
+itertools.workspace = true
+memchr.workspace = true
+parking_lot.workspace = true
+rand.workspace = true
+serde.workspace = true
+sha1w.workspace = true
+thiserror.workspace = true
+tokio-util.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
+tracing.workspace = true
+url.workspace = true
 
 [dev-dependencies]
-serde_json = "1"
+serde_json.workspace = true

--- a/crates/librqbit_lsd/Cargo.toml
+++ b/crates/librqbit_lsd/Cargo.toml
@@ -4,19 +4,20 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-anyhow = "1.0.98"
-librqbit-dualstack-sockets = "0.6.11"
-tokio = { version = "1.45.1", features = ["time"] }
-tokio-util = "0.7.15"
-librqbit-sha1-wrapper = { path = "../sha1w", version = "4", default-features = false }
-librqbit-core = { version = "5", path = "../librqbit_core", default-features = false }
-rand = "0.9.1"
-futures = "0.3.31"
-bstr = "1.12.0"
-parking_lot = "0.12.4"
-httparse = "1.10.1"
-atoi = "2.0.0"
-tracing = "0.1.41"
+sha1w.workspace = true
+librqbit-core.workspace = true
+
+anyhow.workspace = true
+atoi.workspace = true
+bstr.workspace = true
+futures.workspace = true
+httparse.workspace = true
+librqbit-dualstack-sockets.workspace = true
+parking_lot.workspace = true
+rand.workspace = true
+tokio-util.workspace = true
+tokio = { workspace = true, features = ["time"] }
+tracing.workspace = true
 
 [dev-dependencies]
-tracing-subscriber = "0.3.19"
+tracing-subscriber.workspace = true

--- a/crates/peer_binary_protocol/Cargo.toml
+++ b/crates/peer_binary_protocol/Cargo.toml
@@ -8,23 +8,23 @@ documentation = "https://docs.rs/librqbit-peer-protocol"
 repository = "https://github.com/ikatson/rqbit"
 readme = "README.md"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-serde = { version = "1", features = ["derive"] }
-byteorder = "1"
-buffers = { path = "../buffers", package = "librqbit-buffers", version = "4.2" }
-bencode = { path = "../bencode", default-features = false, package = "librqbit-bencode", version = "3.1" }
-clone_to_owned = { path = "../clone_to_owned", package = "librqbit-clone-to-owned", version = "3" }
-librqbit-core = { path = "../librqbit_core", default-features = false, version = "5" }
-bitvec = "1"
-anyhow = "1"
-bytes = "1.7.1"
-itertools = "0.14"
-thiserror = "2.0.12"
-tracing = "0.1.41"
+librqbit-core.workspace = true
+
+anyhow.workspace = true
+bencode.workspace = true
+bitvec.workspace = true
+buffers.workspace = true
+byteorder.workspace = true
+bytes.workspace = true
+clone_to_owned.workspace = true
+itertools.workspace = true
+serde.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
-criterion = "0.7.0"
+criterion.workspace = true
 
 
 [[bench]]

--- a/crates/rqbit/Cargo.toml
+++ b/crates/rqbit/Cargo.toml
@@ -9,14 +9,12 @@ documentation = "https://github.com/ikatson/rqbit"
 repository = "https://github.com/ikatson/rqbit"
 readme = "README.md"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [features]
 default = ["default-tls", "postgres", "webui", "prometheus"]
 openssl-vendored = ["openssl/vendored"]
 tokio-console = ["librqbit/tokio-console"]
 webui = ["librqbit/webui"]
-prometheus = ["librqbit/prometheus", "metrics-exporter-prometheus"]
+prometheus = ["librqbit/prometheus", "dep:metrics-exporter-prometheus"]
 timed_existence = ["librqbit/timed_existence"]
 default-tls = ["librqbit/default-tls"]
 rust-tls = ["librqbit/rust-tls"]
@@ -28,37 +26,32 @@ _disable_disk_write_net_benchmark = [
 ]
 
 [dependencies]
-librqbit = { version = "9.0.0-beta.1", path = "../librqbit", default-features = false, features = [
-    "http-api",
-    "http-api-client",
-    "tracing-subscriber-utils",
-    "upnp-serve-adapter",
-    "watch",
-] }
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-console-subscriber = { version = "0.4", optional = true }
-anyhow = "1"
-clap = { version = "4.5", features = ["derive", "deprecated", "env"] }
-clap_complete = "4.5"
-tracing = { version = "0.1" }
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-regex = "1"
-futures = "0.3"
-parse_duration = "2"
-parking_lot = { version = "0.12" }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-size_format = "1"
-bytes = "1.5.0"
-openssl = { version = "0.10", features = ["vendored"], optional = true }
-upnp-serve = { path = "../upnp-serve", default-features = false, version = "1", package = "librqbit-upnp-serve" }
-metrics-exporter-prometheus = { version = "0.17", optional = true, default-features = false }
-libc = "0.2.158"
-signal-hook = "0.3.17"
-tokio-util = "0.7.11"
-gethostname = "1"
-url = "2"
-librqbit-dualstack-sockets = "0.6.11"
+librqbit.workspace = true
+
+anyhow.workspace = true
+bytes.workspace = true
+clap.workspace = true
+clap_complete.workspace = true
+console-subscriber.workspace = true
+futures.workspace = true
+gethostname.workspace = true
+libc.workspace = true
+librqbit-dualstack-sockets.workspace = true
+metrics-exporter-prometheus = { workspace = true, optional = true }
+openssl.workspace = true
+parking_lot.workspace = true
+parse_duration.workspace = true
+regex.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+signal-hook.workspace = true
+size_format.workspace = true
+tokio-util.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tracing-subscriber.workspace = true
+tracing.workspace = true
+upnp-serve.workspace = true
+url.workspace = true
 
 [dev-dependencies]
-futures = { version = "0.3" }
+futures.workspace = true

--- a/crates/sha1w/Cargo.toml
+++ b/crates/sha1w/Cargo.toml
@@ -8,14 +8,12 @@ documentation = "https://docs.rs/librqbit-sha1-wrapper"
 repository = "https://github.com/ikatson/rqbit"
 readme = "README.md"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html#
-
 [features]
 default = ["sha1-crypto-hash"]
-sha1-crypto-hash = ["crypto-hash"]
-sha1-ring = ["aws-lc-rs"]
+sha1-crypto-hash = ["dep:crypto-hash"]
+sha1-ring = ["dep:aws-lc-rs"]
 
 [dependencies]
-assert_cfg = "0.1.0"
-crypto-hash = { version = "0.3", optional = true }
-aws-lc-rs = { version = "1.12", optional = true }
+assert_cfg.workspace = true
+crypto-hash = { workspace = true, optional = true }
+aws-lc-rs = { workspace = true, optional = true }

--- a/crates/tracker_comms/Cargo.toml
+++ b/crates/tracker_comms/Cargo.toml
@@ -8,25 +8,25 @@ documentation = "https://docs.rs/librqbit-tracker-comms"
 repository = "https://github.com/ikatson/rqbit"
 readme = "README.md"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-tokio = "1"
-anyhow = "1"
-futures = "0.3"
-async-stream = "0.3.5"
-buffers = { path = "../buffers", package = "librqbit-buffers", version = "4.2" }
-librqbit-core = { path = "../librqbit_core", default-features = false, version = "5" }
-byteorder = "1.5"
-serde = { version = "1", features = ["derive"] }
-urlencoding = "2"
-rand = "0.9"
-tracing = "0.1.40"
-reqwest = { version = "0.12", default-features = false, features = ["json"] }
-bencode = { path = "../bencode", default-features = false, package = "librqbit-bencode", version = "3.1" }
-url = { version = "2", default-features = false }
-parking_lot = "0.12.3"
-tokio-util = "0.7.13"
-librqbit-dualstack-sockets = "0.6.11"
-backon = "1.5.1"
-itertools = "0.14.0"
-serde_with = "3.13.0"
+librqbit-core.workspace = true
+
+anyhow.workspace = true
+async-stream.workspace = true
+backon.workspace = true
+bencode.workspace = true
+buffers.workspace = true
+byteorder.workspace = true
+futures.workspace = true
+itertools.workspace = true
+librqbit-dualstack-sockets.workspace = true
+parking_lot.workspace = true
+rand.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+serde_with.workspace = true
+tokio-util.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+url.workspace = true
+urlencoding.workspace = true

--- a/crates/upnp-serve/Cargo.toml
+++ b/crates/upnp-serve/Cargo.toml
@@ -9,32 +9,33 @@ repository = "https://github.com/ikatson/rqbit"
 readme = "README.md"
 
 [dependencies]
-anyhow = "1.0.86"
-axum = { version = "0.8", features = ["tokio"] }
-tokio = { version = "1", features = ["full"] }
-tracing = "0.1.40"
-bstr = "1.10.0"
-serde = { version = "1", features = ["derive"] }
-http = "1.1.0"
-httparse = "1.9.4"
-uuid = { version = "1.10.0", features = ["v4"] }
-librqbit-upnp = { version = "1", path = "../upnp", default-features = false }
-gethostname = "1"
-librqbit-core = { version = "5", path = "../librqbit_core", default-features = false }
-mime_guess = "2.0.5"
-url = { version = "2", default-features = false }
-parking_lot = "0.12.3"
-tokio-util = "0.7.11"
-reqwest = { version = "0.12.7", default-features = false }
-quick-xml = { version = "0.38.3", features = ["serialize"] }
-network-interface = "2.0.0"
-futures = "0.3.30"
-librqbit-dualstack-sockets = "0.6.11"
-rand = "0.9.1"
+librqbit-core.workspace = true
+librqbit-upnp.workspace = true
+
+anyhow.workspace = true
+axum.workspace = true
+bstr.workspace = true
+futures.workspace = true
+gethostname.workspace = true
+http.workspace = true
+httparse.workspace = true
+librqbit-dualstack-sockets.workspace = true
+mime_guess.workspace = true
+network-interface.workspace = true
+parking_lot.workspace = true
+quick-xml.workspace = true
+rand.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+tokio-util.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "fs", "io-util"] }
+tracing.workspace = true
+url.workspace = true
+uuid.workspace = true
 
 [dev-dependencies]
-tracing-subscriber = "0.3.20"
-tower-http = { version = "0.6.2", features = ["trace"] }
+tracing-subscriber.workspace = true
+tower-http.workspace = true
 
 [[example]]
 name = "upnp-stub-server"

--- a/crates/upnp/Cargo.toml
+++ b/crates/upnp/Cargo.toml
@@ -9,23 +9,21 @@ documentation = "https://docs.rs/librqbit-upnp"
 repository = "https://github.com/ikatson/rqbit"
 readme = "README.md"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-tracing = "0.1"
-anyhow = "1"
-reqwest = { version = "0.12", default-features = false }
-serde = { version = "1", features = ["derive"] }
-tokio = { version = "1", features = ["macros"] }
-futures = "0.3"
-url = { version = "2", default-features = false }
-network-interface = { version = "2" }
-httparse = "1.9.4"
-bstr = "1.10.0"
-quick-xml = { version = "0.38.3", features = ["serialize"] }
-librqbit-dualstack-sockets = "0.6.11"
-socket2 = "0.6"
+tracing.workspace = true
+anyhow.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+tokio = { workspace = true, features = ["macros"] }
+futures.workspace = true
+url.workspace = true
+network-interface.workspace = true
+httparse.workspace = true
+bstr.workspace = true
+quick-xml.workspace = true
+librqbit-dualstack-sockets.workspace = true
+socket2.workspace = true
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-tracing-subscriber = "0.3"
+tokio = { workspace = true, features = ["full"] }
+tracing-subscriber.workspace = true


### PR DESCRIPTION
The main motivation is trying to resolve many heavy duplicated dependencies e.g. `tokio`, `sqlx-core`, `sqlx-postgres`, `serde_core`, `axum`, unfortunately it didn't seem to really work, what is really odd is that they all (except `axum`) seem to be using the same version and subset of each other's features which contradicts my mental modal of cargo.
I merged all `[dependencies]`, and then tries to merge

I experimented with different things:

- I added `tokio` without features to the workspace dependencies and then added the features explicitly to the dependencies in the crate, which seems better and probably should be done for all dependencies (and would avoid unnecessary features of dependencies when only using some of the crates in the workspace), see: https://github.com/rust-lang/cargo/issues/12162#issuecomment-2010322151
- I tried removing this [`tokio.features = ["all"]`](https://github.com/ikatson/rqbit/blob/8d99612023355076ca6439c37e88acb35bdd47bb/crates/upnp-serve/Cargo.toml#L14) which seems unnecessary by roughly guessing the features and seeing the errors and it seemed to work first try, but now that I think about it it's probably just using the shared tokio dependency and is probably missing some features
- Upgrading `console-subscriber` to `0.5.0` removed the duplicated `axum` dependency and massively reduced compile time from ~1m to ~37s
- I needed to remove `librqbit-sha1-wrapper.default-features = false` for it to pick the default backend and compile, not sure how it worked before

(P.S. I also sorted the dependencies but with vim `:sort` which doesn't match cargo notion of sorting with things like `cargo add` because of the order of some special characters like `-` and `_`)