### PR TITLE
Allow pausing during the initial file check

### DIFF
--- a/crates/librqbit/src/file_ops.rs
+++ b/crates/librqbit/src/file_ops.rs
@@ -1,9 +1,9 @@
 use std::{
     marker::PhantomData,
-    sync::atomic::{AtomicU64, Ordering},
+    sync::atomic::{AtomicBool, AtomicU64, Ordering},
 };
 
-use anyhow::Context;
+use anyhow::{Context, bail};
 use buffers::{ByteBuf, ByteBufOwned};
 use librqbit_core::{
     lengths::{ChunkInfo, ValidPieceIndex},
@@ -70,7 +70,11 @@ impl<'a> FileOps<'a> {
     }
 
     // Returns the bitvector with pieces we have.
-    pub fn initial_check(&self, progress: &AtomicU64) -> anyhow::Result<BF> {
+    pub fn initial_check(
+        &self,
+        progress: &AtomicU64,
+        pause_requested: &AtomicBool,
+    ) -> anyhow::Result<BF> {
         let mut have_pieces =
             BF::from_boxed_slice(vec![0u8; self.torrent.lengths().piece_bitfield_bytes()].into());
         let mut piece_files = Vec::<usize>::new();
@@ -106,6 +110,10 @@ impl<'a> FileOps<'a> {
         let mut read_buffer = vec![0u8; 65536];
 
         for piece_info in self.torrent.lengths().iter_piece_infos() {
+            if pause_requested.load(Ordering::Relaxed) {
+                bail!("initial check paused");
+            }
+
             piece_files.clear();
             let mut computed_hash = Sha1::new();
             let mut piece_remaining = piece_info.len as usize;

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -1795,7 +1795,7 @@ impl tracker_comms::TorrentStatsProvider for PeerRxTorrentInfo {
             total_bytes: stats.total_bytes,
             uploaded_bytes: stats.uploaded_bytes,
             torrent_state: match stats.state {
-                TS::Initializing => S::Initializing,
+                TS::Initializing { .. } => S::Initializing,
                 TS::Live => S::Live,
                 TS::Paused => S::Paused,
                 TS::Error => S::None,

--- a/crates/librqbit/src/torrent_state/initializing.rs
+++ b/crates/librqbit/src/torrent_state/initializing.rs
@@ -1,7 +1,7 @@
 use std::{
     sync::{
         Arc,
-        atomic::{AtomicU64, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
     },
     time::Instant,
 };
@@ -30,6 +30,8 @@ pub struct TorrentStateInitializing {
     pub(crate) metadata: Arc<TorrentMetadata>,
     pub(crate) only_files: Option<Vec<usize>>,
     pub(crate) checked_bytes: AtomicU64,
+    pause_requested: AtomicBool,
+    check_running: AtomicBool,
     previously_errored: bool,
 }
 
@@ -47,6 +49,8 @@ impl TorrentStateInitializing {
             only_files,
             files,
             checked_bytes: AtomicU64::new(0),
+            pause_requested: AtomicBool::new(false),
+            check_running: AtomicBool::new(false),
             previously_errored,
         }
     }
@@ -54,6 +58,28 @@ impl TorrentStateInitializing {
     pub fn get_checked_bytes(&self) -> u64 {
         self.checked_bytes
             .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    pub(crate) fn request_pause(&self) {
+        self.pause_requested.store(true, Ordering::Relaxed);
+    }
+
+    pub(crate) fn clear_pause_request(&self) {
+        self.pause_requested.store(false, Ordering::Relaxed);
+    }
+
+    pub(crate) fn is_pause_requested(&self) -> bool {
+        self.pause_requested.load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn try_start_check(&self) -> bool {
+        self.check_running
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+    }
+
+    pub(crate) fn finish_check(&self) {
+        self.check_running.store(false, Ordering::Release);
     }
 
     async fn validate_fastresume(
@@ -191,7 +217,7 @@ impl TorrentStateInitializing {
                     .spawner
                     .block_in_place_with_semaphore(|| {
                         FileOps::new(&self.metadata.info, &self.files, &self.metadata.file_infos)
-                            .initial_check(&self.checked_bytes)
+                            .initial_check(&self.checked_bytes, &self.pause_requested)
                     })
                     .await?;
                 bitv_factory

--- a/crates/librqbit/src/torrent_state/mod.rs
+++ b/crates/librqbit/src/torrent_state/mod.rs
@@ -517,7 +517,7 @@ impl ManagedTorrent {
             let g = self.locked.read();
             match &g.state {
                 ManagedTorrentState::Initializing(i) => {
-                    resp.state = if g.paused { S::Paused } else { S::Initializing };
+                    resp.state = S::Initializing { paused: g.paused };
                     resp.progress_bytes = i.checked_bytes.load(Ordering::Relaxed);
                 }
                 ManagedTorrentState::Paused(p) => {

--- a/crates/librqbit/src/torrent_state/mod.rs
+++ b/crates/librqbit/src/torrent_state/mod.rs
@@ -391,14 +391,6 @@ impl ManagedTorrent {
                                 }
                                 Err(err) => {
                                     if init.is_pause_requested() {
-                                        if let Err(error) = init.files.release_files() {
-                                            warn!(
-                                                id=?init.shared.id,
-                                                info_hash=?init.shared.info_hash,
-                                                error=?error,
-                                                "error releasing files after paused initial check"
-                                            );
-                                        }
                                         debug!("initial check paused");
                                         t.state_change_notify.notify_waiters();
                                         return Ok(());

--- a/crates/librqbit/src/torrent_state/mod.rs
+++ b/crates/librqbit/src/torrent_state/mod.rs
@@ -350,6 +350,11 @@ impl ManagedTorrent {
                 }
                 ManagedTorrentState::Initializing(init) => {
                     let init = init.clone();
+                    init.clear_pause_request();
+                    if !init.try_start_check() {
+                        return Ok(());
+                    }
+
                     let t = t.clone();
                     let span = t.shared().span.clone();
                     let token = token.clone();
@@ -366,7 +371,10 @@ impl ManagedTorrent {
                                 .await
                                 .context("bug: concurrent init semaphore was closed")?;
 
-                            match init.check().await {
+                            let check_result = init.check().await;
+                            init.finish_check();
+
+                            match check_result {
                                 Ok(paused) => {
                                     let mut g = t.locked.write();
                                     if let ManagedTorrentState::Initializing(_) = &g.state {
@@ -382,6 +390,20 @@ impl ManagedTorrent {
                                     _start(&t, peer_rx, start_paused, session, Some(g), token)
                                 }
                                 Err(err) => {
+                                    if init.is_pause_requested() {
+                                        if let Err(error) = init.files.release_files() {
+                                            warn!(
+                                                id=?init.shared.id,
+                                                info_hash=?init.shared.info_hash,
+                                                error=?error,
+                                                "error releasing files after paused initial check"
+                                            );
+                                        }
+                                        debug!("initial check paused");
+                                        t.state_change_notify.notify_waiters();
+                                        return Ok(());
+                                    }
+
                                     let result = anyhow::anyhow!("{:?}", err);
                                     t.locked.write().state = ManagedTorrentState::Error(err);
                                     t.state_change_notify.notify_waiters();
@@ -463,8 +485,12 @@ impl ManagedTorrent {
                 self.state_change_notify.notify_waiters();
                 Ok(())
             }
-            ManagedTorrentState::Initializing(_) => {
-                bail!("torrent is initializing, can't pause");
+            ManagedTorrentState::Initializing(init) => {
+                let init = init.clone();
+                g.paused = true;
+                init.request_pause();
+                self.state_change_notify.notify_waiters();
+                Ok(())
             }
             ManagedTorrentState::Paused(_) => {
                 bail!("torrent is already paused");
@@ -495,10 +521,11 @@ impl ManagedTorrent {
             live: None,
         };
 
-        self.with_state(|s| {
-            match s {
+        {
+            let g = self.locked.read();
+            match &g.state {
                 ManagedTorrentState::Initializing(i) => {
-                    resp.state = S::Initializing;
+                    resp.state = if g.paused { S::Paused } else { S::Initializing };
                     resp.progress_bytes = i.checked_bytes.load(Ordering::Relaxed);
                 }
                 ManagedTorrentState::Paused(p) => {
@@ -534,8 +561,9 @@ impl ManagedTorrent {
                     resp.error = Some("bug: torrent in broken \"None\" state".to_string());
                 }
             }
-            resp
-        })
+        }
+
+        resp
     }
 
     #[inline(never)]

--- a/crates/librqbit/src/torrent_state/stats.rs
+++ b/crates/librqbit/src/torrent_state/stats.rs
@@ -44,21 +44,23 @@ impl From<&TorrentStateLive> for LiveStats {
 }
 
 #[derive(Clone, Copy, Serialize, Debug)]
+#[serde(tag = "state", rename_all = "lowercase")]
 pub enum TorrentStatsState {
-    #[serde(rename = "initializing")]
-    Initializing,
-    #[serde(rename = "live")]
+    Initializing {
+        // Serialized as a top-level `initializing_paused` (not just `paused`) to
+        // avoid confusion with the `paused` state once flattened into the JSON.
+        #[serde(rename = "initializing_paused")]
+        paused: bool,
+    },
     Live,
-    #[serde(rename = "paused")]
     Paused,
-    #[serde(rename = "error")]
     Error,
 }
 
 impl std::fmt::Display for TorrentStatsState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            TorrentStatsState::Initializing => f.write_str("initializing"),
+            TorrentStatsState::Initializing { .. } => f.write_str("initializing"),
             TorrentStatsState::Live => f.write_str("live"),
             TorrentStatsState::Paused => f.write_str("paused"),
             TorrentStatsState::Error => f.write_str("error"),
@@ -68,6 +70,10 @@ impl std::fmt::Display for TorrentStatsState {
 
 #[derive(Serialize, Debug)]
 pub struct TorrentStats {
+    // Flattens into `{ "state": "initializing", "paused": <bool> }` etc., so
+    // `state` stays a plain string on the wire and `paused` only appears for
+    // the `initializing` variant.
+    #[serde(flatten)]
     pub state: TorrentStatsState,
     pub file_progress: Vec<u64>,
     pub error: Option<String>,
@@ -132,6 +138,39 @@ impl TorrentStats {
             progress: self.progress_bytes,
             total: self.total_bytes,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample(state: TorrentStatsState) -> TorrentStats {
+        TorrentStats {
+            state,
+            file_progress: vec![],
+            error: None,
+            progress_bytes: 10,
+            uploaded_bytes: 0,
+            total_bytes: 100,
+            finished: false,
+            live: None,
+        }
+    }
+
+    #[test]
+    fn state_flattens_to_string_with_optional_paused() {
+        let init = serde_json::to_value(sample(TorrentStatsState::Initializing { paused: true }))
+            .unwrap();
+        assert_eq!(init["state"], "initializing");
+        assert_eq!(init["initializing_paused"], true);
+
+        let live = serde_json::to_value(sample(TorrentStatsState::Live)).unwrap();
+        assert_eq!(live["state"], "live");
+        assert!(
+            live.get("initializing_paused").is_none(),
+            "initializing_paused must be absent for live"
+        );
     }
 }
 

--- a/crates/librqbit/src/torrent_state/stats.rs
+++ b/crates/librqbit/src/torrent_state/stats.rs
@@ -160,8 +160,8 @@ mod tests {
 
     #[test]
     fn state_flattens_to_string_with_optional_paused() {
-        let init = serde_json::to_value(sample(TorrentStatsState::Initializing { paused: true }))
-            .unwrap();
+        let init =
+            serde_json::to_value(sample(TorrentStatsState::Initializing { paused: true })).unwrap();
         assert_eq!(init["state"], "initializing");
         assert_eq!(init["initializing_paused"], true);
 

--- a/crates/librqbit/webui/src/api-types.ts
+++ b/crates/librqbit/webui/src/api-types.ts
@@ -170,6 +170,7 @@ export interface TorrentStats {
   file_progress: number[];
   progress_bytes: number;
   finished: boolean;
+  initializing_paused?: boolean;
   total_bytes: number;
   live: LiveTorrentStats | null;
 }

--- a/crates/librqbit/webui/src/components/compact/OverviewTab.tsx
+++ b/crates/librqbit/webui/src/components/compact/OverviewTab.tsx
@@ -39,6 +39,7 @@ export const OverviewTab: React.FC<OverviewTabProps> = ({ torrent }) => {
   const totalBytes = statsResponse.total_bytes ?? 1;
   const progressBytes = statsResponse.progress_bytes ?? 0;
   const finished = statsResponse.finished || false;
+  const paused = statsResponse.initializing_paused ?? false;
 
   const totalPieces = torrent.total_pieces ?? 0;
   const downloadedPieces =
@@ -62,7 +63,10 @@ export const OverviewTab: React.FC<OverviewTabProps> = ({ torrent }) => {
   const stateDisplay = (() => {
     if (error) return { text: "Error", color: "text-error" };
     if (state === STATE_INITIALIZING)
-      return { text: "Initializing", color: "text-warning" };
+      return {
+        text: paused ? "Initializing (paused)" : "Initializing",
+        color: "text-warning",
+      };
     if (state === STATE_PAUSED)
       return { text: "Paused", color: "text-secondary" };
     if (state === STATE_LIVE && finished)

--- a/crates/librqbit/webui/src/mock-api.ts
+++ b/crates/librqbit/webui/src/mock-api.ts
@@ -291,6 +291,7 @@ function generateTorrentStats(id: number): TorrentStats {
     file_progress: fileProgress,
     progress_bytes: progressBytes,
     finished,
+    initializing_paused: state === "initializing" && id % 2 === 0,
     total_bytes: totalBytes,
     live:
       state === "live"

--- a/crates/rqbit/src/main.rs
+++ b/crates/rqbit/src/main.rs
@@ -1045,7 +1045,7 @@ async fn stats_printer(session: Arc<Session>) -> Result<(), &'static str> {
         session.with_torrents(|torrents| {
                 for (idx, torrent) in torrents {
                     let stats = torrent.stats();
-                    if let TorrentStatsState::Initializing = stats.state {
+                    if let TorrentStatsState::Initializing { .. } = stats.state {
                         let total = stats.total_bytes;
                         let progress = stats.progress_bytes;
                         let pct =  (progress as f64 / total as f64) * 100f64;


### PR DESCRIPTION
Make the initial hash check abortable. pause() now requests a pause when the torrent is still Initializing instead of bailing out; initial_check periodically checks the flag and stops early; and the start path guards against concurrent checks via try_start_check/finish_check and reports the torrent as Paused while a pause is pending.