### PR TITLE
refactor: migrate to workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,108 @@ lto = false
 [profile.release-debug]
 inherits = "release"
 debug = true
+
+[workspace.dependencies]
+# Internal crates - keys are import names used in source code, package is the actual crate name
+librqbit = { path = "crates/librqbit", version = "9.0.0-beta.1", default-features = false }
+bencode = { path = "crates/bencode", package = "librqbit-bencode", version = "3.1", default-features = false }
+buffers = { path = "crates/buffers", package = "librqbit-buffers", version = "4.2" }
+clone_to_owned = { path = "crates/clone_to_owned", package = "librqbit-clone-to-owned", version = "3" }
+librqbit-core = { path = "crates/librqbit_core", version = "5", default-features = false }
+dht = { path = "crates/dht", package = "librqbit-dht", version = "5.3.0", default-features = false }
+librqbit-lsd = { path = "crates/librqbit_lsd", version = "0.1.0", default-features = false }
+peer_binary_protocol = { path = "crates/peer_binary_protocol", package = "librqbit-peer-protocol", version = "4.3", default-features = false }
+sha1w = { path = "crates/sha1w", package = "librqbit-sha1-wrapper", version = "4.1", default-features = false }
+tracker_comms = { path = "crates/tracker_comms", package = "librqbit-tracker-comms", version = "3", default-features = false }
+librqbit-upnp = { path = "crates/upnp", version = "1" }
+upnp-serve = { path = "crates/upnp-serve", package = "librqbit-upnp-serve", version = "1", default-features = false }
+
+# External crates
+anyhow = "1"
+arc-swap = "1.7"
+arrayvec = "0.7"
+assert_cfg = "0.1"
+async-backtrace = "0.2"
+async-compression = "0.4"
+async-stream = "0.3"
+async-trait = "0.1"
+atoi = "2"
+aws-lc-rs = "1.12"
+axum = "0.8"
+axum-extra = "0.10"
+backon = "1.5"
+base64 = "0.22"
+bincode = "2"
+bitvec = "1"
+bstr = "1"
+byteorder = "1"
+bytes = "1"
+chardetng = "0.1"
+chrono = "0.4"
+clap = "4"
+clap_complete = "4"
+console-subscriber = "0.5"
+criterion = "0.7"
+crypto-hash = "0.3"
+dashmap = "6"
+data-encoding = "2"
+directories = "6"
+encoding_rs = "0.8"
+futures = "0.3"
+gethostname = "1"
+governor = "0.10"
+hex = "0.4"
+home = "0.5"
+http = "1"
+httparse = "1"
+indexmap = "2"
+intervaltree = "0.2"
+itertools = "0.14"
+leaky-bucket = "1.1"
+libc = "0.2"
+librqbit-dualstack-sockets = "0.6"
+librqbit-utp = "0.6"
+lru = "0.16"
+memchr = "2"
+memmap2 = "0.9"
+metrics-exporter-prometheus = { version = "0.17", default-features = false }
+mime_guess = { version = "2", default-features = false }
+network-interface = "2"
+nix = "0.30"
+notify = "8"
+openssl = "0.10"
+parking_lot = "0.12"
+parse_duration = "2"
+pollster = "0.4"
+quick-xml = "0.38"
+rand = "0.9"
+regex = "1"
+reqwest = { version = "0.12", default-features = false }
+rlimit = "0.10"
+serde = "1"
+serde_derive = "1"
+serde_json = "1"
+serde_urlencoded = "0.7"
+serde_with = "3"
+signal-hook = "0.3"
+size_format = "1"
+socket2 = "0.6"
+sqlx = { version = "0.8", default-features = false }
+tauri = "2"
+tauri-build = "2"
+tauri-plugin-shell = "2"
+tempfile = "3"
+thiserror = "2"
+tokio = "1"
+tokio-socks = "0.5"
+tokio-stream = "0.1"
+tokio-test = "0.4"
+tokio-util = "0.7"
+tower-http = "0.6"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false }
+url = { version = "2", default-features = false }
+urlencoding = "2"
+uuid = "1"
+walkdir = "2"
+windows = "0.62"

--- a/crates/bencode/Cargo.toml
+++ b/crates/bencode/Cargo.toml
@@ -9,12 +9,12 @@ repository = "https://github.com/ikatson/rqbit"
 readme = "README.md"
 
 [dependencies]
-serde = "1"
-serde_derive = "1"
-buffers = { path = "../buffers", package = "librqbit-buffers", version = "4.2" }
-clone_to_owned = { path = "../clone_to_owned", package = "librqbit-clone-to-owned", version = "3" }
-bytes = "1.7.1"
-atoi = "2.0.0"
-thiserror = "2.0.12"
-arrayvec = "0.7.6"
-anyhow = "1.0.98"
+serde.workspace = true
+serde_derive.workspace = true
+buffers.workspace = true
+clone_to_owned.workspace = true
+bytes.workspace = true
+atoi.workspace = true
+thiserror.workspace = true
+arrayvec.workspace = true
+anyhow.workspace = true

--- a/crates/buffers/Cargo.toml
+++ b/crates/buffers/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = "1"
-serde_derive = "1"
-clone_to_owned = { path = "../clone_to_owned", package = "librqbit-clone-to-owned", version = "3" }
-bytes = "1"
+serde.workspace = true
+serde_derive.workspace = true
+clone_to_owned.workspace = true
+bytes.workspace = true

--- a/crates/clone_to_owned/Cargo.toml
+++ b/crates/clone_to_owned/Cargo.toml
@@ -10,4 +10,4 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytes = "1.10"
+bytes.workspace = true

--- a/crates/dht/Cargo.toml
+++ b/crates/dht/Cargo.toml
@@ -9,34 +9,29 @@ repository = "https://github.com/ikatson/rqbit"
 readme = "README.md"
 
 [dependencies]
-tokio = { version = "1", features = [
-    "macros",
-    "rt-multi-thread",
-    "net",
-    "sync",
-] }
-tokio-stream = { version = "0.1", features = ["sync"] }
-serde = "1"
-serde_derive = "1"
-leaky-bucket = "1.1"
-serde_json = "1"
-librqbit-buffers = { path = "../buffers", version = "4.2.0" }
-bencode = { path = "../bencode", default-features = false, package = "librqbit-bencode", version = "3.1" }
-anyhow = "1"
-parking_lot = "0.12"
-tracing = "0.1"
-backon = { version = "1.5", features = ["tokio-sleep"] }
-futures = "0.3"
-rand = "0.9"
-indexmap = "2"
-dashmap = { version = "6", features = ["serde"] }
-clone_to_owned = { path = "../clone_to_owned", package = "librqbit-clone-to-owned", version = "3" }
-librqbit-core = { path = "../librqbit_core", default-features = false, version = "5" }
-chrono = { version = "0.4.31", features = ["serde"] }
-tokio-util = "0.7.10"
-bytes = "1.7.1"
-librqbit-dualstack-sockets = "0.6.11"
-thiserror = "2.0.12"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "net", "sync"] }
+tokio-stream = { workspace = true, features = ["sync"] }
+serde.workspace = true
+serde_derive.workspace = true
+leaky-bucket.workspace = true
+serde_json.workspace = true
+buffers.workspace = true
+bencode.workspace = true
+anyhow.workspace = true
+parking_lot.workspace = true
+tracing.workspace = true
+backon = { workspace = true, features = ["tokio-sleep"] }
+futures.workspace = true
+rand.workspace = true
+indexmap.workspace = true
+dashmap = { workspace = true, features = ["serde"] }
+clone_to_owned.workspace = true
+librqbit-core.workspace = true
+chrono = { workspace = true, features = ["serde"] }
+tokio-util.workspace = true
+bytes.workspace = true
+librqbit-dualstack-sockets.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
-tracing-subscriber = "0.3"
+tracing-subscriber.workspace = true

--- a/crates/dht/src/bprotocol.rs
+++ b/crates/dht/src/bprotocol.rs
@@ -5,9 +5,9 @@ use std::{
 };
 
 use bencode::{ByteBuf, ByteBufOwned};
+use buffers::ByteBufT;
 use bytes::Bytes;
 use clone_to_owned::CloneToOwned;
-use librqbit_buffers::ByteBufT;
 use librqbit_core::{
     compact_ip::{
         Compact, CompactListInBuffer, CompactSerialize, CompactSerializeFixedLen, CompactSocketAddr,

--- a/crates/librqbit/Cargo.toml
+++ b/crates/librqbit/Cargo.toml
@@ -42,112 +42,87 @@ _disable_reconnect_test = []
 
 [dependencies]
 # sqlx and home are pinned so that we can compile on older Rusts
-sqlx = { version = "0.8", features = [
-    "runtime-tokio",
-    "macros",
-    "postgres",
-], default-features = false, optional = true }
-home = { version = "0.5", optional = true }
+sqlx = { workspace = true, features = ["runtime-tokio", "macros", "postgres"], optional = true }
+home = { workspace = true, optional = true }
 
-bencode = { path = "../bencode", default-features = false, package = "librqbit-bencode", version = "3.1" }
-tracker_comms = { path = "../tracker_comms", default-features = false, package = "librqbit-tracker-comms", version = "3" }
-buffers = { path = "../buffers", package = "librqbit-buffers", version = "4.2" }
-librqbit-core = { path = "../librqbit_core", default-features = false, version = "5" }
-librqbit-lsd = { path = "../librqbit_lsd", default-features = false, package = "librqbit-lsd", version = "0.1.0" }
-clone_to_owned = { path = "../clone_to_owned", package = "librqbit-clone-to-owned", version = "3" }
-peer_binary_protocol = { path = "../peer_binary_protocol", default-features = false, package = "librqbit-peer-protocol", version = "4.3" }
-sha1w = { path = "../sha1w", default-features = false, package = "librqbit-sha1-wrapper", version = "4.1" }
-dht = { path = "../dht", package = "librqbit-dht", default-features = false, version = "5.3.0" }
-librqbit-upnp = { path = "../upnp", version = "1" }
-upnp-serve = { path = "../upnp-serve", package = "librqbit-upnp-serve", default-features = false, version = "1", optional = true }
+bencode.workspace = true
+tracker_comms.workspace = true
+buffers.workspace = true
+librqbit-core.workspace = true
+librqbit-lsd.workspace = true
+clone_to_owned.workspace = true
+peer_binary_protocol.workspace = true
+sha1w.workspace = true
+dht.workspace = true
+librqbit-upnp.workspace = true
+upnp-serve = { workspace = true, optional = true }
 
-tokio = { version = "1", features = [
-    "macros",
-    "rt-multi-thread",
-    "fs",
-    "io-util",
-] }
-governor = "0.10"
-console-subscriber = { version = "0.5", optional = true }
-axum = { version = "0.8", optional = true }
-tower-http = { version = "0.6", features = ["cors", "trace"], optional = true }
-tokio-stream = "0.1"
-serde = { version = "1", features = ["rc"] }
-serde_derive = "1"
-serde_json = "1"
-serde_urlencoded = "0.7"
-anyhow = "1"
-itertools = "0.14"
-http = "1"
-regex = "1"
-reqwest = { version = "0.12", default-features = false, features = [
-    "json",
-    "socks",
-    "stream",
-] }
-urlencoding = "2"
-byteorder = "1"
-bincode = "2"
-bitvec = "1"
-parking_lot = "0.12"
-tracing = "0.1.40"
-size_format = "1"
-rand = "0.9"
-tracing-subscriber = { version = "0.3", default-features = false, features = [
-    "json",
-    "fmt",
-    "env-filter",
-], optional = true }
-uuid = { version = "1.2", features = ["v4"] }
-futures = "0.3"
-url = { version = "^2.5.2", default-features = false, features = [
-    "serde",
-] } # can't upgrade yet until min version is Rust 1.81, see https://github.com/servo/rust-url/issues/992
-
-hex = "0.4"
-backon = "1.5"
-dashmap = "6"
-base64 = "0.22"
-serde_with = "3.4.0"
-tokio-util = { version = "0.7.10", features = ["io"] }
-metrics-exporter-prometheus = { version = "0.17", optional = true, default-features = false }
-bytes = "1.5.0"
-rlimit = "0.10.1"
-async-stream = "0.3.5"
-memmap2 = { version = "0.9.4" }
-lru = { version = "0.16", optional = true }
-mime_guess = { version = "2.0.5", default-features = false }
-tokio-socks = "0.5.2"
-async-trait = "0.1.81"
-async-backtrace = { version = "0.2", optional = true }
-notify = { version = "8", optional = true }
-walkdir = "2.5.0"
-arc-swap = "1.7.1"
-intervaltree = "0.2.7"
-async-compression = { version = "0.4.18", features = ["tokio", "gzip"] }
-librqbit-utp = { version = "0.6.2", features = ["export-metrics"] }
-axum-extra = { version = "0.10.1", features = ["query"] }
-librqbit-dualstack-sockets = { version = "0.6.11", features = ["axum"] }
-socket2 = "0.6"
-nix = { version = "0.30.1", features = ["uio"] }
-thiserror = "2.0.12"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "fs", "io-util"] }
+governor.workspace = true
+console-subscriber = { workspace = true, optional = true }
+axum = { workspace = true, optional = true }
+tower-http = { workspace = true, features = ["cors", "trace"], optional = true }
+tokio-stream.workspace = true
+serde = { workspace = true, features = ["rc"] }
+serde_derive.workspace = true
+serde_json.workspace = true
+serde_urlencoded.workspace = true
+anyhow.workspace = true
+itertools.workspace = true
+http.workspace = true
+regex.workspace = true
+reqwest = { workspace = true, features = ["json", "socks", "stream"] }
+urlencoding.workspace = true
+byteorder.workspace = true
+bincode.workspace = true
+bitvec.workspace = true
+parking_lot.workspace = true
+tracing.workspace = true
+size_format.workspace = true
+rand.workspace = true
+tracing-subscriber = { workspace = true, features = ["json", "fmt", "env-filter"], optional = true }
+uuid = { workspace = true, features = ["v4"] }
+futures.workspace = true
+url = { workspace = true, features = ["serde"] }
+hex.workspace = true
+backon.workspace = true
+dashmap.workspace = true
+base64.workspace = true
+serde_with.workspace = true
+tokio-util = { workspace = true, features = ["io"] }
+metrics-exporter-prometheus = { workspace = true, optional = true }
+bytes.workspace = true
+rlimit.workspace = true
+async-stream.workspace = true
+memmap2.workspace = true
+lru = { workspace = true, optional = true }
+mime_guess.workspace = true
+tokio-socks.workspace = true
+async-trait.workspace = true
+async-backtrace = { workspace = true, optional = true }
+notify = { workspace = true, optional = true }
+walkdir.workspace = true
+arc-swap.workspace = true
+intervaltree.workspace = true
+async-compression = { workspace = true, features = ["tokio", "gzip"] }
+librqbit-utp = { workspace = true, features = ["export-metrics"] }
+axum-extra = { workspace = true, features = ["query"] }
+librqbit-dualstack-sockets = { workspace = true, features = ["axum"] }
+socket2.workspace = true
+nix = { workspace = true, features = ["uio"] }
+thiserror.workspace = true
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.62.1", features = [
-    "Win32",
-    "Win32_System",
-    "Win32_System_IO",
-    "Win32_System_Ioctl",
-] }
+windows = { workspace = true, features = ["Win32", "Win32_System", "Win32_System_IO", "Win32_System_Ioctl"] }
 
 [build-dependencies]
-anyhow = "1"
+anyhow.workspace = true
 
 [dev-dependencies]
-tracing-subscriber = "0.3"
-tokio-test = "0.4"
-tempfile = "3"
-pollster = "0.4.0"
+tracing-subscriber.workspace = true
+tokio-test.workspace = true
+tempfile.workspace = true
+pollster.workspace = true
 
 [[example]]
 name = "simulate_traffic"

--- a/crates/librqbit_core/Cargo.toml
+++ b/crates/librqbit_core/Cargo.toml
@@ -15,28 +15,28 @@ sha1-crypto-hash = ["sha1w/sha1-crypto-hash"]
 sha1-ring = ["sha1w/sha1-ring"]
 
 [dependencies]
-tracing = "0.1.40"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
-hex = "0.4"
-anyhow = "1"
-url = { version = "2", default-features = false }
-rand = "0.9"
-parking_lot = "0.12"
-serde = "1"
-serde_derive = "1"
-buffers = { path = "../buffers", package = "librqbit-buffers", version = "4.2" }
-bencode = { path = "../bencode", default-features = false, package = "librqbit-bencode", version = "3.1" }
-clone_to_owned = { path = "../clone_to_owned", package = "librqbit-clone-to-owned", version = "3" }
-sha1w = { path = "../sha1w", package = "librqbit-sha1-wrapper", version = "4.1", default-features = false, optional = true }
-itertools = "0.14"
-directories = "6"
-tokio-util = "0.7.10"
-data-encoding = "2.6.0"
-bytes = "1.7.1"
-memchr = "2.7.5"
-thiserror = "2.0.12"
-chardetng = "0.1.17"
-encoding_rs = "0.8.35"
+tracing.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
+hex.workspace = true
+anyhow.workspace = true
+url.workspace = true
+rand.workspace = true
+parking_lot.workspace = true
+serde.workspace = true
+serde_derive.workspace = true
+buffers.workspace = true
+bencode.workspace = true
+clone_to_owned.workspace = true
+sha1w = { workspace = true, optional = true }
+itertools.workspace = true
+directories.workspace = true
+tokio-util.workspace = true
+data-encoding.workspace = true
+bytes.workspace = true
+memchr.workspace = true
+thiserror.workspace = true
+chardetng.workspace = true
+encoding_rs.workspace = true
 
 [dev-dependencies]
-serde_json = "1"
+serde_json.workspace = true

--- a/crates/librqbit_lsd/Cargo.toml
+++ b/crates/librqbit_lsd/Cargo.toml
@@ -4,19 +4,19 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-anyhow = "1.0.98"
-librqbit-dualstack-sockets = "0.6.11"
-tokio = { version = "1.45.1", features = ["time"] }
-tokio-util = "0.7.15"
-librqbit-sha1-wrapper = { path = "../sha1w", version = "4", default-features = false }
-librqbit-core = { version = "5", path = "../librqbit_core", default-features = false }
-rand = "0.9.1"
-futures = "0.3.31"
-bstr = "1.12.0"
-parking_lot = "0.12.4"
-httparse = "1.10.1"
-atoi = "2.0.0"
-tracing = "0.1.41"
+anyhow.workspace = true
+librqbit-dualstack-sockets.workspace = true
+tokio = { workspace = true, features = ["time"] }
+tokio-util.workspace = true
+sha1w.workspace = true
+librqbit-core.workspace = true
+rand.workspace = true
+futures.workspace = true
+bstr.workspace = true
+parking_lot.workspace = true
+httparse.workspace = true
+atoi.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
-tracing-subscriber = "0.3.19"
+tracing-subscriber.workspace = true

--- a/crates/peer_binary_protocol/Cargo.toml
+++ b/crates/peer_binary_protocol/Cargo.toml
@@ -10,23 +10,22 @@ readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-serde = "1"
-serde_derive = "1"
-byteorder = "1"
-buffers = { path = "../buffers", package = "librqbit-buffers", version = "4.2" }
-bencode = { path = "../bencode", default-features = false, package = "librqbit-bencode", version = "3.1" }
-clone_to_owned = { path = "../clone_to_owned", package = "librqbit-clone-to-owned", version = "3" }
-librqbit-core = { path = "../librqbit_core", default-features = false, version = "5" }
-bitvec = "1"
-anyhow = "1"
-bytes = "1.7.1"
-itertools = "0.14"
-thiserror = "2.0.12"
-tracing = "0.1.41"
+serde.workspace = true
+serde_derive.workspace = true
+byteorder.workspace = true
+buffers.workspace = true
+bencode.workspace = true
+clone_to_owned.workspace = true
+librqbit-core.workspace = true
+bitvec.workspace = true
+anyhow.workspace = true
+bytes.workspace = true
+itertools.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
-criterion = "0.7.0"
-
+criterion.workspace = true
 
 [[bench]]
 name = "bench"

--- a/crates/rqbit/Cargo.toml
+++ b/crates/rqbit/Cargo.toml
@@ -28,38 +28,38 @@ _disable_disk_write_net_benchmark = [
 ]
 
 [dependencies]
-librqbit = { version = "9.0.0-beta.1", path = "../librqbit", default-features = false, features = [
+librqbit = { workspace = true, features = [
     "http-api",
     "http-api-client",
     "tracing-subscriber-utils",
     "upnp-serve-adapter",
     "watch",
 ] }
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-console-subscriber = { version = "0.5", optional = true }
-anyhow = "1"
-clap = { version = "4.5", features = ["derive", "deprecated", "env"] }
-clap_complete = "4.5"
-tracing = { version = "0.1" }
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-regex = "1"
-futures = "0.3"
-parse_duration = "2"
-parking_lot = { version = "0.12" }
-serde = "1"
-serde_derive = "1"
-serde_json = "1"
-size_format = "1"
-bytes = "1.5.0"
-openssl = { version = "0.10", features = ["vendored"], optional = true }
-upnp-serve = { path = "../upnp-serve", default-features = false, version = "1", package = "librqbit-upnp-serve" }
-metrics-exporter-prometheus = { version = "0.17", optional = true, default-features = false }
-libc = "0.2.158"
-signal-hook = "0.3.17"
-tokio-util = "0.7.11"
-gethostname = "1"
-url = "2"
-librqbit-dualstack-sockets = "0.6.11"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+console-subscriber = { workspace = true, optional = true }
+anyhow.workspace = true
+clap = { workspace = true, features = ["derive", "deprecated", "env"] }
+clap_complete.workspace = true
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+regex.workspace = true
+futures.workspace = true
+parse_duration.workspace = true
+parking_lot.workspace = true
+serde.workspace = true
+serde_derive.workspace = true
+serde_json.workspace = true
+size_format.workspace = true
+bytes.workspace = true
+openssl = { workspace = true, features = ["vendored"], optional = true }
+upnp-serve.workspace = true
+metrics-exporter-prometheus = { workspace = true, optional = true }
+libc.workspace = true
+signal-hook.workspace = true
+tokio-util.workspace = true
+gethostname.workspace = true
+url.workspace = true
+librqbit-dualstack-sockets.workspace = true
 
 [dev-dependencies]
-futures = { version = "0.3" }
+futures.workspace = true

--- a/crates/sha1w/Cargo.toml
+++ b/crates/sha1w/Cargo.toml
@@ -16,6 +16,6 @@ sha1-crypto-hash = ["crypto-hash"]
 sha1-ring = ["aws-lc-rs"]
 
 [dependencies]
-assert_cfg = "0.1.0"
-crypto-hash = { version = "0.3", optional = true }
-aws-lc-rs = { version = "1.12", optional = true }
+assert_cfg.workspace = true
+crypto-hash = { workspace = true, optional = true }
+aws-lc-rs = { workspace = true, optional = true }

--- a/crates/tracker_comms/Cargo.toml
+++ b/crates/tracker_comms/Cargo.toml
@@ -10,24 +10,24 @@ readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-tokio = "1"
-anyhow = "1"
-futures = "0.3"
-async-stream = "0.3.5"
-buffers = { path = "../buffers", package = "librqbit-buffers", version = "4.2" }
-librqbit-core = { path = "../librqbit_core", default-features = false, version = "5" }
-byteorder = "1.5"
-serde = "1"
-serde_derive = "1"
-urlencoding = "2"
-rand = "0.9"
-tracing = "0.1.40"
-reqwest = { version = "0.12", default-features = false, features = ["json"] }
-bencode = { path = "../bencode", default-features = false, package = "librqbit-bencode", version = "3.1" }
-url = { version = "2", default-features = false }
-parking_lot = "0.12.3"
-tokio-util = "0.7.13"
-librqbit-dualstack-sockets = "0.6.11"
-backon = "1.5.1"
-itertools = "0.14.0"
-serde_with = "3.13.0"
+tokio.workspace = true
+anyhow.workspace = true
+futures.workspace = true
+async-stream.workspace = true
+buffers.workspace = true
+librqbit-core.workspace = true
+byteorder.workspace = true
+serde.workspace = true
+serde_derive.workspace = true
+urlencoding.workspace = true
+rand.workspace = true
+tracing.workspace = true
+reqwest = { workspace = true, features = ["json"] }
+bencode.workspace = true
+url.workspace = true
+parking_lot.workspace = true
+tokio-util.workspace = true
+librqbit-dualstack-sockets.workspace = true
+backon.workspace = true
+itertools.workspace = true
+serde_with.workspace = true

--- a/crates/upnp-serve/Cargo.toml
+++ b/crates/upnp-serve/Cargo.toml
@@ -9,33 +9,33 @@ repository = "https://github.com/ikatson/rqbit"
 readme = "README.md"
 
 [dependencies]
-anyhow = "1.0.86"
-axum = { version = "0.8", features = ["tokio"] }
-tokio = { version = "1", features = ["full"] }
-tracing = "0.1.40"
-bstr = "1.10.0"
-serde = "1"
-serde_derive = "1"
-http = "1.1.0"
-httparse = "1.9.4"
-uuid = { version = "1.10.0", features = ["v4"] }
-librqbit-upnp = { version = "1", path = "../upnp", default-features = false }
-gethostname = "1"
-librqbit-core = { version = "5", path = "../librqbit_core", default-features = false }
-mime_guess = "2.0.5"
-url = { version = "2", default-features = false }
-parking_lot = "0.12.3"
-tokio-util = "0.7.11"
-reqwest = { version = "0.12.7", default-features = false }
-quick-xml = { version = "0.38.3", features = ["serialize"] }
-network-interface = "2.0.0"
-futures = "0.3.30"
-librqbit-dualstack-sockets = "0.6.11"
-rand = "0.9.1"
+anyhow.workspace = true
+axum = { workspace = true, features = ["tokio"] }
+tokio = { workspace = true, features = ["full"] }
+tracing.workspace = true
+bstr.workspace = true
+serde.workspace = true
+serde_derive.workspace = true
+http.workspace = true
+httparse.workspace = true
+uuid = { workspace = true, features = ["v4"] }
+librqbit-upnp.workspace = true
+gethostname.workspace = true
+librqbit-core.workspace = true
+mime_guess.workspace = true
+url.workspace = true
+parking_lot.workspace = true
+tokio-util.workspace = true
+reqwest.workspace = true
+quick-xml = { workspace = true, features = ["serialize"] }
+network-interface.workspace = true
+futures.workspace = true
+librqbit-dualstack-sockets.workspace = true
+rand.workspace = true
 
 [dev-dependencies]
-tracing-subscriber = "0.3.20"
-tower-http = { version = "0.6.2", features = ["trace"] }
+tracing-subscriber.workspace = true
+tower-http = { workspace = true, features = ["trace"] }
 
 [[example]]
 name = "upnp-stub-server"

--- a/crates/upnp/Cargo.toml
+++ b/crates/upnp/Cargo.toml
@@ -12,21 +12,21 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tracing = "0.1"
-anyhow = "1"
-reqwest = { version = "0.12", default-features = false }
-serde = "1"
-serde_derive = "1"
-tokio = { version = "1", features = ["macros"] }
-futures = "0.3"
-url = { version = "2", default-features = false }
-network-interface = { version = "2" }
-httparse = "1.9.4"
-bstr = "1.10.0"
-quick-xml = { version = "0.38.3", features = ["serialize"] }
-librqbit-dualstack-sockets = "0.6.11"
-socket2 = "0.6"
+tracing.workspace = true
+anyhow.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+serde_derive.workspace = true
+tokio = { workspace = true, features = ["macros"] }
+futures.workspace = true
+url.workspace = true
+network-interface.workspace = true
+httparse.workspace = true
+bstr.workspace = true
+quick-xml = { workspace = true, features = ["serialize"] }
+librqbit-dualstack-sockets.workspace = true
+socket2.workspace = true
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-tracing-subscriber = "0.3"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tracing-subscriber.workspace = true

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -9,33 +9,33 @@ repository = ""
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-tauri-build = { version = "2", features = [] }
+tauri-build.workspace = true
 
 [dependencies]
-tauri = { version = "2", features = [] }
-serde = "1"
-serde_derive = "1"
-serde_json = "1.0"
-librqbit = { path = "../../crates/librqbit", features = [
+tauri.workspace = true
+serde.workspace = true
+serde_derive.workspace = true
+serde_json.workspace = true
+librqbit = { workspace = true, features = [
     "tracing-subscriber-utils",
     "http-api",
     "webui",
     "upnp-serve-adapter",
     "prometheus",
 ] }
-tokio = { version = "1.47.0", features = ["rt-multi-thread"] }
-anyhow = "1.0.75"
-base64 = "0.22"
-http = "1.0.0"
-directories = "6"
-tracing-subscriber = { version = "0.3.20", features = ["env-filter", "json"] }
-tracing = "0.1"
-serde_with = "3.4.0"
-parking_lot = "0.12.1"
-gethostname = "1"
-tauri-plugin-shell = "2"
-metrics-exporter-prometheus = { version = "0.17", default-features = false }
-librqbit-dualstack-sockets = "0.6.11"
+tokio = { workspace = true, features = ["rt-multi-thread"] }
+anyhow.workspace = true
+base64.workspace = true
+http.workspace = true
+directories.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
+tracing.workspace = true
+serde_with.workspace = true
+parking_lot.workspace = true
+gethostname.workspace = true
+tauri-plugin-shell.workspace = true
+metrics-exporter-prometheus.workspace = true
+librqbit-dualstack-sockets.workspace = true
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem


### PR DESCRIPTION
- Add [workspace.dependencies] section in root Cargo.toml
- Update all 15 crate Cargo.toml files to use workspace = true
- Centralize dependency versions for easier maintenance
- Fix inconsistent import in dht/src/bprotocol.rs (librqbit_buffers -> buffers)