### PR TITLE
Add configurable client identity for HTTP User-Agent and peer handshakes

### DIFF
--- a/crates/librqbit/src/dht_utils.rs
+++ b/crates/librqbit/src/dht_utils.rs
@@ -34,6 +34,7 @@ pub async fn read_metainfo_from_peer_receiver<A: Stream<Item = SocketAddr> + Unp
     addrs_stream: A,
     peer_connection_options: Option<PeerConnectionOptions>,
     connector: Arc<StreamConnector>,
+    client_name_and_version: String,
 ) -> ReadMetainfoResult<A> {
     let mut seen = HashSet::<SocketAddr>::new();
     let mut addrs = addrs_stream;
@@ -43,6 +44,7 @@ pub async fn read_metainfo_from_peer_receiver<A: Stream<Item = SocketAddr> + Unp
     let read_info_guarded = |addr| {
         let semaphore = &semaphore;
         let connector = connector.clone();
+        let client_name_and_version = client_name_and_version.clone();
         async move {
             let token = semaphore.acquire().await?;
             let ret = peer_info_reader::read_metainfo_from_peer(
@@ -54,6 +56,7 @@ pub async fn read_metainfo_from_peer_receiver<A: Stream<Item = SocketAddr> + Unp
                 // ok not to use a shared one.
                 BlockingSpawner::new(1),
                 connector,
+                client_name_and_version,
             )
             .instrument(debug_span!("read_metainfo_from_peer", ?addr))
             .await
@@ -142,6 +145,7 @@ mod tests {
             peer_rx,
             None,
             Arc::new(StreamConnector::new(Default::default()).await.unwrap()),
+            crate::client_name_and_version().to_owned(),
         )
         .await
         {

--- a/crates/librqbit/src/lib.rs
+++ b/crates/librqbit/src/lib.rs
@@ -117,7 +117,7 @@ pub const fn version() -> &'static str {
 }
 
 pub const fn client_name_and_version() -> &'static str {
-    concat!("rqbit ", env!("CARGO_PKG_VERSION"))
+    concat!("rqbit/", env!("CARGO_PKG_VERSION"))
 }
 
 pub fn try_increase_nofile_limit() -> anyhow::Result<u64> {

--- a/crates/librqbit/src/lib.rs
+++ b/crates/librqbit/src/lib.rs
@@ -117,7 +117,7 @@ pub const fn version() -> &'static str {
 }
 
 pub const fn client_name_and_version() -> &'static str {
-    concat!("rqbit/", env!("CARGO_PKG_VERSION"))
+    concat!("rqbit ", env!("CARGO_PKG_VERSION"))
 }
 
 pub fn try_increase_nofile_limit() -> anyhow::Result<u64> {

--- a/crates/librqbit/src/peer_connection.rs
+++ b/crates/librqbit/src/peer_connection.rs
@@ -52,6 +52,9 @@ pub trait PeerConnectionHandler {
     ) -> anyhow::Result<()> {
         Ok(())
     }
+    fn client_name_and_version(&self) -> &str {
+        crate::client_name_and_version()
+    }
 }
 
 #[derive(Debug)]
@@ -293,7 +296,7 @@ impl<H: PeerConnectionHandler> PeerConnection<H> {
 
         if supports_extended {
             let mut my_extended = ExtendedHandshake::new();
-            my_extended.v = Some(ByteBuf(crate::client_name_and_version().as_bytes()));
+            my_extended.v = Some(ByteBuf(self.handler.client_name_and_version().as_bytes()));
             my_extended.yourip = Some(self.addr.ip().into());
             self.handler
                 .update_my_extended_handshake(&mut my_extended)

--- a/crates/librqbit/src/peer_info_reader/mod.rs
+++ b/crates/librqbit/src/peer_info_reader/mod.rs
@@ -37,6 +37,7 @@ pub(crate) async fn read_metainfo_from_peer(
     peer_connection_options: Option<PeerConnectionOptions>,
     spawner: BlockingSpawner,
     connector: Arc<StreamConnector>,
+    client_name_and_version: String,
 ) -> anyhow::Result<TorrentAndInfoBytes> {
     let (result_tx, result_rx) = tokio::sync::oneshot::channel::<
         Result<(TorrentMetaV1Info<ByteBufOwned>, ByteBufOwned), bencode::DeserializeError>,
@@ -48,6 +49,7 @@ pub(crate) async fn read_metainfo_from_peer(
         writer_tx,
         result_tx: Mutex::new(Some(result_tx)),
         locked: RwLock::new(None),
+        client_name_and_version,
     };
     let connection = PeerConnection::new(
         addr,
@@ -157,6 +159,7 @@ struct Handler {
         >,
     >,
     locked: RwLock<Option<HandlerLocked>>,
+    client_name_and_version: String,
 }
 
 impl PeerConnectionHandler for Handler {
@@ -253,5 +256,9 @@ impl PeerConnectionHandler for Handler {
 
     fn should_transmit_have(&self, _id: librqbit_core::lengths::ValidPieceIndex) -> bool {
         false
+    }
+
+    fn client_name_and_version(&self) -> &str {
+        &self.client_name_and_version
     }
 }

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -1581,6 +1581,7 @@ impl Session {
             peer_rx,
             Some(self.merge_peer_opts(peer_opts)),
             self.connector.clone(),
+            self.client_name_and_version.clone(),
         )
         .await
         {

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -150,6 +150,7 @@ pub struct Session {
     _disable_upload: bool,
     pub ipv4_only: bool,
     pub peer_limit: Option<usize>,
+    client_name_and_version: String,
 }
 
 async fn torrent_from_url(
@@ -457,6 +458,10 @@ pub struct SessionOptions {
 
     /// Force IPv4 only.
     pub ipv4_only: bool,
+
+    /// Override the client name and version used in User-Agent headers and
+    /// peer extended handshakes. Defaults to "rqbit/X.Y.Z".
+    pub client_name_and_version: Option<String>,
 }
 
 fn torrent_file_from_info_bytes(info_bytes: &[u8], trackers: &[url::Url]) -> anyhow::Result<Bytes> {
@@ -505,6 +510,10 @@ impl Session {
 
     pub fn cancellation_token(&self) -> &CancellationToken {
         &self.cancellation_token
+    }
+
+    pub fn client_name_and_version(&self) -> &str {
+        &self.client_name_and_version
     }
 
     /// Create a new session with options.
@@ -639,6 +648,10 @@ impl Session {
                 None => None,
             };
 
+            let client_name_and_version = opts
+                .client_name_and_version
+                .unwrap_or_else(|| crate::client_name_and_version().to_owned());
+
             let reqwest_client = {
                 let builder = if let Some(proxy_url) = proxy_url {
                     let proxy = reqwest::Proxy::all(proxy_url)
@@ -654,7 +667,10 @@ impl Session {
                     b
                 };
 
-                builder.build().context("error building HTTP(S) client")?
+                builder
+                    .user_agent(&client_name_and_version)
+                    .build()
+                    .context("error building HTTP(S) client")?
             };
 
             let stream_connector = Arc::new(
@@ -738,6 +754,7 @@ impl Session {
                 trackers: opts.trackers,
                 disable_trackers: opts.disable_trackers,
                 peer_limit: opts.peer_limit,
+                client_name_and_version,
 
                 #[cfg(feature = "disable-upload")]
                 _disable_upload: opts.disable_upload,
@@ -1279,6 +1296,7 @@ impl Session {
                 connector: self.connector.clone(),
                 session: Arc::downgrade(self),
                 magnet_name: name,
+                client_name_and_version: self.client_name_and_version.clone(),
             });
 
             let initializing = Arc::new(TorrentStateInitializing::new(

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -460,7 +460,7 @@ pub struct SessionOptions {
     pub ipv4_only: bool,
 
     /// Override the client name and version used in User-Agent headers and
-    /// peer extended handshakes. Defaults to "rqbit/X.Y.Z".
+    /// peer extended handshakes. Defaults to "rqbit X.Y.Z".
     pub client_name_and_version: Option<String>,
 }
 

--- a/crates/librqbit/src/torrent_state/live/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/mod.rs
@@ -483,6 +483,7 @@ impl TorrentStateLive {
             counters,
             first_message_received: AtomicBool::new(false),
             cancel_token: self.cancellation_token.child_token(),
+            client_name_and_version: self.shared.client_name_and_version().to_owned(),
         };
         let _token_guard = handler.cancel_token.clone().drop_guard();
         let options = PeerConnectionOptions {
@@ -548,6 +549,7 @@ impl TorrentStateLive {
             counters,
             first_message_received: AtomicBool::new(false),
             cancel_token: state.cancellation_token.child_token(),
+            client_name_and_version: state.shared.client_name_and_version().to_owned(),
         };
         let _token_guard = handler.cancel_token.clone().drop_guard();
 
@@ -1027,6 +1029,8 @@ struct PeerHandler {
     first_message_received: AtomicBool,
 
     cancel_token: CancellationToken,
+
+    client_name_and_version: String,
 }
 
 impl PeerConnectionHandler for &'_ PeerHandler {
@@ -1214,6 +1218,10 @@ impl PeerConnectionHandler for &'_ PeerHandler {
         }
 
         Ok(())
+    }
+
+    fn client_name_and_version(&self) -> &str {
+        &self.client_name_and_version
     }
 }
 

--- a/crates/librqbit/src/torrent_state/mod.rs
+++ b/crates/librqbit/src/torrent_state/mod.rs
@@ -192,6 +192,14 @@ pub struct ManagedTorrentShared {
 
     // "dn" from magnet link
     pub(crate) magnet_name: Option<String>,
+
+    pub(crate) client_name_and_version: String,
+}
+
+impl ManagedTorrentShared {
+    pub(crate) fn client_name_and_version(&self) -> &str {
+        &self.client_name_and_version
+    }
 }
 
 pub struct ManagedTorrent {

--- a/crates/rqbit/src/main.rs
+++ b/crates/rqbit/src/main.rs
@@ -662,6 +662,7 @@ async fn async_main(mut opts: Opts, cancel: CancellationToken) -> anyhow::Result
         peer_limit: opts.peer_limit,
         runtime_worker_threads: Some(opts.max_blocking_threads as usize),
         ipv4_only: opts.ipv4_only,
+        client_name_and_version: None,
     };
 
     #[allow(clippy::needless_update)]


### PR DESCRIPTION
Many private trackers require an explicit User-Agent to be passed (to prevent crawling). UNIT3D-Announce (https://github.com/Roardom/UNIT3D-Announce) is commonly used on private trackers which will block any HTTP torrents from working when none is provided in the request header. Because of this change, I thought it might be fine to also add field overrides for the user-agent identifier as it was requested in #473. The implementation uses shallow copying which would be 1 string clone per torrent and 1 per peer connection (not really expensive). The added overhead is about 20 bytes.