### PR TITLE
Fix DefaultBodyLimit to allow torrents bigger than 2 MB to be uploaded, Fixed init state throwing 500 internal server error

### DIFF
--- a/crates/librqbit/examples/simulate_traffic.rs
+++ b/crates/librqbit/examples/simulate_traffic.rs
@@ -305,6 +305,7 @@ impl TestHarness {
                 read_only: false,
                 basic_auth: None,
                 allow_create: true,
+                max_upload_body_size: None,
                 prometheus_handle: None,
             }),
         );

--- a/crates/librqbit/src/api.rs
+++ b/crates/librqbit/src/api.rs
@@ -500,22 +500,15 @@ impl Api {
 
     pub fn api_dump_haves(&self, idx: TorrentIdOrHash) -> Result<(BF, u32)> {
         let mgr = self.mgr_handle(idx)?;
-        let result = mgr.with_chunk_tracker(|chunks| {
+        mgr.with_chunk_tracker(|chunks| {
             let bf = BF::from_bitslice(chunks.get_have_pieces().as_slice());
             let len = chunks.get_lengths().total_pieces();
             (bf, len)
-        });
-        match result {
-            Ok(r) => Ok(r),
-            Err(_) => {
-                let len = mgr
-                    .with_metadata(|m| m.lengths().total_pieces())
-                    .unwrap_or(0);
-                let bf =
-                    BF::from_boxed_slice(vec![0u8; (len as usize).div_ceil(8)].into_boxed_slice());
-                Ok((bf, len))
-            }
-        }
+        })
+        .with_status_error(
+            StatusCode::PRECONDITION_FAILED,
+            crate::Error::TorrentIsNotLive,
+        )
     }
 
     pub async fn api_stream(&self, idx: TorrentIdOrHash, file_id: usize) -> Result<FileStream> {

--- a/crates/librqbit/src/api.rs
+++ b/crates/librqbit/src/api.rs
@@ -500,11 +500,23 @@ impl Api {
 
     pub fn api_dump_haves(&self, idx: TorrentIdOrHash) -> Result<(BF, u32)> {
         let mgr = self.mgr_handle(idx)?;
-        Ok(mgr.with_chunk_tracker(|chunks| {
+        let result = mgr.with_chunk_tracker(|chunks| {
             let bf = BF::from_bitslice(chunks.get_have_pieces().as_slice());
             let len = chunks.get_lengths().total_pieces();
             (bf, len)
-        })?)
+        });
+        match result {
+            Ok(r) => Ok(r),
+            Err(_) => {
+                let len = mgr
+                    .with_metadata(|m| m.lengths().total_pieces())
+                    .unwrap_or(0);
+                let bf = BF::from_boxed_slice(
+                    vec![0u8; (len as usize).div_ceil(8)].into_boxed_slice(),
+                );
+                Ok((bf, len))
+            }
+        }
     }
 
     pub async fn api_stream(&self, idx: TorrentIdOrHash, file_id: usize) -> Result<FileStream> {

--- a/crates/librqbit/src/api.rs
+++ b/crates/librqbit/src/api.rs
@@ -511,9 +511,8 @@ impl Api {
                 let len = mgr
                     .with_metadata(|m| m.lengths().total_pieces())
                     .unwrap_or(0);
-                let bf = BF::from_boxed_slice(
-                    vec![0u8; (len as usize).div_ceil(8)].into_boxed_slice(),
-                );
+                let bf =
+                    BF::from_boxed_slice(vec![0u8; (len as usize).div_ceil(8)].into_boxed_slice());
                 Ok((bf, len))
             }
         }

--- a/crates/librqbit/src/http_api/handlers/mod.rs
+++ b/crates/librqbit/src/http_api/handlers/mod.rs
@@ -110,10 +110,7 @@ pub fn make_api_router(state: ApiState) -> Router {
 
     if !state.opts.read_only {
         api_router = api_router
-            .route(
-                "/torrents",
-                post(torrents::h_torrents_post).layer(DefaultBodyLimit::max(100 * 1024 * 1024)),
-            )
+            .route("/torrents", post(torrents::h_torrents_post))
             .route(
                 "/torrents/limits",
                 post(configure::h_update_session_ratelimits),
@@ -142,5 +139,7 @@ pub fn make_api_router(state: ApiState) -> Router {
             .route("/torrents/create", post(torrents::h_create_torrent));
     }
 
-    api_router.with_state(state)
+    api_router
+        .layer(DefaultBodyLimit::max(100 * 1024 * 1024))
+        .with_state(state)
 }

--- a/crates/librqbit/src/http_api/handlers/mod.rs
+++ b/crates/librqbit/src/http_api/handlers/mod.rs
@@ -13,6 +13,7 @@ use axum::response::Redirect;
 
 use axum::{
     Router,
+    extract::DefaultBodyLimit,
     response::IntoResponse,
     routing::{get, post},
 };
@@ -109,7 +110,7 @@ pub fn make_api_router(state: ApiState) -> Router {
 
     if !state.opts.read_only {
         api_router = api_router
-            .route("/torrents", post(torrents::h_torrents_post))
+            .route("/torrents", post(torrents::h_torrents_post).layer(DefaultBodyLimit::max(100 * 1024 * 1024)))
             .route(
                 "/torrents/limits",
                 post(configure::h_update_session_ratelimits),

--- a/crates/librqbit/src/http_api/handlers/mod.rs
+++ b/crates/librqbit/src/http_api/handlers/mod.rs
@@ -110,7 +110,10 @@ pub fn make_api_router(state: ApiState) -> Router {
 
     if !state.opts.read_only {
         api_router = api_router
-            .route("/torrents", post(torrents::h_torrents_post).layer(DefaultBodyLimit::max(100 * 1024 * 1024)))
+            .route(
+                "/torrents",
+                post(torrents::h_torrents_post).layer(DefaultBodyLimit::max(100 * 1024 * 1024)),
+            )
             .route(
                 "/torrents/limits",
                 post(configure::h_update_session_ratelimits),

--- a/crates/librqbit/src/http_api/handlers/mod.rs
+++ b/crates/librqbit/src/http_api/handlers/mod.rs
@@ -13,7 +13,6 @@ use axum::response::Redirect;
 
 use axum::{
     Router,
-    extract::DefaultBodyLimit,
     response::IntoResponse,
     routing::{get, post},
 };
@@ -139,7 +138,5 @@ pub fn make_api_router(state: ApiState) -> Router {
             .route("/torrents/create", post(torrents::h_create_torrent));
     }
 
-    api_router
-        .layer(DefaultBodyLimit::max(100 * 1024 * 1024))
-        .with_state(state)
+    api_router.with_state(state)
 }

--- a/crates/librqbit/src/http_api/handlers/torrents.rs
+++ b/crates/librqbit/src/http_api/handlers/torrents.rs
@@ -2,6 +2,7 @@ use std::{net::SocketAddr, str::FromStr};
 
 use anyhow::Context;
 use axum::{
+    body::{Body, to_bytes},
     extract::{Path, Query, State},
     response::IntoResponse,
 };
@@ -35,11 +36,14 @@ pub async fn h_torrents_post(
     State(state): State<ApiState>,
     Query(params): Query<TorrentAddQueryParams>,
     Timeout(timeout): Timeout<600_000, 3_600_000>,
-    data: Bytes,
+    body: Body,
 ) -> Result<impl IntoResponse> {
     let is_url = params.is_url;
     let opts = params.into_add_torrent_options();
-    let data = data.to_vec();
+    let data = to_bytes(body, 100 * 1024 * 1024)
+        .await
+        .map_err(|_| ApiError::from((StatusCode::PAYLOAD_TOO_LARGE, "body too large")))?
+        .to_vec();
     let maybe_magnet = |data: &[u8]| -> bool {
         std::str::from_utf8(data)
             .ok()

--- a/crates/librqbit/src/http_api/handlers/torrents.rs
+++ b/crates/librqbit/src/http_api/handlers/torrents.rs
@@ -40,7 +40,8 @@ pub async fn h_torrents_post(
 ) -> Result<impl IntoResponse> {
     let is_url = params.is_url;
     let opts = params.into_add_torrent_options();
-    let data = to_bytes(body, 100 * 1024 * 1024)
+    let max_size = state.opts.max_upload_body_size.unwrap_or(10 * 1024 * 1024);
+    let data = to_bytes(body, max_size)
         .await
         .map_err(|_| ApiError::from((StatusCode::PAYLOAD_TOO_LARGE, "body too large")))?
         .to_vec();

--- a/crates/librqbit/src/http_api/mod.rs
+++ b/crates/librqbit/src/http_api/mod.rs
@@ -37,6 +37,8 @@ pub struct HttpApiOptions {
     pub basic_auth: Option<(String, String)>,
     // Allow creating torrents via API.
     pub allow_create: bool,
+    /// Maximum upload body size.
+    pub max_upload_body_size: Option<usize>,
     #[cfg(feature = "prometheus")]
     pub prometheus_handle: Option<metrics_exporter_prometheus::PrometheusHandle>,
 }

--- a/crates/rqbit/src/main.rs
+++ b/crates/rqbit/src/main.rs
@@ -102,6 +102,13 @@ struct Opts {
     #[arg(long = "http-api-allow-create", env = "RQBIT_HTTP_API_ALLOW_CREATE")]
     http_api_allow_create: bool,
 
+    /// Upload body size limit in bytes.
+    #[arg(
+        long = "http-api-max-upload-size",
+        env = "RQBIT_HTTP_API_MAX_UPLOAD_SIZE"
+    )]
+    http_api_max_upload_size: Option<usize>,
+
     /// Set this flag if you want to use tokio's single threaded runtime.
     /// It MAY perform better, but the main purpose is easier debugging, as time
     /// profilers work better with this one.
@@ -689,6 +696,7 @@ async fn async_main(mut opts: Opts, cancel: CancellationToken) -> anyhow::Result
             None
         },
         allow_create: opts.http_api_allow_create,
+        max_upload_body_size: opts.http_api_max_upload_size,
 
         // We need to install prometheus recorder early before we registered any metrics.
         #[cfg(feature = "prometheus")]


### PR DESCRIPTION
- When a torrent is in the Initialized or Error state we should return an empty zeroed bitfield instead of throwing and error as a 500 internal server error.
- Raised body limit size when posting from the axum default of 2 MB to 100 MB. Fixes the 413 payload to large error when uploading huge torrent files.