### PR TITLE
Support WANIPConnection v2 for UPnP port forwarding

### DIFF
--- a/crates/upnp/src/lib.rs
+++ b/crates/upnp/src/lib.rs
@@ -14,10 +14,19 @@ use tokio::sync::mpsc::{UnboundedSender, unbounded_channel};
 use tracing::{Instrument, Span, debug, debug_span, trace, warn};
 use url::Url;
 
-const SERVICE_TYPE_WAN_IP_CONNECTION: &str = "urn:schemas-upnp-org:service:WANIPConnection:1";
+const SERVICE_TYPE_WAN_IP_CONNECTION_V1: &str = "urn:schemas-upnp-org:service:WANIPConnection:1";
+const SERVICE_TYPE_WAN_IP_CONNECTION_V2: &str = "urn:schemas-upnp-org:service:WANIPConnection:2";
+
+fn is_wan_ip_connection_service(service_type: &str) -> bool {
+    service_type == SERVICE_TYPE_WAN_IP_CONNECTION_V1
+        || service_type == SERVICE_TYPE_WAN_IP_CONNECTION_V2
+}
+
 const SSDP_MULTICAST_IP: SocketAddr =
     SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(239, 255, 255, 250), 1900));
 pub const SSDP_SEARCH_WAN_IPCONNECTION_ST: &str = "urn:schemas-upnp-org:service:WANIPConnection:1";
+pub const SSDP_SEARCH_WAN_IPCONNECTION_V2_ST: &str =
+    "urn:schemas-upnp-org:service:WANIPConnection:2";
 pub const SSDP_SEARCH_ROOT_ST: &str = "upnp:rootdevice";
 
 pub fn make_ssdp_search_request(kind: &str) -> String {
@@ -82,13 +91,14 @@ async fn forward_port(
     local_ip: IpAddr,
     port: u16,
     lease_duration: Duration,
+    service_type: &str,
 ) -> anyhow::Result<()> {
     let request_body = format!(
         r#"
         <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"
             s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
             <s:Body>
-                <u:AddPortMapping xmlns:u="{SERVICE_TYPE_WAN_IP_CONNECTION}">
+                <u:AddPortMapping xmlns:u="{service_type}">
                     <NewRemoteHost></NewRemoteHost>
                     <NewExternalPort>{port}</NewExternalPort>
                     <NewProtocol>TCP</NewProtocol>
@@ -110,10 +120,7 @@ async fn forward_port(
     let response = client
         .post(url.clone())
         .header("Content-Type", "text/xml")
-        .header(
-            "SOAPAction",
-            format!("\"{SERVICE_TYPE_WAN_IP_CONNECTION}#AddPortMapping\""),
-        )
+        .header("SOAPAction", format!("\"{service_type}#AddPortMapping\""))
         .body(request_body)
         .send()
         .await
@@ -244,12 +251,18 @@ impl UpnpEndpoint {
         Ok(local_ip)
     }
 
-    fn get_wan_ip_control_urls(&self) -> impl Iterator<Item = (tracing::Span, Url)> + '_ {
+    fn get_wan_ip_control_urls(&self) -> impl Iterator<Item = (tracing::Span, Url, String)> + '_ {
         self.iter_services()
-            .filter(|(_, s)| s.service_type == SERVICE_TYPE_WAN_IP_CONNECTION)
-            .map(|(span, s)| (span, self.discover_response.location.join(&s.control_url)))
-            .filter_map(|(span, url)| match url {
-                Ok(url) => Some((span, url)),
+            .filter(|(_, s)| is_wan_ip_connection_service(&s.service_type))
+            .map(|(span, s)| {
+                (
+                    span,
+                    self.discover_response.location.join(&s.control_url),
+                    s.service_type.clone(),
+                )
+            })
+            .filter_map(|(span, url, service_type)| match url {
+                Ok(url) => Some((span, url, service_type)),
                 Err(e) => {
                     debug!("bad control url: {e:#}");
                     None
@@ -422,13 +435,12 @@ impl UpnpPortForwarder {
         &self,
         tx: &UnboundedSender<UpnpDiscoverResponse>,
     ) -> anyhow::Result<()> {
-        discover_once(
-            tx,
-            SSDP_SEARCH_WAN_IPCONNECTION_ST,
-            self.opts.discover_timeout,
-            self.bind_device.as_ref(),
-        )
-        .await
+        let timeout = self.opts.discover_timeout;
+        let bind_device = self.bind_device.as_ref();
+        let v1 = discover_once(tx, SSDP_SEARCH_WAN_IPCONNECTION_ST, timeout, bind_device);
+        let v2 = discover_once(tx, SSDP_SEARCH_WAN_IPCONNECTION_V2_ST, timeout, bind_device);
+        futures::future::try_join(v1, v2).await?;
+        Ok(())
     }
 
     async fn discovery(&self, tx: UnboundedSender<UpnpDiscoverResponse>) -> anyhow::Result<()> {
@@ -443,23 +455,41 @@ impl UpnpPortForwarder {
         }
     }
 
-    async fn manage_port(&self, control_url: Url, local_ip: IpAddr, port: u16) -> ! {
+    async fn manage_port(
+        &self,
+        control_url: Url,
+        local_ip: IpAddr,
+        port: u16,
+        service_type: String,
+    ) -> ! {
         let lease_duration = self.opts.lease_duration;
         let mut interval = tokio::time::interval(lease_duration / 2);
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
         loop {
             interval.tick().await;
-            if let Err(e) = forward_port(control_url.clone(), local_ip, port, lease_duration).await
+            if let Err(e) = forward_port(
+                control_url.clone(),
+                local_ip,
+                port,
+                lease_duration,
+                &service_type,
+            )
+            .await
             {
                 warn!("failed to forward port: {e:#}");
             }
         }
     }
 
-    async fn manage_service(&self, control_url: Url, local_ip: IpAddr) -> anyhow::Result<()> {
+    async fn manage_service(
+        &self,
+        control_url: Url,
+        local_ip: IpAddr,
+        service_type: String,
+    ) -> anyhow::Result<()> {
         futures::future::join_all(self.ports.iter().cloned().map(|port| {
-            self.manage_port(control_url.clone(), local_ip, port)
+            self.manage_port(control_url.clone(), local_ip, port, service_type.clone())
                 .instrument(debug_span!("manage_port", port = port))
         }))
         .await;
@@ -490,7 +520,7 @@ impl UpnpPortForwarder {
                 },
                 Some(Ok(endpoint)) = endpoints.next(), if !endpoints.is_empty() => {
                     let mut local_ip = None;
-                    for (span, control_url) in endpoint.get_wan_ip_control_urls() {
+                    for (span, control_url, service_type) in endpoint.get_wan_ip_control_urls() {
                         if spawned_tasks.contains(&control_url) {
                             debug!("already spawned for {}", control_url);
                             continue;
@@ -511,7 +541,10 @@ impl UpnpPortForwarder {
                             }
                         };
                         spawned_tasks.insert(control_url.clone());
-                        service_managers.push(self.manage_service(control_url, ip).instrument(span))
+                        service_managers.push(
+                            self.manage_service(control_url, ip, service_type)
+                                .instrument(span),
+                        )
                     }
                 },
                 _ = service_managers.next(), if !service_managers.is_empty() => {


### PR DESCRIPTION
The service-type filter matched only WANIPConnection:1 exactly, but modern routers commonly advertise WANIPConnection:2 (e.g. some OpenWrt builds). This caused get_wan_ip_control_urls to return zero matches and silently skip forwarding, even though miniupnpc worked against the same IGD.

Match either v1 or v2, and thread the matched service-type URN through to the SOAP AddPortMapping body and SOAPAction header (previously hardcoded to :1).

Resolves #612 