### PR TITLE
librqbit(dht): provide an option to set DhtConfig::listen_addr

### DIFF
--- a/crates/dht/src/lib.rs
+++ b/crates/dht/src/lib.rs
@@ -14,7 +14,7 @@ pub use error::{Error, Result};
 pub use crate::dht::DhtStats;
 pub use crate::dht::{DhtConfig, DhtState, RequestPeersStream};
 pub use librqbit_core::hash_id::Id20;
-pub use persistence::{PersistentDht, PersistentDhtConfig};
+pub use persistence::{DhtPersistenceConfig, PersistentDht, dht_listen_addr};
 
 pub type Dht = Arc<DhtState>;
 

--- a/crates/dht/src/persistence.rs
+++ b/crates/dht/src/persistence.rs
@@ -9,7 +9,7 @@ use librqbit_dualstack_sockets::BindDevice;
 use serde::{Deserialize, Serialize};
 use std::fs::OpenOptions;
 use std::io::{BufReader, BufWriter};
-use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
@@ -20,12 +20,29 @@ use crate::peer_store::PeerStore;
 use crate::routing_table::RoutingTable;
 use crate::{Dht, DhtConfig, DhtState};
 
+/// Configuration for DHT persistence (periodic dump of routing table and peer store).
+/// When provided, the DHT state will be serialized to disk periodically.
 #[derive(Default)]
-pub struct PersistentDhtConfig {
+pub struct DhtPersistenceConfig {
+    /// How often to dump state. Defaults to 60s.
     pub dump_interval: Option<Duration>,
+    /// Path to the JSON file. Uses OS-specific default if None.
     pub config_filename: Option<PathBuf>,
-    pub port: Option<u16>,
-    pub ipv4_only: bool,
+}
+
+/// Compute the DHT listen address from the explicit/stored port preferences and
+/// the session-level `ipv4_only` flag.
+///
+/// The bind IP is derived solely from `ipv4_only` (`0.0.0.0` if true, `[::]`
+/// otherwise); any persisted IP is intentionally ignored. The port is chosen
+/// in priority order: explicit -> stored -> 0 (random).
+pub fn dht_listen_addr(port: Option<u16>, stored_port: Option<u16>, ipv4_only: bool) -> SocketAddr {
+    let ip: IpAddr = if ipv4_only {
+        Ipv4Addr::UNSPECIFIED.into()
+    } else {
+        Ipv6Addr::UNSPECIFIED.into()
+    };
+    SocketAddr::new(ip, port.or(stored_port).unwrap_or(0))
 }
 
 #[derive(Serialize, Deserialize)]
@@ -85,14 +102,16 @@ impl PersistentDht {
 
     #[inline(never)]
     pub fn create<'a>(
-        config: Option<PersistentDhtConfig>,
+        persistence_config: DhtPersistenceConfig,
+        port: Option<u16>,
+        ipv4_only: bool,
+        bootstrap_addrs: Option<Vec<String>>,
         cancellation_token: Option<CancellationToken>,
         bind_device: Option<&'a BindDevice>,
     ) -> BoxFuture<'a, anyhow::Result<Dht>> {
         async move {
-            let mut config = config.unwrap_or_default();
-            let config_filename = match config.config_filename.take() {
-                Some(config_filename) => config_filename,
+            let config_filename = match persistence_config.config_filename {
+                Some(f) => f,
                 None => Self::default_persistence_filename()?,
             };
 
@@ -112,20 +131,8 @@ impl PersistentDht {
                     match serde_json::from_reader::<_, DhtSerialize<RoutingTable, PeerStore>>(
                         reader,
                     ) {
-                        Ok(mut r) => {
+                        Ok(r) => {
                             info!(filename=?config_filename, "loaded DHT routing table from");
-                            if config.ipv4_only {
-                                // Force IPv4 if requested
-                                let port = r.addr.port();
-                                r.addr = SocketAddr::from(([0, 0, 0, 0], port));
-                            } else if r.addr.ip() == Ipv4Addr::UNSPECIFIED {
-                                warn!(
-                                    "patching DHT listen IP address for rqbit 9 upgrade: 0.0.0.0 -> [::]"
-                                );
-                                let port = r.addr.port();
-                                r.addr = SocketAddr::from((Ipv6Addr::UNSPECIFIED, port));
-                            }
-
                             Some(r)
                         }
                         Err(e) => {
@@ -146,23 +153,18 @@ impl PersistentDht {
                     }
                 },
             };
-            let (mut listen_addr, routing_table, peer_store) = de
-                .map(|de| (Some(de.addr), Some(de.table), de.peer_store))
+            let (stored_port, routing_table, peer_store) = de
+                .map(|de| (Some(de.addr.port()), Some(de.table), de.peer_store))
                 .unwrap_or((None, None, None));
 
-            if let Some(port) = config.port {
-                if let Some(ref mut addr) = listen_addr {
-                    addr.set_port(port);
-                } else {
-                    listen_addr = Some(SocketAddr::from((Ipv6Addr::UNSPECIFIED, port)));
-                }
-            }
+            let listen_addr = dht_listen_addr(port, stored_port, ipv4_only);
             let peer_id = routing_table.as_ref().map(|r| r.id());
 
             let dht_config = DhtConfig {
                 peer_id,
+                bootstrap_addrs,
                 routing_table,
-                listen_addr,
+                listen_addr: Some(listen_addr),
                 peer_store,
                 cancellation_token,
                 bind_device,
@@ -175,7 +177,7 @@ impl PersistentDht {
                 dht.cancellation_token().clone(),
                 {
                     let dht = dht.clone();
-                    let dump_interval = config
+                    let dump_interval = persistence_config
                         .dump_interval
                         .unwrap_or_else(|| Duration::from_secs(60));
                     async move {
@@ -204,5 +206,66 @@ impl PersistentDht {
             Ok(dht)
         }
         .boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_port_no_stored_v6() {
+        let addr = dht_listen_addr(None, None, false);
+        assert_eq!(addr.ip(), IpAddr::from(Ipv6Addr::UNSPECIFIED));
+        assert_eq!(addr.port(), 0);
+    }
+
+    #[test]
+    fn no_port_no_stored_v4() {
+        let addr = dht_listen_addr(None, None, true);
+        assert_eq!(addr.ip(), IpAddr::from(Ipv4Addr::UNSPECIFIED));
+        assert_eq!(addr.port(), 0);
+    }
+
+    #[test]
+    fn explicit_port_v6() {
+        let addr = dht_listen_addr(Some(6881), None, false);
+        assert_eq!(addr.ip(), IpAddr::from(Ipv6Addr::UNSPECIFIED));
+        assert_eq!(addr.port(), 6881);
+    }
+
+    #[test]
+    fn explicit_port_v4() {
+        let addr = dht_listen_addr(Some(6881), None, true);
+        assert_eq!(addr.ip(), IpAddr::from(Ipv4Addr::UNSPECIFIED));
+        assert_eq!(addr.port(), 6881);
+    }
+
+    #[test]
+    fn stored_port_only_v6() {
+        let addr = dht_listen_addr(None, Some(12345), false);
+        assert_eq!(addr.ip(), IpAddr::from(Ipv6Addr::UNSPECIFIED));
+        assert_eq!(addr.port(), 12345);
+    }
+
+    #[test]
+    fn stored_port_only_v4() {
+        let addr = dht_listen_addr(None, Some(12345), true);
+        assert_eq!(addr.ip(), IpAddr::from(Ipv4Addr::UNSPECIFIED));
+        assert_eq!(addr.port(), 12345);
+    }
+
+    #[test]
+    fn explicit_overrides_stored_v6() {
+        let addr = dht_listen_addr(Some(6881), Some(12345), false);
+        assert_eq!(addr.ip(), IpAddr::from(Ipv6Addr::UNSPECIFIED));
+        assert_eq!(addr.port(), 6881);
+    }
+
+    #[test]
+    fn explicit_overrides_stored_v4() {
+        let addr = dht_listen_addr(Some(6881), Some(12345), true);
+        assert_eq!(addr.ip(), IpAddr::from(Ipv4Addr::UNSPECIFIED));
+        assert_eq!(addr.port(), 6881);
     }
 }

--- a/crates/librqbit/examples/custom_storage.rs
+++ b/crates/librqbit/examples/custom_storage.rs
@@ -1,6 +1,6 @@
 use bytes::Bytes;
 use librqbit::{
-    SessionOptions,
+    DhtSessionConfig, SessionOptions,
     storage::{StorageFactory, StorageFactoryExt, TorrentStorage},
 };
 use tracing::info;
@@ -78,7 +78,10 @@ async fn main() -> anyhow::Result<()> {
     let s = librqbit::Session::new_with_opts(
         Default::default(),
         SessionOptions {
-            disable_dht_persistence: true,
+            dht: Some(DhtSessionConfig {
+                persistence: None,
+                ..Default::default()
+            }),
             persistence: None,
             ..Default::default()
         },

--- a/crates/librqbit/examples/simulate_traffic.rs
+++ b/crates/librqbit/examples/simulate_traffic.rs
@@ -160,8 +160,7 @@ impl TestHarness {
         let session = Session::new_with_opts(
             out.clone(),
             SessionOptions {
-                disable_dht: true,
-                disable_dht_persistence: true,
+                dht: None,
                 fastresume: false,
                 persistence: None,
                 peer_id: Some(peer_id),
@@ -252,8 +251,7 @@ impl TestHarness {
         let session = Session::new_with_opts(
             path.clone(),
             SessionOptions {
-                disable_dht: true,
-                disable_dht_persistence: true,
+                dht: None,
                 fastresume: false,
                 persistence: None,
                 peer_id: Some(peer_id),

--- a/crates/librqbit/src/lib.rs
+++ b/crates/librqbit/src/lib.rs
@@ -92,8 +92,8 @@ pub use librqbit_core::spawn_utils::spawn as librqbit_spawn;
 pub use listen::{ListenerMode, ListenerOptions};
 pub use peer_connection::PeerConnectionOptions;
 pub use session::{
-    AddTorrent, AddTorrentOptions, AddTorrentResponse, ListOnlyResponse, SUPPORTED_SCHEMES,
-    Session, SessionOptions, SessionPersistenceConfig,
+    AddTorrent, AddTorrentOptions, AddTorrentResponse, DhtSessionConfig, ListOnlyResponse,
+    SUPPORTED_SCHEMES, Session, SessionOptions, SessionPersistenceConfig,
 };
 pub use stream_connect::ConnectionOptions;
 pub use torrent_state::{

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -403,6 +403,9 @@ pub struct SessionOptions {
     /// A list o DHT bootstrap nodes as strings of the form host:port or ip:port
     pub dht_bootstrap_addrs: Option<Vec<String>>,
 
+    /// The listen address for DHT. If not specified, a random port will be used.
+    pub dht_listen_addr: Option<SocketAddr>,
+
     /// What network device to bind to for DHT, BT-UDP, BT-TCP, trackers and LSD.
     /// On OSX will use IP(V6)_BOUND_IF, on Linux will use SO_BINDTODEVICE.
     pub bind_device_name: Option<String>,
@@ -564,6 +567,7 @@ impl Session {
                         bootstrap_addrs: opts.dht_bootstrap_addrs.clone(),
                         cancellation_token: Some(token.child_token()),
                         bind_device: bind_device.as_ref(),
+                        listen_addr: opts.dht_listen_addr,
                         ..Default::default()
                     })
                     .await

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -46,7 +46,7 @@ use bencode::bencode_serialize_to_writer;
 use buffers::{ByteBuf, ByteBufOwned};
 use bytes::Bytes;
 use clone_to_owned::CloneToOwned;
-use dht::{Dht, DhtBuilder, DhtConfig, Id20, PersistentDht, PersistentDhtConfig};
+use dht::{Dht, DhtBuilder, DhtConfig, DhtPersistenceConfig, Id20, PersistentDht, dht_listen_addr};
 use futures::{
     FutureExt, Stream, StreamExt, TryFutureExt,
     future::BoxFuture,
@@ -390,21 +390,35 @@ impl SessionPersistenceConfig {
     }
 }
 
-#[derive(Default)]
-pub struct SessionOptions {
-    /// Turn on to disable DHT.
-    pub disable_dht: bool,
-    /// Turn on to disable DHT persistence. By default it will re-use stored DHT
-    /// configuration, including the port it listens on.
-    pub disable_dht_persistence: bool,
-    /// Pass in to configure DHT persistence filename. This can be used to run multiple
-    /// librqbit instances at a time.
-    pub dht_config: Option<PersistentDhtConfig>,
-    /// A list o DHT bootstrap nodes as strings of the form host:port or ip:port
-    pub dht_bootstrap_addrs: Option<Vec<String>>,
+/// Configuration for the DHT subsystem.
+/// Set to `None` in `SessionOptions::dht` to disable DHT entirely.
+pub struct DhtSessionConfig {
+    /// Bootstrap nodes (host:port or ip:port). Uses built-in defaults if None.
+    pub bootstrap_addrs: Option<Vec<String>>,
+    /// The DHT listen port. Priority: this explicit port -> persisted port
+    /// (when persistence is enabled) -> random. The bind IP is derived from
+    /// `SessionOptions::ipv4_only` (`0.0.0.0` if true, `[::]` otherwise).
+    /// Use `SessionOptions::bind_device_name` to scope the bind to a specific
+    /// network interface.
+    pub port: Option<u16>,
+    /// Persistence behavior. If None, persistence is disabled.
+    pub persistence: Option<DhtPersistenceConfig>,
+}
 
-    /// The listen address for DHT. If not specified, a random port will be used.
-    pub dht_listen_addr: Option<SocketAddr>,
+impl Default for DhtSessionConfig {
+    fn default() -> Self {
+        Self {
+            bootstrap_addrs: None,
+            port: None,
+            persistence: Some(DhtPersistenceConfig::default()),
+        }
+    }
+}
+
+pub struct SessionOptions {
+    /// DHT configuration. Set to None to disable DHT entirely.
+    /// Defaults to DHT enabled with persistence.
+    pub dht: Option<DhtSessionConfig>,
 
     /// What network device to bind to for DHT, BT-UDP, BT-TCP, trackers and LSD.
     /// On OSX will use IP(V6)_BOUND_IF, on Linux will use SO_BINDTODEVICE.
@@ -465,6 +479,36 @@ pub struct SessionOptions {
     /// Override the client name and version used in User-Agent headers and
     /// peer extended handshakes. Defaults to "rqbit X.Y.Z".
     pub client_name_and_version: Option<String>,
+}
+
+impl Default for SessionOptions {
+    fn default() -> Self {
+        Self {
+            dht: Some(DhtSessionConfig::default()),
+            bind_device_name: None,
+            disable_trackers: false,
+            fastresume: false,
+            persistence: None,
+            peer_id: None,
+            listen: None,
+            connect: None,
+            default_storage_factory: None,
+            cancellation_token: None,
+            concurrent_init_limit: None,
+            runtime_worker_threads: None,
+            root_span: None,
+            ratelimits: LimitsConfig::default(),
+            blocklist_url: None,
+            allowlist_url: None,
+            trackers: HashSet::new(),
+            peer_limit: None,
+            #[cfg(feature = "disable-upload")]
+            disable_upload: false,
+            disable_local_service_discovery: false,
+            ipv4_only: false,
+            client_name_and_version: None,
+        }
+    }
 }
 
 fn torrent_file_from_info_bytes(info_bytes: &[u8], trackers: &[url::Url]) -> anyhow::Result<Bytes> {
@@ -559,31 +603,34 @@ impl Session {
                 None
             };
 
-            let dht = if opts.disable_dht {
-                None
-            } else {
-                let dht = if opts.disable_dht_persistence {
-                    DhtBuilder::with_config(DhtConfig {
-                        bootstrap_addrs: opts.dht_bootstrap_addrs.clone(),
-                        cancellation_token: Some(token.child_token()),
-                        bind_device: bind_device.as_ref(),
-                        listen_addr: opts.dht_listen_addr,
-                        ..Default::default()
-                    })
-                    .await
-                    .context("error initializing DHT")?
-                } else {
-                    let pdht_config = opts.dht_config.take().unwrap_or_default();
+            let dht = if let Some(dht_config) = opts.dht.take() {
+                let dht = if let Some(persistence_config) = dht_config.persistence {
                     PersistentDht::create(
-                        Some(pdht_config),
+                        persistence_config,
+                        dht_config.port,
+                        opts.ipv4_only,
+                        dht_config.bootstrap_addrs,
                         Some(token.clone()),
                         bind_device.as_ref(),
                     )
                     .await
                     .context("error initializing persistent DHT")?
+                } else {
+                    let listen_addr = dht_listen_addr(dht_config.port, None, opts.ipv4_only);
+                    DhtBuilder::with_config(DhtConfig {
+                        bootstrap_addrs: dht_config.bootstrap_addrs,
+                        cancellation_token: Some(token.child_token()),
+                        bind_device: bind_device.as_ref(),
+                        listen_addr: Some(listen_addr),
+                        ..Default::default()
+                    })
+                    .await
+                    .context("error initializing DHT")?
                 };
 
                 Some(dht)
+            } else {
+                None
             };
             let peer_opts = opts
                 .connect

--- a/crates/librqbit/src/tests/e2e.rs
+++ b/crates/librqbit/src/tests/e2e.rs
@@ -105,7 +105,7 @@ async fn _test_e2e_download(mode: ListenerMode, drop_checks: &DropChecks) {
                 let session = crate::Session::new_with_opts(
                     std::env::temp_dir().join("does_not_exist"),
                     SessionOptions {
-                        disable_dht: true,
+                        dht: None,
                         peer_id: Some(peer_id),
                         listen: Some(ListenerOptions {
                             mode,
@@ -209,9 +209,7 @@ async fn _test_e2e_download(mode: ListenerMode, drop_checks: &DropChecks) {
         let session = Session::new_with_opts(
             outdir.to_owned(),
             SessionOptions {
-                disable_dht: true,
-                disable_dht_persistence: true,
-                dht_config: None,
+                dht: None,
                 persistence: Some(SessionPersistenceConfig::Json {
                     folder: Some(session_persistence),
                 }),

--- a/crates/librqbit/src/tests/e2e_another_local_client.rs
+++ b/crates/librqbit/src/tests/e2e_another_local_client.rs
@@ -42,7 +42,7 @@ async fn test_utp_with_another_client() {
     let (listen_addr, client_addr) = parse_listen_and_client_addr();
     test_with_another_client(
         crate::SessionOptions {
-            disable_dht: true,
+            dht: None,
             persistence: None,
             listen: Some(ListenerOptions {
                 mode: crate::listen::ListenerMode::UtpOnly,
@@ -66,7 +66,7 @@ async fn test_tcp_with_another_client() {
     let (listen_addr, client_addr) = parse_listen_and_client_addr();
     test_with_another_client(
         crate::SessionOptions {
-            disable_dht: true,
+            dht: None,
             persistence: None,
             listen: Some(ListenerOptions {
                 mode: crate::listen::ListenerMode::TcpOnly,

--- a/crates/librqbit/src/tests/e2e_stream.rs
+++ b/crates/librqbit/src/tests/e2e_stream.rs
@@ -31,7 +31,7 @@ async fn e2e_stream() -> anyhow::Result<()> {
     let server_session = Session::new_with_opts(
         files.path().into(),
         crate::SessionOptions {
-            disable_dht: true,
+            dht: None,
             peer_id: Some(TestPeerMetadata::good().as_peer_id()),
             persistence: None,
             listen: Some(crate::listen::ListenerOptions {
@@ -77,7 +77,7 @@ async fn e2e_stream() -> anyhow::Result<()> {
     let client_session = Session::new_with_opts(
         client_dir.path().into(),
         crate::SessionOptions {
-            disable_dht: true,
+            dht: None,
             persistence: None,
             peer_id: Some(TestPeerMetadata::good().as_peer_id()),
             ..Default::default()

--- a/crates/librqbit/src/upnp_server_adapter.rs
+++ b/crates/librqbit/src/upnp_server_adapter.rs
@@ -553,7 +553,7 @@ mod tests {
         let session = Session::new_with_opts(
             td.path().to_owned(),
             SessionOptions {
-                disable_dht: true,
+                dht: None,
                 ..Default::default()
             },
         )

--- a/crates/rqbit/src/main.rs
+++ b/crates/rqbit/src/main.rs
@@ -663,6 +663,7 @@ async fn async_main(mut opts: Opts, cancel: CancellationToken) -> anyhow::Result
         runtime_worker_threads: Some(opts.max_blocking_threads as usize),
         ipv4_only: opts.ipv4_only,
         client_name_and_version: None,
+        ..Default::default()
     };
 
     #[allow(clippy::needless_update)]

--- a/crates/rqbit/src/main.rs
+++ b/crates/rqbit/src/main.rs
@@ -14,8 +14,9 @@ use clap::{CommandFactory, Parser, ValueEnum};
 use clap_complete::Shell;
 use librqbit::{
     AddTorrent, AddTorrentOptions, AddTorrentResponse, Api, ConnectionOptions,
-    CreateTorrentOptions, ListOnlyResponse, ListenerMode, ListenerOptions, PeerConnectionOptions,
-    Session, SessionOptions, SessionPersistenceConfig, TorrentStatsState,
+    CreateTorrentOptions, DhtSessionConfig, ListOnlyResponse, ListenerMode, ListenerOptions,
+    PeerConnectionOptions, Session, SessionOptions, SessionPersistenceConfig, TorrentStatsState,
+    dht::DhtPersistenceConfig,
     http_api::{HttpApi, HttpApiOptions},
     librqbit_spawn,
     limits::LimitsConfig,
@@ -603,14 +604,26 @@ async fn async_main(mut opts: Opts, cancel: CancellationToken) -> anyhow::Result
         ..Default::default()
     });
 
+    let dht = if opts.disable_dht {
+        None
+    } else {
+        let persistence = if opts.disable_dht_persistence {
+            None
+        } else {
+            Some(DhtPersistenceConfig::default())
+        };
+        Some(DhtSessionConfig {
+            bootstrap_addrs: opts
+                .dht_bootstrap_addrs
+                .as_ref()
+                .map(|s| s.split(",").map(|v| v.to_string()).collect()),
+            port: None,
+            persistence,
+        })
+    };
+
     let mut sopts = SessionOptions {
-        disable_dht: opts.disable_dht,
-        disable_dht_persistence: opts.disable_dht_persistence,
-        dht_bootstrap_addrs: opts
-            .dht_bootstrap_addrs
-            .as_ref()
-            .map(|s| s.split(",").map(|v| v.to_string()).collect()),
-        dht_config: None,
+        dht,
         // This will be overridden by "server start" below if needed.
         persistence: None,
         peer_id: None,
@@ -663,7 +676,6 @@ async fn async_main(mut opts: Opts, cancel: CancellationToken) -> anyhow::Result
         runtime_worker_threads: Some(opts.max_blocking_threads as usize),
         ipv4_only: opts.ipv4_only,
         client_name_and_version: None,
-        ..Default::default()
     };
 
     #[allow(clippy::needless_update)]
@@ -760,7 +772,9 @@ async fn async_main(mut opts: Opts, cancel: CancellationToken) -> anyhow::Result
             }
 
             // "rqbit download" is ephemeral, so disable all persistence.
-            sopts.disable_dht_persistence = true;
+            if let Some(ref mut dht) = sopts.dht {
+                dht.persistence = None;
+            }
             sopts.persistence = None;
 
             let mut disable_http_api = download_opts.disable_http_api;
@@ -904,7 +918,9 @@ async fn async_main(mut opts: Opts, cancel: CancellationToken) -> anyhow::Result
             }
 
             // "rqbit share" is ephemeral, so disable all persistence.
-            sopts.disable_dht_persistence = true;
+            if let Some(ref mut dht) = sopts.dht {
+                dht.persistence = None;
+            }
             sopts.persistence = None;
 
             if sopts.listen.is_none() {

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -14,13 +14,13 @@ use anyhow::Context;
 use config::RqbitDesktopConfig;
 use http::StatusCode;
 use librqbit::{
-    AddTorrent, AddTorrentOptions, Api, ApiError, Session, SessionOptions,
+    AddTorrent, AddTorrentOptions, Api, ApiError, DhtSessionConfig, Session, SessionOptions,
     SessionPersistenceConfig, WithStatusError,
     api::{
         ApiAddTorrentResponse, ApiTorrentListOpts, EmptyJsonResponse, TorrentDetailsResponse,
         TorrentIdOrHash, TorrentListResponse, TorrentStats,
     },
-    dht::PersistentDhtConfig,
+    dht::DhtPersistenceConfig,
     http_api_types::{PeerStatsFilter, PeerStatsSnapshot},
     session_stats::snapshot::SessionStatsSnapshot,
     tracing_subscriber_config_utils::{InitLoggingOptions, InitLoggingResult, init_logging},
@@ -103,15 +103,27 @@ async fn api_from_config(
         }
     }
 
+    let dht = if config.dht.disable {
+        None
+    } else {
+        let persistence = if config.dht.disable_persistence {
+            None
+        } else {
+            Some(DhtPersistenceConfig {
+                config_filename: Some(config.dht.persistence_filename.clone()),
+                ..Default::default()
+            })
+        };
+        Some(DhtSessionConfig {
+            persistence,
+            ..Default::default()
+        })
+    };
+
     let session = Session::new_with_opts(
         config.default_download_location.clone(),
         SessionOptions {
-            disable_dht: config.dht.disable,
-            disable_dht_persistence: config.dht.disable_persistence,
-            dht_config: Some(PersistentDhtConfig {
-                config_filename: Some(config.dht.persistence_filename.clone()),
-                ..Default::default()
-            }),
+            dht,
             persistence,
             connect: Some(connect),
             listen,


### PR DESCRIPTION
Summary: Currently, if not using `PersistentDhtConfig`, it is not possible to set the listen_addr of DhtConfig.

I feel this should rather be captured under a "dht_config: Option<DhtConfig>" field instead, but it would conflict with the existing `pub dht_config: Option<PersistentDhtConfig>` so this version does not attempt to change any of this.

Test Plan: `cargo test`