### PR TITLE
webui: restore playlist actions

### DIFF
--- a/crates/librqbit/webui/src/components/buttons/PlaylistButton.tsx
+++ b/crates/librqbit/webui/src/components/buttons/PlaylistButton.tsx
@@ -1,0 +1,117 @@
+import { useContext } from "react";
+import { FaClipboardList } from "react-icons/fa";
+import { APIContext } from "../../context";
+import { useErrorStore } from "../../stores/errorStore";
+import { Button } from "./Button";
+import { IconButton } from "./IconButton";
+
+interface PlaylistButtonProps {
+  torrentId: number;
+  disabled?: boolean;
+}
+
+function usePlaylistClipboard(torrentId: number) {
+  const API = useContext(APIContext);
+  const setAlert = useErrorStore((state) => state.setAlert);
+  const playlistUrl = API.getPlaylistUrl(torrentId);
+
+  const copyPlaylistUrlToClipboard = async () => {
+    if (!playlistUrl) {
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(playlistUrl);
+    } catch {
+      setAlert({
+        text: "Copy playlist URL",
+        details: {
+          text: (
+            <>
+              <p>
+                Copy{" "}
+                <a href={playlistUrl} className="text-blue-500">
+                  playlist URL
+                </a>{" "}
+                to clipboard and paste into e.g. VLC to play.
+              </p>
+            </>
+          ),
+        },
+      });
+      return;
+    }
+
+    setAlert({
+      text: "Copied",
+      details: {
+        text: "Playlist URL copied to clipboard. Paste into e.g. VLC to play.",
+      },
+    });
+  };
+
+  return { playlistUrl, copyPlaylistUrlToClipboard };
+}
+
+export const PlaylistIconButton: React.FC<PlaylistButtonProps> = ({
+  torrentId,
+  disabled,
+}) => {
+  const { playlistUrl, copyPlaylistUrlToClipboard } =
+    usePlaylistClipboard(torrentId);
+
+  return (
+    <IconButton
+      href={playlistUrl ?? "#"}
+      onClick={copyPlaylistUrlToClipboard}
+      disabled={disabled || !playlistUrl}
+      title="Copy playlist URL"
+    >
+      <FaClipboardList className="hover:text-green-500" />
+    </IconButton>
+  );
+};
+
+export const PlaylistTextButton: React.FC<PlaylistButtonProps> = ({
+  torrentId,
+  disabled,
+}) => {
+  const { playlistUrl, copyPlaylistUrlToClipboard } =
+    usePlaylistClipboard(torrentId);
+
+  return (
+    <Button
+      onClick={copyPlaylistUrlToClipboard}
+      disabled={disabled || !playlistUrl}
+      variant="secondary"
+      size="sm"
+      className="shrink-0"
+    >
+      <FaClipboardList className="w-3 h-3" />
+      Playlist
+    </Button>
+  );
+};
+
+export const PlaylistLink: React.FC<Pick<PlaylistButtonProps, "torrentId">> = ({
+  torrentId,
+}) => {
+  const { playlistUrl, copyPlaylistUrlToClipboard } =
+    usePlaylistClipboard(torrentId);
+
+  if (!playlistUrl) {
+    return <span className="text-tertiary">Unavailable</span>;
+  }
+
+  return (
+    <a
+      href={playlistUrl}
+      onClick={(e) => {
+        e.preventDefault();
+        copyPlaylistUrlToClipboard();
+      }}
+      className="text-blue-500 hover:underline cursor-pointer"
+    >
+      Copy playlist URL
+    </a>
+  );
+};

--- a/crates/librqbit/webui/src/components/buttons/TorrentActions.tsx
+++ b/crates/librqbit/webui/src/components/buttons/TorrentActions.tsx
@@ -7,6 +7,7 @@ import { FaCog, FaPause, FaPlay, FaTrash } from "react-icons/fa";
 import { useErrorStore } from "../../stores/errorStore";
 import { useTorrentStore } from "../../stores/torrentStore";
 import { useUIStore } from "../../stores/uiStore";
+import { PlaylistIconButton } from "./PlaylistButton";
 
 export const TorrentActions: React.FC<{
   torrent: TorrentListItem & { stats: TorrentStats };
@@ -92,6 +93,7 @@ export const TorrentActions: React.FC<{
       <IconButton onClick={startDeleting} disabled={disabled}>
         <FaTrash className="hover:text-red-500" />
       </IconButton>
+      <PlaylistIconButton torrentId={id} disabled={disabled} />
       <DeleteTorrentModal
         show={deleting}
         onHide={cancelDeleting}

--- a/crates/librqbit/webui/src/components/compact/OverviewTab.tsx
+++ b/crates/librqbit/webui/src/components/compact/OverviewTab.tsx
@@ -6,6 +6,7 @@ import {
 } from "../../api-types";
 import { formatBytes } from "../../helper/formatBytes";
 import { getCompletionETA } from "../../helper/getCompletionETA";
+import { PlaylistLink } from "../buttons/PlaylistButton";
 import { PiecesCanvas } from "./PiecesCanvas";
 
 interface OverviewTabProps {
@@ -82,7 +83,6 @@ export const OverviewTab: React.FC<OverviewTabProps> = ({ torrent }) => {
           {stateDisplay.text}
         </span>
       </div>
-
       {/* Pieces visualization */}
       {totalPieces > 0 && (
         <div>
@@ -158,6 +158,12 @@ export const OverviewTab: React.FC<OverviewTabProps> = ({ torrent }) => {
         </div>
         <div className="truncate">
           <LV label="Output" value={torrent.output_folder} mono />
+        </div>
+        <div className="truncate">
+          <LV
+            label="Playlist"
+            value={<PlaylistLink torrentId={torrent.id} />}
+          />
         </div>
       </div>
 


### PR DESCRIPTION
Restore the playlist action in card controls and add the playlist URL copy link to the table overview metadata.

Fixes #601