### PR TITLE
feat: add DHT nodes from BEP-5 .torrent files to the routing table

### DIFF
--- a/crates/dht/src/dht.rs
+++ b/crates/dht/src/dht.rs
@@ -1396,3 +1396,80 @@ impl FromSocketAddr for SocketAddrV6 {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        net::{Ipv4Addr, SocketAddr},
+        time::Duration,
+    };
+
+    use librqbit_core::hash_id::Id20;
+
+    use crate::{Dht, DhtConfig, DhtState, routing_table::RoutingTable};
+
+    /// Spawn an in-process DHT node bound to an ephemeral v4 loopback port.
+    async fn spawn_node(
+        peer_id: Id20,
+        routing_table: Option<RoutingTable>,
+        bootstrap_addrs: Vec<String>,
+    ) -> Dht {
+        DhtState::with_config(DhtConfig {
+            peer_id: Some(peer_id),
+            bootstrap_addrs: Some(bootstrap_addrs),
+            routing_table,
+            listen_addr: Some((Ipv4Addr::LOCALHOST, 0).into()),
+            ..Default::default()
+        })
+        .await
+        .unwrap()
+    }
+
+    /// Poll the routing tables until a node with the given id shows up, or time out.
+    async fn wait_for_node_in_table(dht: &Dht, id: Id20, timeout: Duration) -> bool {
+        tokio::time::timeout(timeout, async {
+            loop {
+                let found = dht
+                    .with_routing_tables(|v4, v6| v4.iter().chain(v6.iter()).any(|n| n.id() == id));
+                if found {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+        })
+        .await
+        .is_ok()
+    }
+
+    // An unreachable bootstrap addr keeps a node's bootstrap task pending (retrying)
+    // so its worker stays alive without ever contacting the public DHT.
+    const UNREACHABLE_BOOTSTRAP: &str = "127.0.0.1:1";
+
+    /// Bootstrapping a node against a peer that knows another node should pull that
+    /// other node into the local routing table via find_node recursion.
+    #[tokio::test]
+    async fn bootstrap_populates_routing_table() {
+        let b_id = Id20::new([0x11; 20]);
+        let c_id = Id20::new([0xcc; 20]);
+        let c_addr: SocketAddr = (Ipv4Addr::LOCALHOST, 9999).into();
+
+        // Node B is seeded with a single known node C.
+        let mut b_table = RoutingTable::new(b_id, None);
+        b_table.add_node(c_id, c_addr);
+        let b = spawn_node(b_id, Some(b_table), vec![UNREACHABLE_BOOTSTRAP.to_string()]).await;
+
+        // Node A bootstraps off B, so it should learn about C.
+        let a_id = Id20::new([0x22; 20]);
+        let a = spawn_node(
+            a_id,
+            None,
+            vec![format!("127.0.0.1:{}", b.listen_addr().port())],
+        )
+        .await;
+
+        assert!(
+            wait_for_node_in_table(&a, c_id, Duration::from_secs(10)).await,
+            "A should have learned about node C via bootstrap"
+        );
+    }
+}

--- a/crates/dht/src/dht.rs
+++ b/crates/dht/src/dht.rs
@@ -979,26 +979,7 @@ impl DhtWorker {
     }
 
     async fn bootstrap_hostname(&self, hostname: &str) -> crate::Result<()> {
-        let addrs = tokio::net::lookup_host(hostname)
-            .await
-            .map_err(|err| Error::lookup(hostname, err))?
-            .collect::<Vec<_>>();
-        let v4 = RecursiveRequest::find_node_for_routing_table(
-            self.dht.clone(),
-            self.dht.id,
-            addrs.iter().copied().filter(|a| a.is_ipv4()),
-        )
-        .instrument(debug_span!("v4"));
-
-        let v6 = RecursiveRequest::find_node_for_routing_table(
-            self.dht.clone(),
-            self.dht.id,
-            addrs.iter().copied().filter(|a| a.is_ipv6()),
-        )
-        .instrument(debug_span!("v6"));
-
-        let (v4, v6) = tokio::join!(v4, v6);
-        v4.or(v6)
+        self.dht.resolve_and_find_nodes(hostname).await
     }
 
     async fn bootstrap_hostname_with_backoff(&self, addr: &str) -> crate::Result<()> {
@@ -1356,6 +1337,46 @@ impl DhtState {
         announce_port: Option<u16>,
     ) -> RequestPeersStream {
         RequestPeersStream::new(self.clone(), info_hash, announce_port)
+    }
+
+    /// Run find_node against the given addresses (split by IP family) to populate
+    /// the routing table.
+    async fn find_nodes_in_routing_table(
+        self: &Arc<Self>,
+        addrs: &[SocketAddr],
+    ) -> crate::Result<()> {
+        let v4 = RecursiveRequest::find_node_for_routing_table(
+            self.clone(),
+            self.id,
+            addrs.iter().copied().filter(|a| a.is_ipv4()),
+        )
+        .instrument(debug_span!("v4"));
+
+        let v6 = RecursiveRequest::find_node_for_routing_table(
+            self.clone(),
+            self.id,
+            addrs.iter().copied().filter(|a| a.is_ipv6()),
+        )
+        .instrument(debug_span!("v6"));
+
+        let (v4, v6) = tokio::join!(v4, v6);
+        v4.or(v6)
+    }
+
+    /// Resolve `addr` (a "host:port" string or a (host, port) tuple, which may be
+    /// a hostname or IPv4/IPv6 literal) and populate the routing table from it.
+    async fn resolve_and_find_nodes(
+        self: &Arc<Self>,
+        addr: impl tokio::net::ToSocketAddrs + std::fmt::Debug,
+    ) -> crate::Result<()> {
+        // lookup_host consumes `addr` and Error::lookup wants a &str, so derive
+        // the error label up front from the Debug repr.
+        let label = format!("{addr:?}");
+        let addrs = tokio::net::lookup_host(addr)
+            .await
+            .map_err(|err| Error::lookup(&label, err))?
+            .collect::<Vec<_>>();
+        self.find_nodes_in_routing_table(&addrs).await
     }
 
     pub fn listen_addr(&self) -> SocketAddr {

--- a/crates/dht/src/dht.rs
+++ b/crates/dht/src/dht.rs
@@ -1339,6 +1339,39 @@ impl DhtState {
         RequestPeersStream::new(self.clone(), info_hash, announce_port)
     }
 
+    /// Inject additional bootstrap nodes (e.g. from a .torrent BEP-5 `nodes`
+    /// list) into the routing table by resolving each host and running find_node
+    /// against it. Each entry is `(host, port)` where host may be a hostname or an
+    /// IPv4/IPv6 literal. Runs in the background, best-effort.
+    pub fn add_bootstrap_nodes(self: &Arc<Self>, nodes: Vec<(String, u16)>) {
+        if nodes.is_empty() {
+            return;
+        }
+        let dht = self.clone();
+        spawn_with_cancel(
+            debug_span!(parent: None, "add_bootstrap_nodes", count = nodes.len()),
+            "add_bootstrap_nodes",
+            self.cancellation_token.clone(),
+            async move {
+                let mut futs = FuturesUnordered::new();
+                for (host, port) in nodes {
+                    let dht = dht.clone();
+                    futs.push(async move {
+                        // (host, port) impls ToSocketAddrs: DNS names and IPv4/IPv6
+                        // literals (no bracketing needed) are all handled here.
+                        dht.resolve_and_find_nodes((host.as_str(), port)).await
+                    });
+                }
+                while let Some(res) = futs.next().await {
+                    if let Err(e) = res {
+                        debug!("error adding bootstrap node: {e:#}");
+                    }
+                }
+                Ok::<(), crate::Error>(())
+            },
+        );
+    }
+
     /// Run find_node against the given addresses (split by IP family) to populate
     /// the routing table.
     async fn find_nodes_in_routing_table(
@@ -1492,5 +1525,44 @@ mod tests {
             wait_for_node_in_table(&a, c_id, Duration::from_secs(10)).await,
             "A should have learned about node C via bootstrap"
         );
+    }
+
+    /// `add_bootstrap_nodes` should populate the routing table at runtime, using
+    /// only the DHT (not initial peers). A does not bootstrap off B here, so the
+    /// only way it can learn about C is via the added node.
+    #[tokio::test]
+    async fn add_bootstrap_nodes_populates_table() {
+        let b_id = Id20::new([0x11; 20]);
+        let c_id = Id20::new([0xcc; 20]);
+        let c_addr: SocketAddr = (Ipv4Addr::LOCALHOST, 9999).into();
+
+        let mut b_table = RoutingTable::new(b_id, None);
+        b_table.add_node(c_id, c_addr);
+        let b = spawn_node(b_id, Some(b_table), vec![UNREACHABLE_BOOTSTRAP.to_string()]).await;
+
+        // A's own bootstrap goes nowhere; it starts with an empty routing table.
+        let a_id = Id20::new([0x22; 20]);
+        let a = spawn_node(a_id, None, vec![UNREACHABLE_BOOTSTRAP.to_string()]).await;
+
+        a.add_bootstrap_nodes(vec![("127.0.0.1".to_string(), b.listen_addr().port())]);
+
+        assert!(
+            wait_for_node_in_table(&a, c_id, Duration::from_secs(10)).await,
+            "A should have learned about node C via add_bootstrap_nodes"
+        );
+    }
+
+    /// Empty input is a no-op and must not panic.
+    #[tokio::test]
+    async fn add_bootstrap_nodes_empty_is_noop() {
+        let a = spawn_node(
+            Id20::new([0x33; 20]),
+            None,
+            vec![UNREACHABLE_BOOTSTRAP.to_string()],
+        )
+        .await;
+        a.add_bootstrap_nodes(vec![]);
+        let count = a.with_routing_tables(|v4, v6| v4.iter().count() + v6.iter().count());
+        assert_eq!(count, 0);
     }
 }

--- a/crates/librqbit/src/create_torrent_file.rs
+++ b/crates/librqbit/src/create_torrent_file.rs
@@ -9,7 +9,9 @@ use buffers::ByteBufOwned;
 use bytes::Bytes;
 use librqbit_core::Id20;
 use librqbit_core::magnet::Magnet;
-use librqbit_core::torrent_metainfo::{TorrentMetaV1File, TorrentMetaV1Info, TorrentMetaV1Owned};
+use librqbit_core::torrent_metainfo::{
+    DhtNode, TorrentMetaV1File, TorrentMetaV1Info, TorrentMetaV1Owned,
+};
 use sha1w::ISha1;
 
 use crate::spawn_utils::BlockingSpawner;
@@ -19,6 +21,8 @@ pub struct CreateTorrentOptions<'a> {
     pub name: Option<&'a str>,
     pub trackers: Vec<String>,
     pub piece_length: Option<u32>,
+    /// BEP-0005: DHT bootstrap nodes to embed in the .torrent file.
+    pub nodes: Vec<DhtNode>,
 }
 
 fn walk_dir_find_paths(dir: &Path, out: &mut Vec<Cow<'_, Path>>) -> anyhow::Result<()> {
@@ -219,6 +223,7 @@ pub async fn create_torrent<'a>(
         .iter()
         .map(|t| ByteBufOwned::from(t.as_bytes()))
         .collect();
+    let nodes = options.nodes.clone();
     let res = create_torrent_raw(path, options, spawner).await?;
     let (info_hash, bytes) = compute_info_hash(&res.info).context("error computing info hash")?;
     Ok(CreateTorrentResult {
@@ -235,6 +240,7 @@ pub async fn create_torrent<'a>(
             publisher: None,
             publisher_url: None,
             creation_date: None,
+            nodes,
             info_hash,
         },
         output_folder: res.output_folder,
@@ -245,7 +251,7 @@ pub async fn create_torrent<'a>(
 mod tests {
     use librqbit_core::torrent_metainfo::torrent_from_bytes;
 
-    use crate::{create_torrent, spawn_utils::BlockingSpawner};
+    use crate::{CreateTorrentOptions, create_torrent, spawn_utils::BlockingSpawner};
 
     #[tokio::test]
     async fn test_create_torrent() {
@@ -264,5 +270,38 @@ mod tests {
 
         let deserialized = torrent_from_bytes(&bytes).unwrap();
         assert_eq!(torrent.info_hash(), deserialized.info_hash);
+    }
+
+    #[tokio::test]
+    async fn test_create_torrent_with_bootstrap_nodes() {
+        use crate::tests::test_util;
+
+        let dir = test_util::create_default_random_dir_with_torrents(
+            3,
+            1000 * 1000,
+            Some("rqbit_test_create_torrent"),
+        );
+        let options = CreateTorrentOptions {
+            nodes: vec![librqbit_core::torrent_metainfo::DhtNode::new(
+                "127.0.0.1".to_string(),
+                50001,
+            )],
+            ..Default::default()
+        };
+        let torrent = create_torrent(dir.path(), options, &BlockingSpawner::new(1))
+            .await
+            .unwrap();
+
+        let bytes = torrent.as_bytes().unwrap();
+
+        let deserialized = torrent_from_bytes(&bytes).unwrap();
+        assert_eq!(torrent.info_hash(), deserialized.info_hash);
+        assert_eq!(
+            deserialized.nodes,
+            vec![librqbit_core::torrent_metainfo::DhtNode::new(
+                "127.0.0.1".to_string(),
+                50001
+            )]
+        );
     }
 }

--- a/crates/librqbit/src/http_api/handlers/torrents.rs
+++ b/crates/librqbit/src/http_api/handlers/torrents.rs
@@ -12,6 +12,7 @@ use http::{
     header::{CONTENT_DISPOSITION, CONTENT_TYPE},
 };
 use librqbit_core::magnet::Magnet;
+use librqbit_core::torrent_metainfo::DhtNode;
 use serde::{Deserialize, Serialize};
 
 use super::ApiState;
@@ -365,6 +366,8 @@ pub struct HttpCreateTorrentOptions {
     #[serde(default)]
     trackers: Vec<String>,
     name: Option<String>,
+    #[serde(default)]
+    nodes: Vec<DhtNode>,
 }
 
 pub async fn h_create_torrent(
@@ -389,6 +392,7 @@ pub async fn h_create_torrent(
         name: opts.name.as_deref(),
         trackers: opts.trackers,
         piece_length: None,
+        nodes: opts.nodes,
     };
 
     let (torrent, handle) = state

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -1134,6 +1134,27 @@ impl Session {
                         }
                     };
 
+                    // BEP-0005: `nodes` are DHT contacts, not BT peers. Hand them
+                    // to the DHT so it can query them to discover peers. Host may
+                    // be a hostname or IP literal; the DHT resolves them.
+                    if !torrent.meta.nodes.is_empty() {
+                        match self.dht.as_ref() {
+                            Some(dht) => {
+                                let nodes: Vec<(String, u16)> = torrent
+                                    .meta
+                                    .nodes
+                                    .iter()
+                                    .map(|node| (node.host.clone(), node.port))
+                                    .collect();
+                                info!(?nodes, "BEP-0005: adding torrent nodes to DHT");
+                                dht.add_bootstrap_nodes(nodes);
+                            }
+                            None => {
+                                debug!("BEP-0005: torrent has nodes but DHT is disabled, ignoring");
+                            }
+                        }
+                    }
+
                     let mut trackers = torrent
                         .meta
                         .iter_announce()

--- a/crates/librqbit/src/upnp_server_adapter.rs
+++ b/crates/librqbit/src/upnp_server_adapter.rs
@@ -427,6 +427,7 @@ mod tests {
             publisher_url: None,
             creation_date: None,
             info_hash: Id20::default(),
+            nodes: vec![],
         }
     }
 

--- a/crates/librqbit_core/src/dht_node.rs
+++ b/crates/librqbit_core/src/dht_node.rs
@@ -1,0 +1,113 @@
+use serde::ser::SerializeSeq;
+use serde::{Deserialize, Serialize};
+
+/// BEP-0005 DHT bootstrap node entry: ["<host>", <port>].
+/// Custom serde to serialize as a 2-element bencode list.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DhtNode {
+    pub host: String,
+    pub port: u16,
+}
+
+impl DhtNode {
+    pub fn new(host: impl Into<String>, port: u16) -> Self {
+        Self {
+            host: host.into(),
+            port,
+        }
+    }
+}
+
+impl Serialize for DhtNode {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut seq = serializer.serialize_seq(Some(2))?;
+        seq.serialize_element(&self.host)?;
+        seq.serialize_element(&self.port)?;
+        seq.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for DhtNode {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct DhtNodeVisitor;
+        impl<'de> serde::de::Visitor<'de> for DhtNodeVisitor {
+            type Value = DhtNode;
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                write!(f, "a list of [host, port]")
+            }
+            fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                self,
+                mut seq: A,
+            ) -> Result<DhtNode, A::Error> {
+                let host: String = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let port: u16 = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(1, &self))?;
+
+                seq.next_element::<serde::de::IgnoredAny>()?;
+                Ok(DhtNode { host, port })
+            }
+        }
+        deserializer.deserialize_seq(DhtNodeVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn serialize(value: &impl Serialize) -> Vec<u8> {
+        let mut buf = Vec::new();
+        bencode::bencode_serialize_to_writer(value, &mut buf).unwrap();
+        buf
+    }
+
+    #[test]
+    fn test_roundtrip_bencode_single() {
+        let node = DhtNode::new("127.0.0.1", 6881);
+        let bytes = serialize(&node);
+        assert_eq!(&bytes, b"l9:127.0.0.1i6881ee");
+        let decoded: DhtNode = bencode::from_bytes(&bytes).unwrap();
+        assert_eq!(decoded, node);
+    }
+
+    #[test]
+    fn test_roundtrip_bencode_vec() {
+        let nodes = vec![
+            DhtNode::new("127.0.0.1", 6881),
+            DhtNode::new("10.0.0.1", 50001),
+        ];
+        let bytes = serialize(&nodes);
+        let decoded: Vec<DhtNode> = bencode::from_bytes(&bytes).unwrap();
+        assert_eq!(decoded, nodes);
+    }
+
+    #[test]
+    fn test_roundtrip_bencode_in_struct() {
+        #[derive(Debug, PartialEq, Eq, serde_derive::Serialize, serde_derive::Deserialize)]
+        struct Outer {
+            name: String,
+            nodes: Vec<DhtNode>,
+            extra: u32,
+        }
+
+        let outer = Outer {
+            name: "test".into(),
+            nodes: vec![DhtNode::new("192.168.1.1", 8080)],
+            extra: 42,
+        };
+        let bytes = serialize(&outer);
+        let decoded: Outer = bencode::from_bytes(&bytes).unwrap();
+        assert_eq!(decoded, outer);
+    }
+
+    #[test]
+    fn test_deserialize_empty_vec() {
+        let bytes = serialize(&Vec::<DhtNode>::new());
+        assert_eq!(&bytes, b"le");
+        let decoded: Vec<DhtNode> = bencode::from_bytes(&bytes).unwrap();
+        assert!(decoded.is_empty());
+    }
+}

--- a/crates/librqbit_core/src/lib.rs
+++ b/crates/librqbit_core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod compact_ip;
 pub mod constants;
+pub mod dht_node;
 pub mod directories;
 mod error;
 pub mod hash_id;

--- a/crates/librqbit_core/src/torrent_metainfo.rs
+++ b/crates/librqbit_core/src/torrent_metainfo.rs
@@ -10,6 +10,8 @@ use tracing::debug;
 
 use crate::{Error, hash_id::Id20, lengths::Lengths};
 
+pub use crate::dht_node::DhtNode;
+
 pub type TorrentMetaV1Borrowed<'a> = TorrentMetaV1<ByteBuf<'a>>;
 pub type TorrentMetaV1Owned = TorrentMetaV1<ByteBufOwned>;
 
@@ -66,6 +68,10 @@ pub struct TorrentMetaV1<BufType> {
     pub publisher_url: Option<BufType>,
     #[serde(rename = "creation date", skip_serializing_if = "Option::is_none")]
     pub creation_date: Option<usize>,
+
+    /// BEP-0005: DHT bootstrap nodes as `[["<host>", <port>], ...]`.
+    #[serde(default = "Vec::new", skip_serializing_if = "Vec::is_empty")]
+    pub nodes: Vec<DhtNode>,
 
     #[serde(skip)]
     pub info_hash: Id20,
@@ -499,6 +505,7 @@ where
             publisher: self.publisher.clone_to_owned(within_buffer),
             publisher_url: self.publisher_url.clone_to_owned(within_buffer),
             creation_date: self.creation_date,
+            nodes: self.nodes.clone(),
             info_hash: self.info_hash,
         }
     }


### PR DESCRIPTION
## Summary

Addresses the review on #583. BEP-5 `nodes` embedded in a `.torrent` are the closest DHT contacts, not BitTorrent peers — they must be queried over DHT to discover peers. The previous approach injected them into `initial_peers`, treating them as BT peers. This PR:

- Adds a public `DhtState::add_bootstrap_nodes(Vec<(String, u16)>)` API to inject nodes into the routing table at runtime (best-effort, background), resolving hostnames as well as IPv4/IPv6 literals (per the spec, `<host>` may be a DNS name like `your.router.node`).
- Refactors the existing `bootstrap_hostname` logic onto `DhtState` (`find_nodes_in_routing_table` + `resolve_and_find_nodes`) so bootstrap and the new API share one code path.
- Wires `.torrent` `nodes` in `librqbit`'s `add_torrent` to the DHT via that API instead of `initial_peers` (ignored with a debug log if DHT is disabled).

The initial BEP-5 commit was amended to remove the now-obsolete initial-peers wiring, keeping history clean.

## Test plan

- `cargo test -p librqbit-dht --lib` — new tests:
  - `bootstrap_populates_routing_table` (locks in existing bootstrap behavior)
  - `add_bootstrap_nodes_populates_table` (A learns a node only via the new API)
  - `add_bootstrap_nodes_empty_is_noop`
- `cargo test -p librqbit test_create_torrent_with_bootstrap_nodes`
- `cargo test -p librqbit-core dht_node::tests`
- `cargo clippy -p librqbit-dht --lib --tests` and `cargo clippy -p librqbit --all-targets` clean
- `cargo fmt --all -- --check` clean

Assisted by AI