### PR TITLE
Add --upnp-port-forward flag to rqbit download

### DIFF
--- a/crates/rqbit/src/main.rs
+++ b/crates/rqbit/src/main.rs
@@ -362,6 +362,15 @@ struct DownloadOpts {
     /// Disable HTTP API entirely.
     #[arg(long = "disable-http-api")]
     disable_http_api: bool,
+
+    /// Forward the listen port through UPnP on your router.
+    ///
+    /// By default "rqbit download" does not port-forward, as it is an
+    /// ephemeral one-shot process. Set this to forward the port for the
+    /// duration of the download (e.g. to become connectable). Still respects
+    /// the global --disable-upnp-port-forward.
+    #[arg(long = "upnp-port-forward", env = "RQBIT_UPNP_PORT_FORWARD")]
+    upnp_port_forward: bool,
 }
 
 #[derive(Clone)]
@@ -775,8 +784,10 @@ async fn async_main(mut opts: Opts, cancel: CancellationToken) -> anyhow::Result
             }
 
             if let Some(listen) = sopts.listen.as_mut() {
-                // We are creating an ephemeral download, no point in port forwarding.
-                listen.enable_upnp_port_forwarding = false;
+                // "rqbit download" is ephemeral, so by default don't port-forward.
+                // --upnp-port-forward opts in, but the global --disable-upnp-port-forward
+                // still acts as an off-switch.
+                listen.enable_upnp_port_forwarding &= download_opts.upnp_port_forward;
             }
 
             let torrent_opts = || AddTorrentOptions {


### PR DESCRIPTION
The download subcommand hard-disabled UPnP port forwarding because it is an ephemeral one-shot process, with no way to opt back in. Add a download-local `--upnp-port-forward` flag (and env `RQBIT_UPNP_PORT_FORWARD`) that re-enables forwarding for the duration of the download, for users who want to be connectable without running a full server.

The flag is a bare opt-in bool (no enable- prefix), matching the existing `--http-api-allow-create` / `--overwrite` convention. It is AND-ed with the global setting so `--disable-upnp-port-forward` still acts as a hard off-switch.

Resolves #613.