### PR TITLE
BEP 52 (2/16): Merkle tree module

### DIFF
--- a/crates/librqbit_core/src/lib.rs
+++ b/crates/librqbit_core/src/lib.rs
@@ -5,6 +5,8 @@ mod error;
 pub mod hash_id;
 pub mod lengths;
 pub mod magnet;
+#[cfg(any(feature = "sha1-crypto-hash", feature = "sha1-ring"))]
+pub mod merkle;
 pub mod peer_id;
 pub mod spawn_utils;
 pub mod speed_estimator;

--- a/crates/librqbit_core/src/merkle.rs
+++ b/crates/librqbit_core/src/merkle.rs
@@ -1,0 +1,826 @@
+//! BEP 52 Merkle tree primitives for BitTorrent v2.
+//!
+//! Provides computation and verification of SHA-256 merkle trees used in
+//! BEP 52 piece hashing. Files are divided into 16 KiB blocks, hashed with
+//! SHA-256, and organized into a balanced binary tree.
+//!
+//! Key BEP 52 rules:
+//! - Zero hash = all-zero bytes (NOT SHA-256 of empty data).
+//! - Padding at the leaf level uses zero_hash(). Internal nodes are computed
+//!   normally via hash_pair(). A "padding piece" at the piece layer is the
+//!   subtree root of `blocks_per_piece` zero-hash leaves.
+//! - Piece-layer hashes are trimmed: only actual (non-padding) pieces are kept.
+
+use crate::Id32;
+use sha1w::{ISha256, Sha256};
+
+/// Size of each merkle tree leaf block (16 KiB), per BEP 52.
+pub const MERKLE_BLOCK_SIZE: usize = 16384;
+const SMALL_TREE_MAX_LEAVES: usize = 8;
+
+/// Errors from merkle tree operations.
+#[derive(thiserror::Error, Debug, PartialEq, Eq)]
+pub enum MerkleError {
+    #[error("blocks_per_piece must not be zero")]
+    ZeroBlocksPerPiece,
+    #[error("blocks_per_piece must be a power of two, got {0}")]
+    NonPowerOfTwoBlocksPerPiece(u32),
+    #[error("block_hashes must not be empty")]
+    EmptyBlockHashes,
+    #[error("invalid proof length: expected {expected}, got {actual}")]
+    InvalidProofLength { expected: usize, actual: usize },
+    #[error("piece has too many blocks: max {max_blocks}, got {actual_blocks}")]
+    PieceTooLarge {
+        max_blocks: usize,
+        actual_blocks: usize,
+    },
+    #[error("block index out of range: max {max_index}, got {actual_index}")]
+    InvalidBlockIndex { max_index: u32, actual_index: u32 },
+}
+
+/// Result of computing a full merkle tree from block hashes.
+#[derive(Debug)]
+pub struct MerkleResult {
+    /// The root hash of the complete merkle tree.
+    pub root: Id32,
+    /// Piece-layer hashes, one per actual piece. Trailing padding pieces are trimmed.
+    pub piece_hashes: Vec<Id32>,
+}
+
+/// Returns the BEP 52 zero hash: all-zero bytes (NOT SHA-256 of empty data).
+pub fn zero_hash() -> Id32 {
+    Id32::default()
+}
+
+/// SHA-256 hash of a single block of file data (up to 16 KiB).
+pub fn hash_block(data: &[u8]) -> Id32 {
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    Id32::new(hasher.finish())
+}
+
+/// SHA-256(left || right) — combines two child nodes in the merkle tree.
+pub fn hash_pair(left: &Id32, right: &Id32) -> Id32 {
+    let mut hasher = Sha256::new();
+    hasher.update(&left.0);
+    hasher.update(&right.0);
+    Id32::new(hasher.finish())
+}
+
+fn validate_blocks_per_piece(blocks_per_piece: u32) -> Result<(), MerkleError> {
+    if blocks_per_piece == 0 {
+        return Err(MerkleError::ZeroBlocksPerPiece);
+    }
+    if !blocks_per_piece.is_power_of_two() {
+        return Err(MerkleError::NonPowerOfTwoBlocksPerPiece(blocks_per_piece));
+    }
+    Ok(())
+}
+
+/// Build a balanced binary tree from power-of-2 leaves and return the root.
+fn build_subtree_root_vec(leaves: &[Id32]) -> Id32 {
+    debug_assert!(!leaves.is_empty());
+    debug_assert!(leaves.len().is_power_of_two());
+
+    if leaves.len() == 1 {
+        return leaves[0];
+    }
+
+    let mut current = leaves.to_vec();
+    while current.len() > 1 {
+        let mut next = Vec::with_capacity(current.len() / 2);
+        for pair in current.chunks_exact(2) {
+            next.push(hash_pair(&pair[0], &pair[1]));
+        }
+        current = next;
+    }
+    current[0]
+}
+
+/// Stack-based root builder for small trees (<= 8 leaves).
+fn build_subtree_root_small(leaves: &[Id32]) -> Id32 {
+    debug_assert!(!leaves.is_empty());
+    debug_assert!(leaves.len().is_power_of_two());
+    debug_assert!(leaves.len() <= SMALL_TREE_MAX_LEAVES);
+
+    let mut current = [Id32::default(); SMALL_TREE_MAX_LEAVES];
+    current[..leaves.len()].copy_from_slice(leaves);
+    let mut len = leaves.len();
+
+    while len > 1 {
+        for i in 0..(len / 2) {
+            current[i] = hash_pair(&current[i * 2], &current[i * 2 + 1]);
+        }
+        len /= 2;
+    }
+
+    current[0]
+}
+
+fn build_subtree_root(leaves: &[Id32]) -> Id32 {
+    if leaves.len() <= SMALL_TREE_MAX_LEAVES {
+        return build_subtree_root_small(leaves);
+    }
+    build_subtree_root_vec(leaves)
+}
+
+/// Compute the full merkle tree from block hashes, extracting piece-layer hashes.
+///
+/// The tree is padded to a power-of-2 number of leaves with [`zero_hash()`].
+/// The piece layer is extracted at height `log2(blocks_per_piece)` from the leaves.
+/// Trailing piece hashes beyond the actual file content are trimmed.
+pub fn compute_merkle_root(
+    block_hashes: &[Id32],
+    blocks_per_piece: u32,
+) -> Result<MerkleResult, MerkleError> {
+    if block_hashes.is_empty() {
+        return Err(MerkleError::EmptyBlockHashes);
+    }
+    validate_blocks_per_piece(blocks_per_piece)?;
+
+    let bpp = blocks_per_piece as usize;
+    let n_actual = block_hashes.len();
+    let n_pieces_actual = n_actual.div_ceil(bpp);
+    let n_padded = n_actual.next_power_of_two().max(bpp);
+    let piece_layer_height = blocks_per_piece.trailing_zeros() as usize;
+
+    if n_padded <= SMALL_TREE_MAX_LEAVES {
+        let mut current_level = [Id32::default(); SMALL_TREE_MAX_LEAVES];
+        current_level[..n_actual].copy_from_slice(block_hashes);
+        current_level[n_actual..n_padded].fill(zero_hash());
+
+        let mut piece_hashes: Option<Vec<Id32>> = None;
+        let mut len = n_padded;
+        let mut height = 0;
+
+        if piece_layer_height == 0 {
+            piece_hashes = Some(current_level[..n_pieces_actual].to_vec());
+        }
+
+        while len > 1 {
+            for i in 0..(len / 2) {
+                current_level[i] = hash_pair(&current_level[i * 2], &current_level[i * 2 + 1]);
+            }
+            len /= 2;
+            height += 1;
+
+            if height == piece_layer_height && piece_hashes.is_none() {
+                piece_hashes = Some(current_level[..n_pieces_actual].to_vec());
+            }
+        }
+
+        let root = current_level[0];
+        return Ok(MerkleResult {
+            root,
+            piece_hashes: piece_hashes.unwrap_or_else(|| vec![root]),
+        });
+    }
+
+    // Build padded leaf level
+    let mut current_level: Vec<Id32> = Vec::with_capacity(n_padded);
+    current_level.extend_from_slice(block_hashes);
+    current_level.resize(n_padded, zero_hash());
+
+    let mut piece_hashes: Option<Vec<Id32>> = None;
+
+    // Capture piece layer at height 0 (bpp == 1: piece layer IS the leaves)
+    if piece_layer_height == 0 {
+        piece_hashes = Some(current_level[..n_pieces_actual].to_vec());
+    }
+
+    let mut height = 0;
+    while current_level.len() > 1 {
+        let mut next_level = Vec::with_capacity(current_level.len() / 2);
+        for pair in current_level.chunks_exact(2) {
+            next_level.push(hash_pair(&pair[0], &pair[1]));
+        }
+        current_level = next_level;
+        height += 1;
+
+        if height == piece_layer_height && piece_hashes.is_none() {
+            piece_hashes = Some(current_level[..n_pieces_actual].to_vec());
+        }
+    }
+
+    let root = current_level[0];
+
+    Ok(MerkleResult {
+        root,
+        piece_hashes: piece_hashes.unwrap_or_else(|| vec![root]),
+    })
+}
+
+/// Verify a piece by hashing its data into blocks, building the subtree, and
+/// comparing the root against the expected piece hash.
+///
+/// `piece_data` may be shorter than a full piece (last piece of a file).
+/// Missing blocks are padded with [`zero_hash()`].
+pub fn verify_piece(
+    piece_data: &[u8],
+    blocks_per_piece: u32,
+    expected_hash: &Id32,
+) -> Result<bool, MerkleError> {
+    validate_blocks_per_piece(blocks_per_piece)?;
+
+    let bpp = blocks_per_piece as usize;
+    let actual_blocks = piece_data.chunks(MERKLE_BLOCK_SIZE).count();
+    if actual_blocks > bpp {
+        return Err(MerkleError::PieceTooLarge {
+            max_blocks: bpp,
+            actual_blocks,
+        });
+    }
+
+    let block_hashes: Vec<Id32> = piece_data
+        .chunks(MERKLE_BLOCK_SIZE)
+        .map(hash_block)
+        .collect();
+
+    let mut leaves = block_hashes;
+    leaves.resize(bpp, zero_hash());
+
+    let root = build_subtree_root(&leaves);
+    Ok(root == *expected_hash)
+}
+
+/// Verify a single block using a merkle proof (bottom-up sibling hashes).
+///
+/// Proof ordering is bottom-up: `proof[0]` is the sibling at the leaf level,
+/// `proof[1]` at the next level up, etc. `block_index_in_piece` determines
+/// left/right placement at each level (bit 0 = leaf level, bit 1 = next, ...).
+pub fn verify_block_with_proof(
+    block_data: &[u8],
+    block_index_in_piece: u32,
+    proof: &[Id32],
+    expected_piece_hash: &Id32,
+    blocks_per_piece: u32,
+) -> Result<bool, MerkleError> {
+    validate_blocks_per_piece(blocks_per_piece)?;
+    if block_index_in_piece >= blocks_per_piece {
+        return Err(MerkleError::InvalidBlockIndex {
+            max_index: blocks_per_piece - 1,
+            actual_index: block_index_in_piece,
+        });
+    }
+
+    let expected_proof_len = blocks_per_piece.trailing_zeros() as usize;
+    if proof.len() != expected_proof_len {
+        return Err(MerkleError::InvalidProofLength {
+            expected: expected_proof_len,
+            actual: proof.len(),
+        });
+    }
+
+    let mut current = hash_block(block_data);
+    let mut index = block_index_in_piece;
+
+    for sibling in proof {
+        if index & 1 == 0 {
+            current = hash_pair(&current, sibling);
+        } else {
+            current = hash_pair(sibling, &current);
+        }
+        index >>= 1;
+    }
+
+    Ok(current == *expected_piece_hash)
+}
+
+/// Compute the piece-layer hash for a "padding piece" — a piece composed
+/// entirely of [`zero_hash()`] leaves.
+///
+/// For `blocks_per_piece == 1`, returns `zero_hash()`.
+/// For larger values, returns the subtree root of `blocks_per_piece` zero-hash
+/// leaves. This is NOT the same as `zero_hash()` when `blocks_per_piece > 1`.
+pub fn padding_piece_hash(blocks_per_piece: u32) -> Result<Id32, MerkleError> {
+    validate_blocks_per_piece(blocks_per_piece)?;
+
+    if blocks_per_piece == 1 {
+        return Ok(zero_hash());
+    }
+
+    let bpp = blocks_per_piece as usize;
+    let leaves = vec![zero_hash(); bpp];
+    Ok(build_subtree_root(&leaves))
+}
+
+/// Rebuild the merkle root from piece-layer hashes.
+///
+/// Pads the piece layer to a power of 2 using [`padding_piece_hash()`], then
+/// builds the tree from the piece layer up to the root.
+///
+/// This is the inverse direction of [`compute_merkle_root()`]: given the piece
+/// layer extracted from a torrent file, reconstruct the file's merkle root
+/// to validate against `pieces_root`.
+pub fn root_from_piece_layer(
+    piece_hashes: &[Id32],
+    blocks_per_piece: u32,
+) -> Result<Id32, MerkleError> {
+    if piece_hashes.is_empty() {
+        return Err(MerkleError::EmptyBlockHashes);
+    }
+    validate_blocks_per_piece(blocks_per_piece)?;
+
+    let pad_hash = padding_piece_hash(blocks_per_piece)?;
+    let n_padded = piece_hashes.len().next_power_of_two();
+
+    if n_padded <= SMALL_TREE_MAX_LEAVES {
+        let mut current = [Id32::default(); SMALL_TREE_MAX_LEAVES];
+        current[..piece_hashes.len()].copy_from_slice(piece_hashes);
+        current[piece_hashes.len()..n_padded].fill(pad_hash);
+        let mut len = n_padded;
+
+        while len > 1 {
+            for i in 0..(len / 2) {
+                current[i] = hash_pair(&current[i * 2], &current[i * 2 + 1]);
+            }
+            len /= 2;
+        }
+
+        return Ok(current[0]);
+    }
+
+    let mut current: Vec<Id32> = Vec::with_capacity(n_padded);
+    current.extend_from_slice(piece_hashes);
+    current.resize(n_padded, pad_hash);
+
+    while current.len() > 1 {
+        let mut next = Vec::with_capacity(current.len() / 2);
+        for pair in current.chunks_exact(2) {
+            next.push(hash_pair(&pair[0], &pair[1]));
+        }
+        current = next;
+    }
+
+    Ok(current[0])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_block(byte: u8) -> Vec<u8> {
+        vec![byte; MERKLE_BLOCK_SIZE]
+    }
+
+    // --- Core primitives ---
+
+    #[test]
+    fn test_zero_hash_is_all_zeros() {
+        let zh = zero_hash();
+        assert_eq!(zh.0, [0u8; 32]);
+    }
+
+    #[test]
+    fn test_hash_block_deterministic() {
+        let data = make_block(0xAB);
+        let h1 = hash_block(&data);
+        let h2 = hash_block(&data);
+        assert_eq!(h1, h2);
+        assert_ne!(h1, zero_hash());
+    }
+
+    #[test]
+    fn test_hash_pair_deterministic() {
+        let a = hash_block(&make_block(1));
+        let b = hash_block(&make_block(2));
+        let h1 = hash_pair(&a, &b);
+        let h2 = hash_pair(&a, &b);
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn test_hash_pair_not_commutative() {
+        let a = hash_block(&make_block(1));
+        let b = hash_block(&make_block(2));
+        assert_ne!(hash_pair(&a, &b), hash_pair(&b, &a));
+    }
+
+    #[test]
+    fn test_build_subtree_root_small_matches_vec_path() {
+        let leaves: Vec<Id32> = (0..8).map(|i| hash_block(&make_block(i))).collect();
+        assert_eq!(
+            build_subtree_root_small(&leaves),
+            build_subtree_root_vec(&leaves)
+        );
+    }
+
+    // --- compute_merkle_root ---
+
+    #[test]
+    fn test_single_block_bpp1() -> Result<(), MerkleError> {
+        let h = hash_block(&make_block(0));
+        let result = compute_merkle_root(&[h], 1)?;
+        assert_eq!(result.root, h);
+        assert_eq!(result.piece_hashes, vec![h]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_two_blocks_bpp2() -> Result<(), MerkleError> {
+        let h0 = hash_block(&make_block(0));
+        let h1 = hash_block(&make_block(1));
+        let expected_root = hash_pair(&h0, &h1);
+
+        let result = compute_merkle_root(&[h0, h1], 2)?;
+        assert_eq!(result.root, expected_root);
+        assert_eq!(result.piece_hashes, vec![expected_root]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_four_blocks_two_pieces_bpp2() -> Result<(), MerkleError> {
+        let h0 = hash_block(&make_block(0));
+        let h1 = hash_block(&make_block(1));
+        let h2 = hash_block(&make_block(2));
+        let h3 = hash_block(&make_block(3));
+
+        let piece0 = hash_pair(&h0, &h1);
+        let piece1 = hash_pair(&h2, &h3);
+        let expected_root = hash_pair(&piece0, &piece1);
+
+        let result = compute_merkle_root(&[h0, h1, h2, h3], 2)?;
+        assert_eq!(result.root, expected_root);
+        assert_eq!(result.piece_hashes, vec![piece0, piece1]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_three_blocks_bpp2_padding() -> Result<(), MerkleError> {
+        // 3 blocks, bpp=2: 2 pieces (piece 1 has 1 real block + 1 zero pad)
+        let h0 = hash_block(&make_block(0));
+        let h1 = hash_block(&make_block(1));
+        let h2 = hash_block(&make_block(2));
+        let zh = zero_hash();
+
+        let piece0 = hash_pair(&h0, &h1);
+        let piece1 = hash_pair(&h2, &zh);
+        let expected_root = hash_pair(&piece0, &piece1);
+
+        let result = compute_merkle_root(&[h0, h1, h2], 2)?;
+        assert_eq!(result.root, expected_root);
+        assert_eq!(result.piece_hashes.len(), 2);
+        assert_eq!(result.piece_hashes, vec![piece0, piece1]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_piece_layer_trimming_9_blocks_bpp4() -> Result<(), MerkleError> {
+        // 9 blocks, bpp=4 → 3 piece hashes (not 4)
+        let hashes: Vec<Id32> = (0..9).map(|i| hash_block(&make_block(i))).collect();
+
+        let result = compute_merkle_root(&hashes, 4)?;
+        assert_eq!(
+            result.piece_hashes.len(),
+            3,
+            "9 blocks with bpp=4 should produce 3 piece hashes, not 4"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_single_block_bpp4() -> Result<(), MerkleError> {
+        // 1 block with bpp=4: single piece, 3 zero-hash padding leaves
+        let h = hash_block(&make_block(42));
+        let zh = zero_hash();
+
+        let n01 = hash_pair(&h, &zh);
+        let n23 = hash_pair(&zh, &zh);
+        let expected_root = hash_pair(&n01, &n23);
+
+        let result = compute_merkle_root(&[h], 4)?;
+        assert_eq!(result.root, expected_root);
+        assert_eq!(result.piece_hashes.len(), 1);
+        assert_eq!(result.piece_hashes[0], expected_root);
+        Ok(())
+    }
+
+    #[test]
+    fn test_bpp1_multiple_blocks() -> Result<(), MerkleError> {
+        // bpp=1: each block is its own piece
+        let h0 = hash_block(&make_block(0));
+        let h1 = hash_block(&make_block(1));
+
+        let result = compute_merkle_root(&[h0, h1], 1)?;
+        assert_eq!(result.piece_hashes, vec![h0, h1]);
+        assert_eq!(result.root, hash_pair(&h0, &h1));
+        Ok(())
+    }
+
+    // --- verify_piece ---
+
+    #[test]
+    fn test_verify_piece_valid() -> Result<(), MerkleError> {
+        let block0 = make_block(10);
+        let block1 = make_block(20);
+        let mut piece_data = block0.clone();
+        piece_data.extend_from_slice(&block1);
+
+        let h0 = hash_block(&block0);
+        let h1 = hash_block(&block1);
+        let expected = hash_pair(&h0, &h1);
+
+        assert!(verify_piece(&piece_data, 2, &expected)?);
+        Ok(())
+    }
+
+    #[test]
+    fn test_verify_piece_invalid() -> Result<(), MerkleError> {
+        let piece_data = make_block(10);
+        let wrong_hash = hash_block(&make_block(99));
+
+        assert!(!verify_piece(&piece_data, 1, &wrong_hash)?);
+        Ok(())
+    }
+
+    #[test]
+    fn test_verify_piece_last_piece_shorter() -> Result<(), MerkleError> {
+        // Last piece with fewer blocks than bpp: 1 real block out of bpp=4
+        let block = make_block(7);
+        let h = hash_block(&block);
+        let zh = zero_hash();
+
+        let n01 = hash_pair(&h, &zh);
+        let n23 = hash_pair(&zh, &zh);
+        let expected = hash_pair(&n01, &n23);
+
+        assert!(verify_piece(&block, 4, &expected)?);
+        Ok(())
+    }
+
+    // --- verify_block_with_proof ---
+
+    #[test]
+    fn test_verify_block_with_proof_valid() -> Result<(), MerkleError> {
+        // Build a 4-leaf tree manually and verify block 0 with proof
+        let blocks: Vec<Vec<u8>> = (0..4).map(make_block).collect();
+        let h: Vec<Id32> = blocks.iter().map(|b| hash_block(b)).collect();
+
+        let n01 = hash_pair(&h[0], &h[1]);
+        let n23 = hash_pair(&h[2], &h[3]);
+        let root = hash_pair(&n01, &n23);
+
+        // Proof for block 0: [h[1], n23]
+        let proof = vec![h[1], n23];
+        assert!(verify_block_with_proof(&blocks[0], 0, &proof, &root, 4)?);
+
+        // Proof for block 2: [h[3], n01]
+        let proof2 = vec![h[3], n01];
+        assert!(verify_block_with_proof(&blocks[2], 2, &proof2, &root, 4)?);
+
+        // Proof for block 1: [h[0], n23]
+        let proof1 = vec![h[0], n23];
+        assert!(verify_block_with_proof(&blocks[1], 1, &proof1, &root, 4)?);
+
+        // Proof for block 3: [h[2], n01]
+        let proof3 = vec![h[2], n01];
+        assert!(verify_block_with_proof(&blocks[3], 3, &proof3, &root, 4)?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_verify_block_with_proof_wrong_data() -> Result<(), MerkleError> {
+        let blocks: Vec<Vec<u8>> = (0..4).map(make_block).collect();
+        let h: Vec<Id32> = blocks.iter().map(|b| hash_block(b)).collect();
+
+        let n01 = hash_pair(&h[0], &h[1]);
+        let n23 = hash_pair(&h[2], &h[3]);
+        let root = hash_pair(&n01, &n23);
+
+        // Correct proof for block 0, but with wrong block data
+        let proof = vec![h[1], n23];
+        let wrong_data = make_block(99);
+        assert!(!verify_block_with_proof(&wrong_data, 0, &proof, &root, 4)?);
+        Ok(())
+    }
+
+    #[test]
+    fn test_verify_block_with_proof_wrong_order() -> Result<(), MerkleError> {
+        // Reversed proof order should fail
+        let blocks: Vec<Vec<u8>> = (0..4).map(make_block).collect();
+        let h: Vec<Id32> = blocks.iter().map(|b| hash_block(b)).collect();
+
+        let n01 = hash_pair(&h[0], &h[1]);
+        let n23 = hash_pair(&h[2], &h[3]);
+        let root = hash_pair(&n01, &n23);
+
+        // Correct proof for block 0 is [h[1], n23]; reversed is [n23, h[1]]
+        let reversed_proof = vec![n23, h[1]];
+        assert!(!verify_block_with_proof(
+            &blocks[0],
+            0,
+            &reversed_proof,
+            &root,
+            4
+        )?);
+        Ok(())
+    }
+
+    #[test]
+    fn test_verify_block_with_proof_out_of_range_index() {
+        // Build a valid 4-block piece and proof for block 0.
+        let blocks: Vec<Vec<u8>> = (0..4).map(make_block).collect();
+        let h: Vec<Id32> = blocks.iter().map(|b| hash_block(b)).collect();
+
+        let n01 = hash_pair(&h[0], &h[1]);
+        let n23 = hash_pair(&h[2], &h[3]);
+        let root = hash_pair(&n01, &n23);
+        let proof_for_block0 = vec![h[1], n23];
+
+        // Index 4 is out of range for bpp=4 (valid indices are 0..=3).
+        // Without range validation this could alias a valid path after shifts.
+        assert_eq!(
+            verify_block_with_proof(&blocks[0], 4, &proof_for_block0, &root, 4).unwrap_err(),
+            MerkleError::InvalidBlockIndex {
+                max_index: 3,
+                actual_index: 4
+            }
+        );
+    }
+
+    // --- padding_piece_hash ---
+
+    #[test]
+    fn test_padding_piece_hash_bpp1() -> Result<(), MerkleError> {
+        assert_eq!(padding_piece_hash(1)?, zero_hash());
+        Ok(())
+    }
+
+    #[test]
+    fn test_padding_piece_hash_bpp2() -> Result<(), MerkleError> {
+        let zh = zero_hash();
+        let expected = hash_pair(&zh, &zh);
+        assert_eq!(padding_piece_hash(2)?, expected);
+        // Must NOT equal zero_hash for bpp > 1
+        assert_ne!(padding_piece_hash(2)?, zero_hash());
+        Ok(())
+    }
+
+    #[test]
+    fn test_padding_piece_hash_bpp4() -> Result<(), MerkleError> {
+        let zh = zero_hash();
+        let n01 = hash_pair(&zh, &zh);
+        let n23 = hash_pair(&zh, &zh);
+        let expected = hash_pair(&n01, &n23);
+        assert_eq!(padding_piece_hash(4)?, expected);
+        assert_ne!(padding_piece_hash(4)?, zero_hash());
+        assert_ne!(padding_piece_hash(4)?, padding_piece_hash(2)?);
+        Ok(())
+    }
+
+    // --- root_from_piece_layer ---
+
+    #[test]
+    fn test_root_from_piece_layer_single() -> Result<(), MerkleError> {
+        let h = hash_block(&make_block(0));
+        assert_eq!(root_from_piece_layer(&[h], 1)?, h);
+        Ok(())
+    }
+
+    #[test]
+    fn test_root_from_piece_layer_two_pieces() -> Result<(), MerkleError> {
+        let p0 = hash_block(&make_block(0));
+        let p1 = hash_block(&make_block(1));
+        let expected = hash_pair(&p0, &p1);
+        assert_eq!(root_from_piece_layer(&[p0, p1], 2)?, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn test_root_from_piece_layer_cross_validates_compute() -> Result<(), MerkleError> {
+        // Build a tree with compute_merkle_root, then reconstruct from piece layer
+        let hashes: Vec<Id32> = (0..8).map(|i| hash_block(&make_block(i))).collect();
+        let result = compute_merkle_root(&hashes, 2)?;
+
+        let reconstructed = root_from_piece_layer(&result.piece_hashes, 2)?;
+        assert_eq!(
+            reconstructed, result.root,
+            "root_from_piece_layer must match compute_merkle_root"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_root_from_piece_layer_cross_validates_with_padding() -> Result<(), MerkleError> {
+        // 5 blocks, bpp=2 → 3 piece hashes, padded to 4 at piece layer
+        let hashes: Vec<Id32> = (0..5).map(|i| hash_block(&make_block(i))).collect();
+        let result = compute_merkle_root(&hashes, 2)?;
+        assert_eq!(result.piece_hashes.len(), 3);
+
+        let reconstructed = root_from_piece_layer(&result.piece_hashes, 2)?;
+        assert_eq!(reconstructed, result.root);
+        Ok(())
+    }
+
+    #[test]
+    fn test_root_from_piece_layer_large_cross_validation() -> Result<(), MerkleError> {
+        // 33 blocks, bpp=4 → 9 piece hashes
+        let hashes: Vec<Id32> = (0..33).map(|i| hash_block(&make_block(i as u8))).collect();
+        let result = compute_merkle_root(&hashes, 4)?;
+        assert_eq!(result.piece_hashes.len(), 9);
+
+        let reconstructed = root_from_piece_layer(&result.piece_hashes, 4)?;
+        assert_eq!(reconstructed, result.root);
+        Ok(())
+    }
+
+    // --- Error cases ---
+
+    #[test]
+    fn test_error_zero_blocks_per_piece() {
+        assert_eq!(
+            compute_merkle_root(&[zero_hash()], 0).unwrap_err(),
+            MerkleError::ZeroBlocksPerPiece
+        );
+        assert_eq!(
+            verify_piece(&[], 0, &zero_hash()).unwrap_err(),
+            MerkleError::ZeroBlocksPerPiece
+        );
+        assert_eq!(
+            padding_piece_hash(0).unwrap_err(),
+            MerkleError::ZeroBlocksPerPiece
+        );
+        assert_eq!(
+            root_from_piece_layer(&[zero_hash()], 0).unwrap_err(),
+            MerkleError::ZeroBlocksPerPiece
+        );
+    }
+
+    #[test]
+    fn test_error_non_power_of_two_bpp() {
+        assert_eq!(
+            compute_merkle_root(&[zero_hash()], 3).unwrap_err(),
+            MerkleError::NonPowerOfTwoBlocksPerPiece(3)
+        );
+        assert_eq!(
+            verify_piece(&[], 5, &zero_hash()).unwrap_err(),
+            MerkleError::NonPowerOfTwoBlocksPerPiece(5)
+        );
+        assert_eq!(
+            padding_piece_hash(6).unwrap_err(),
+            MerkleError::NonPowerOfTwoBlocksPerPiece(6)
+        );
+        assert_eq!(
+            root_from_piece_layer(&[zero_hash()], 7).unwrap_err(),
+            MerkleError::NonPowerOfTwoBlocksPerPiece(7)
+        );
+    }
+
+    #[test]
+    fn test_error_empty_block_hashes() {
+        assert_eq!(
+            compute_merkle_root(&[], 1).unwrap_err(),
+            MerkleError::EmptyBlockHashes
+        );
+        assert_eq!(
+            root_from_piece_layer(&[], 1).unwrap_err(),
+            MerkleError::EmptyBlockHashes
+        );
+    }
+
+    #[test]
+    fn test_error_invalid_proof_length() {
+        let h = hash_block(&make_block(0));
+        // bpp=4 requires proof of length 2
+        assert_eq!(
+            verify_block_with_proof(&make_block(0), 0, &[h], &h, 4).unwrap_err(),
+            MerkleError::InvalidProofLength {
+                expected: 2,
+                actual: 1
+            }
+        );
+        assert_eq!(
+            verify_block_with_proof(&make_block(0), 0, &[h, h, h], &h, 4).unwrap_err(),
+            MerkleError::InvalidProofLength {
+                expected: 2,
+                actual: 3
+            }
+        );
+    }
+
+    #[test]
+    fn test_error_piece_too_large() {
+        // bpp=2 allows at most 2 blocks. Provide 3 blocks.
+        let mut piece = make_block(1);
+        piece.extend_from_slice(&make_block(2));
+        piece.extend_from_slice(&make_block(3));
+
+        assert_eq!(
+            verify_piece(&piece, 2, &zero_hash()).unwrap_err(),
+            MerkleError::PieceTooLarge {
+                max_blocks: 2,
+                actual_blocks: 3
+            }
+        );
+    }
+
+    #[test]
+    fn test_verify_block_bpp1_no_proof() -> Result<(), MerkleError> {
+        // bpp=1: proof length is 0, the block hash IS the piece hash
+        let block = make_block(42);
+        let h = hash_block(&block);
+        assert!(verify_block_with_proof(&block, 0, &[], &h, 1)?);
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary

Implements PR 2 from `docs/BEP52-INCREMENTAL-PR-PLAN.md` (Merkle Tree Module).

- Add new `crates/librqbit_core/src/merkle.rs` with BEP 52 merkle primitives:
  - constants: `MERKLE_BLOCK_SIZE`
  - typed errors: `MerkleError`
  - core hashing: `zero_hash()`, `hash_block()`, `hash_pair()`
  - construction: `compute_merkle_root()` returning `MerkleResult { root, piece_hashes }`
  - verification: `verify_piece()`, `verify_block_with_proof()`
  - helpers: `padding_piece_hash()`, `root_from_piece_layer()`
- Export the module from `crates/librqbit_core/src/lib.rs` (feature-gated with sha1 backends).
- Include runtime correctness guards in verification paths:
  - reject oversized piece data in `verify_piece()`
  - reject out-of-range block indices in `verify_block_with_proof()`
- Implement small-tree stack path optimization (`padded leaf count <= 8`) while keeping Vec path for larger trees.
- Add broad unit coverage (33 merkle tests), including proof ordering, cross-validation, trimming behavior, and invalid input cases.

## BEP 52 Roadmap

This is PR 2 of 16 implementing BEP 52 (BitTorrent v2) support.
See https://gist.github.com/meatsquirk/533cae01ad9ba49834ffbb3bb3edc469 for the full stacked plan.

## Test plan

- [x] `cargo +1.90.0 check --all-targets`
- [x] `cargo +1.90.0 clippy --all-targets -- -D warnings -D dead_code -D unused_variables`
- [x] `cargo +1.90.0 test -p librqbit-core merkle`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Latest Update (2026-02-15)

Follow-up commit `217e3488` applies review-driven improvements to `merkle.rs`:

- Streaming merkle construction API: `compute_merkle_root_streaming()`.
- Single-pass piece verification (`verify_piece`) with no double chunk iteration.
- Tree reduction helper reuse to avoid duplicated pair-hashing loops.
- Small-tree stack path in `padding_piece_hash()`.
- Branchless fixed-size hash comparison (`ct_eq_id32`) in verification paths.
- Additional tests for streaming parity and constant-time comparison helper.

Additional validation run after this update:

- `cargo check`
- `cargo clippy --all-targets`
- `cargo test -p librqbit-core merkle::tests::`
- `cargo test --workspace`

All passed.
