### PR TITLE
Streaming: blocking permit for the whole stream duration

### DIFF
--- a/crates/librqbit/src/api.rs
+++ b/crates/librqbit/src/api.rs
@@ -495,9 +495,9 @@ impl Api {
         Ok(mgr.with_chunk_tracker(|chunks| format!("{:?}", chunks.get_have_pieces().as_slice()))?)
     }
 
-    pub fn api_stream(&self, idx: TorrentIdOrHash, file_id: usize) -> Result<FileStream> {
+    pub async fn api_stream(&self, idx: TorrentIdOrHash, file_id: usize) -> Result<FileStream> {
         let mgr = self.mgr_handle(idx)?;
-        Ok(mgr.stream(file_id)?)
+        Ok(mgr.stream(file_id).await?)
     }
 }
 

--- a/crates/librqbit/src/read_buf.rs
+++ b/crates/librqbit/src/read_buf.rs
@@ -343,7 +343,7 @@ mod tests {
 
             for piece in 0..ITERATIONS {
                 let msg = rb
-                    .read_message(&mut reader, Duration::from_millis(100))
+                    .read_message(&mut reader, Duration::from_millis(1000))
                     .await
                     .unwrap();
                 let utdata = match msg {

--- a/crates/librqbit/src/tests/e2e_stream.rs
+++ b/crates/librqbit/src/tests/e2e_stream.rs
@@ -104,7 +104,7 @@ async fn e2e_stream() -> anyhow::Result<()> {
 
     info!("client torrent initialized, starting stream");
 
-    let mut stream = client_handle.stream(0)?;
+    let mut stream = client_handle.stream(0).await?;
     let mut buf = Vec::<u8>::with_capacity(8192);
     stream.read_to_end(&mut buf).await?;
 


### PR DESCRIPTION
This takes a blocking permit for the whole stream duration.

Previously, a permit was acquired for each chunk, which could lead to stream stalls during heavy downloads and slow disk.