### PR TITLE
Expose peer client name in peer stats

### DIFF
--- a/crates/librqbit/src/torrent_state/live/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/mod.rs
@@ -1153,6 +1153,14 @@ impl PeerConnectionHandler for &'_ PeerHandler {
     }
 
     fn on_extended_handshake(&self, hs: &ExtendedHandshake<ByteBuf>) -> anyhow::Result<()> {
+        if let Some(client_name) = hs.v.as_ref().and_then(format_peer_client_name) {
+            self.state
+                .peers
+                .with_live_mut(self.addr, "update peer client name", |live| {
+                    live.client_name = Some(client_name);
+                });
+        }
+
         if let Some(reqq) = hs.reqq.and_then(|reqq| usize::try_from(reqq).ok())
             && reqq > 0
         {
@@ -2074,4 +2082,13 @@ impl PeerHandler {
             notify.notify_waiters();
         }
     }
+}
+
+fn format_peer_client_name(value: &ByteBuf<'_>) -> Option<String> {
+    let client_name = String::from_utf8_lossy(value.as_ref()).trim().to_string();
+    if client_name.is_empty() {
+        return None;
+    }
+
+    Some(client_name)
 }

--- a/crates/librqbit/src/torrent_state/live/peer/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/peer/mod.rs
@@ -250,6 +250,11 @@ impl Peer {
 
 #[derive(Debug)]
 pub(crate) struct LivePeerState {
+    #[allow(dead_code)]
+    peer_id: Id20,
+
+    pub client_name: Option<String>,
+
     pub peer_interested: bool,
 
     // This is used to track the pieces the peer has.
@@ -273,12 +278,14 @@ pub(crate) struct LivePeerState {
 
 impl LivePeerState {
     pub fn new(
-        _peer_id: Id20,
+        peer_id: Id20,
         tx: PeerTx,
         initial_interested: bool,
         connection_kind: ConnectionKind,
     ) -> Self {
         LivePeerState {
+            peer_id,
+            client_name: None,
             peer_interested: initial_interested,
             bitfield: BF::default(),
             inflight_requests: Default::default(),

--- a/crates/librqbit/src/torrent_state/live/peer/stats/snapshot.rs
+++ b/crates/librqbit/src/torrent_state/live/peer/stats/snapshot.rs
@@ -28,6 +28,7 @@ pub struct PeerStats {
     pub counters: PeerCounters,
     pub state: &'static str,
     pub conn_kind: Option<ConnectionKind>,
+    pub client_name: Option<String>,
 }
 
 impl From<&super::atomic::PeerCountersAtomic> for PeerCounters {
@@ -61,6 +62,10 @@ impl From<&Peer> for PeerStats {
             state: state.name(),
             conn_kind: match state {
                 PeerState::Live(l) => Some(l.connection_kind),
+                _ => None,
+            },
+            client_name: match state {
+                PeerState::Live(l) => l.client_name.clone(),
                 _ => None,
             },
         }

--- a/crates/librqbit/webui/src/api-types.ts
+++ b/crates/librqbit/webui/src/api-types.ts
@@ -85,6 +85,7 @@ export interface PeerStats {
   counters: PeerCounters;
   state: string;
   conn_kind: ConnectionKind | null;
+  client_name: string | null;
 }
 
 export interface PeerStatsSnapshot {

--- a/crates/librqbit/webui/src/components/compact/PeersTab.tsx
+++ b/crates/librqbit/webui/src/components/compact/PeersTab.tsx
@@ -34,6 +34,7 @@ const SPEED_AVERAGE_WINDOW_MS = 5000;
 type PeerSortColumn =
   | "addr"
   | "connKind"
+  | "client"
   | "downloadSpeed"
   | "uploadSpeed"
   | "downloaded"
@@ -178,6 +179,11 @@ export const PeersTab: React.FC<PeersTabProps> = ({ torrent }) => {
             b.stats.conn_kind ?? "",
           );
           break;
+        case "client":
+          cmp = (a.stats.client_name ?? "").localeCompare(
+            b.stats.client_name ?? "",
+          );
+          break;
         case "downloadSpeed":
           cmp = a.downloadSpeed - b.downloadSpeed;
           break;
@@ -236,6 +242,14 @@ export const PeersTab: React.FC<PeersTabProps> = ({ torrent }) => {
                   sortDirection={sortDirection}
                 />
               </th>
+              <th className={headerClass} onClick={() => handleSort("client")}>
+                Client
+                <SortIcon
+                  column="client"
+                  sortColumn={sortColumn}
+                  sortDirection={sortDirection}
+                />
+              </th>
               <th
                 className={headerClass}
                 onClick={() => handleSort("downloadSpeed")}
@@ -286,7 +300,7 @@ export const PeersTab: React.FC<PeersTabProps> = ({ torrent }) => {
             {sortedPeers.length === 0 ? (
               <tr>
                 <td
-                  colSpan={6}
+                  colSpan={7}
                   className="px-2 py-3 text-center text-sm text-tertiary"
                 >
                   {peerSnapshot === null
@@ -300,6 +314,9 @@ export const PeersTab: React.FC<PeersTabProps> = ({ torrent }) => {
                   <td className="px-2 py-1 text-sm font-mono">{peer.addr}</td>
                   <td className="px-2 py-1 text-sm text-secondary">
                     {peer.stats.conn_kind ?? "-"}
+                  </td>
+                  <td className="px-2 py-1 text-sm text-secondary">
+                    {peer.stats.client_name ?? "-"}
                   </td>
                   <td className="px-2 py-1 text-sm text-success">
                     {formatSpeed(peer.downloadSpeed)}

--- a/crates/librqbit/webui/src/mock-api.ts
+++ b/crates/librqbit/webui/src/mock-api.ts
@@ -457,6 +457,13 @@ export const MockAPI: RqbitAPI & { getVersion: () => Promise<string> } = {
 
     const peers: Record<string, any> = {};
     const rand = seededRandom(index * 4421); // For other random values
+    const mockClients = [
+      "qBittorrent 4.6.5",
+      "Transmission 4.0.5",
+      "Deluge 2.1.1",
+      "rqbit 9.0.0",
+      "libtorrent 2.0.9",
+    ];
 
     for (const peer of peerList) {
       peers[`${peer.ip}:${peer.port}`] = {
@@ -476,6 +483,7 @@ export const MockAPI: RqbitAPI & { getVersion: () => Promise<string> } = {
         },
         state: "live",
         conn_kind: peer.connKind,
+        client_name: mockClients[Math.floor(rand() * mockClients.length)],
       };
     }
 


### PR DESCRIPTION
Parse the client name/version from the BitTorrent extended handshake (the "v" field) and store it on the live peer state, surfacing it through PeerStats so the client of each peer can be displayed.