### PR TITLE
categories: init

### DIFF
--- a/crates/librqbit/src/api.rs
+++ b/crates/librqbit/src/api.rs
@@ -173,6 +173,9 @@ impl TorrentIdOrHash {
 pub struct ApiTorrentListOpts {
     #[serde(default)]
     pub with_stats: bool,
+    /// Filter by categories. Empty means no filter.
+    #[serde(default)]
+    pub categories: Option<String>,
 }
 
 impl Api {
@@ -200,13 +203,29 @@ impl Api {
     }
 
     pub fn api_torrent_list(&self) -> TorrentListResponse {
-        self.api_torrent_list_ext(ApiTorrentListOpts { with_stats: false })
+        self.api_torrent_list_ext(ApiTorrentListOpts {
+            with_stats: false,
+            categories: None,
+        })
     }
 
     pub fn api_torrent_list_ext(&self, opts: ApiTorrentListOpts) -> TorrentListResponse {
+        let filter_categories = opts
+            .categories
+            .as_ref()
+            .map(|s| s.split(',').collect::<std::collections::HashSet<&str>>());
+
         let items = self.session.with_torrents(|torrents| {
             torrents
-                .map(|(id, mgr)| {
+                .filter_map(|(id, mgr)| {
+                    // Apply category filter
+                    if let Some(cat_filter) = &filter_categories {
+                        let torrent_cat = mgr.category().unwrap_or_default();
+                        if !cat_filter.contains(torrent_cat.as_str()) {
+                            return None;
+                        }
+                    }
+
                     let total_pieces = mgr
                         .metadata
                         .load()
@@ -223,6 +242,7 @@ impl Api {
                             .output_folder
                             .to_string_lossy()
                             .into_owned(),
+                        category: mgr.category(),
                         total_pieces,
 
                         // These will be filled in /details and /stats endpoints
@@ -232,7 +252,7 @@ impl Api {
                     if opts.with_stats {
                         r.stats = Some(mgr.stats());
                     }
-                    r
+                    Some(r)
                 })
                 .collect()
         });
@@ -250,14 +270,17 @@ impl Api {
             .to_string_lossy()
             .into_owned()
             .to_string();
-        make_torrent_details(
+        let category = handle.category();
+        let mut details = make_torrent_details(
             Some(handle.id()),
             &info_hash,
             handle.metadata.load().as_ref().map(|r| &r.info),
             handle.name().as_deref(),
             only_files.as_deref(),
             output_folder,
-        )
+        )?;
+        details.category = category;
+        Ok(details)
     }
 
     pub fn api_session_stats(&self) -> SessionStatsSnapshot {
@@ -344,6 +367,21 @@ impl Api {
             .update_only_files(&handle, only_files)
             .await
             .context("error updating only_files")?;
+        Ok(Default::default())
+    }
+
+    pub async fn api_torrent_action_update_category(
+        &self,
+        idx: TorrentIdOrHash,
+        category: Option<String>,
+    ) -> Result<EmptyJsonResponse> {
+        let handle = self.mgr_handle(idx)?;
+        tracing::debug!(idx = ?idx, category = ?category, "updating category");
+        self.session
+            .update_category(&handle, category)
+            .await
+            .context("error updating category")?;
+        tracing::debug!(idx = ?idx, "category updated successfully");
         Ok(Default::default())
     }
 
@@ -542,6 +580,9 @@ pub struct TorrentDetailsResponse {
     pub name: Option<String>,
     pub output_folder: String,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub category: Option<String>,
+
     #[serde(default)]
     pub total_pieces: u32,
 
@@ -593,9 +634,10 @@ fn make_torrent_details(
         name: name
             .map(|s| s.to_owned())
             .or_else(|| info.and_then(|i| i.name().map(|n| n.into_owned()))),
-        files: Some(files),
         output_folder,
+        category: None,
         total_pieces,
+        files: Some(files),
         stats: None,
     })
 }

--- a/crates/librqbit/src/http_api/handlers/mod.rs
+++ b/crates/librqbit/src/http_api/handlers/mod.rs
@@ -134,9 +134,15 @@ pub fn make_api_router(state: ApiState) -> Router {
                 "/torrents/{id}/update_only_files",
                 post(torrents::h_torrent_action_update_only_files),
             )
+            .route(
+                "/torrents/{id}/update_category",
+                post(torrents::h_torrent_action_update_category),
+            )
             .route("/torrents/{id}/add_peers", post(torrents::h_add_peers))
             .route("/torrents/create", post(torrents::h_create_torrent));
     }
 
-    api_router.with_state(state)
+    api_router
+        .route("/categories", get(torrents::h_categories))
+        .with_state(state)
 }

--- a/crates/librqbit/src/http_api/handlers/torrents.rs
+++ b/crates/librqbit/src/http_api/handlers/torrents.rs
@@ -253,6 +253,30 @@ pub async fn h_torrent_action_update_only_files(
         .map(axum::Json)
 }
 
+#[derive(Deserialize)]
+pub struct UpdateCategoryRequest {
+    // A missing or null category clears it.
+    #[serde(default)]
+    category: Option<String>,
+}
+
+pub async fn h_torrent_action_update_category(
+    State(state): State<ApiState>,
+    Path(idx): Path<TorrentIdOrHash>,
+    axum::Json(req): axum::Json<UpdateCategoryRequest>,
+) -> Result<impl IntoResponse> {
+    // Normalize empty/whitespace-only category to None.
+    let category = req
+        .category
+        .map(|c| c.trim().to_owned())
+        .filter(|c| !c.is_empty());
+    state
+        .api
+        .api_torrent_action_update_category(idx, category)
+        .await
+        .map(axum::Json)
+}
+
 pub async fn h_session_stats(State(state): State<ApiState>) -> impl IntoResponse {
     axum::Json(state.api.api_session_stats())
 }
@@ -434,4 +458,8 @@ pub async fn h_create_torrent(
             Ok((headers, torrent.as_bytes()?).into_response())
         }
     }
+}
+
+pub async fn h_categories(State(state): State<ApiState>) -> impl IntoResponse {
+    axum::Json(state.api.session().categories().to_vec())
 }

--- a/crates/librqbit/src/http_api_types.rs
+++ b/crates/librqbit/src/http_api_types.rs
@@ -23,6 +23,7 @@ pub struct TorrentAddQueryParams {
     // Will force interpreting the content as a URL.
     pub is_url: Option<bool>,
     pub list_only: Option<bool>,
+    pub category: Option<String>,
 }
 
 impl Serialize for OnlyFiles {
@@ -100,6 +101,7 @@ impl TorrentAddQueryParams {
             output_folder: self.output_folder,
             sub_folder: self.sub_folder,
             list_only: self.list_only.unwrap_or(false),
+            category: self.category,
             initial_peers: self.initial_peers.map(|i| i.0),
             peer_opts: Some(PeerConnectionOptions {
                 connect_timeout: self.peer_connect_timeout.map(Duration::from_secs),

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -151,6 +151,7 @@ pub struct Session {
     pub ipv4_only: bool,
     pub peer_limit: Option<usize>,
     client_name_and_version: String,
+    categories: Vec<String>,
 }
 
 async fn torrent_from_url(
@@ -291,6 +292,9 @@ pub struct AddTorrentOptions {
 
     // Custom trackers
     pub trackers: Option<Vec<String>>,
+
+    /// Category this torrent belongs to. Must match a session-defined category.
+    pub category: Option<String>,
 }
 
 pub struct ListOnlyResponse {
@@ -479,6 +483,9 @@ pub struct SessionOptions {
     /// Override the client name and version used in User-Agent headers and
     /// peer extended handshakes. Defaults to "rqbit X.Y.Z".
     pub client_name_and_version: Option<String>,
+
+    /// Categories available for torrent tagging. Empty means no categories.
+    pub categories: Vec<String>,
 }
 
 impl Default for SessionOptions {
@@ -507,6 +514,7 @@ impl Default for SessionOptions {
             disable_local_service_discovery: false,
             ipv4_only: false,
             client_name_and_version: None,
+            categories: Vec::new(),
         }
     }
 }
@@ -806,6 +814,16 @@ impl Session {
                 disable_trackers: opts.disable_trackers,
                 peer_limit: opts.peer_limit,
                 client_name_and_version,
+                categories: {
+                    let categories = opts.categories;
+                    let mut seen = std::collections::HashSet::new();
+                    for c in &categories {
+                        if !seen.insert(c.as_str()) {
+                            anyhow::bail!("duplicate category: {c}");
+                        }
+                    }
+                    categories
+                },
 
                 #[cfg(feature = "disable-upload")]
                 _disable_upload: opts.disable_upload,
@@ -1156,6 +1174,7 @@ impl Session {
                             torrent.meta.info.data.validate()?,
                             torrent.torrent_bytes,
                             torrent.meta.info.raw_bytes.0,
+                            opts.category.clone(),
                         )?),
                         trackers: trackers
                             .iter()
@@ -1227,6 +1246,17 @@ impl Session {
             name,
         } = add_res;
 
+        // Validate category if provided
+        if let Some(ref cat) = opts.category {
+            if !self.categories.is_empty() && !self.is_valid_category(cat) {
+                anyhow::bail!(
+                    "invalid category {:?}, must be one of: {:?}",
+                    cat,
+                    self.categories
+                );
+            }
+        }
+
         let private = metadata.as_ref().is_some_and(|m| m.info.info().private);
 
         let make_peer_rx = || {
@@ -1242,7 +1272,7 @@ impl Session {
 
         let mut seen_peers = Vec::new();
 
-        let (metadata, peer_rx) = {
+        let (mut metadata, peer_rx) = {
             match metadata {
                 Some(metadata) => {
                     let mut peer_rx = None;
@@ -1273,6 +1303,10 @@ impl Session {
                 }
             }
         };
+
+        // The category is a mutable, user-assigned label. It's set here uniformly regardless of
+        // whether the metadata came from a .torrent file or a resolved magnet.
+        metadata.category = opts.category.clone();
 
         trace!("Torrent metadata: {:#?}", &metadata.info.info());
 
@@ -1355,6 +1389,7 @@ impl Session {
                     ratelimits: opts.ratelimits,
                     initial_peers: opts.initial_peers.clone().unwrap_or_default(),
                     peer_limit: opts.peer_limit.or(self.peer_limit),
+                    category: opts.category.clone(),
                     #[cfg(feature = "disable-upload")]
                     _disable_upload: self._disable_upload,
                 },
@@ -1663,6 +1698,7 @@ impl Session {
                         info,
                         torrent_file_from_info_bytes(info_bytes.as_ref(), trackers)?,
                         info_bytes.0,
+                        None,
                     )?,
                     peer_rx: rx,
                     seen_peers: {
@@ -1719,6 +1755,26 @@ impl Session {
             .context("error adding to session")?;
 
         Ok((torrent, handle))
+    }
+
+    /// Get all defined categories.
+    pub fn categories(&self) -> &[String] {
+        &self.categories
+    }
+
+    /// Check if a category name is valid (i.e. defined in session options).
+    pub fn is_valid_category(&self, category: &str) -> bool {
+        self.categories.iter().any(|c| c == category)
+    }
+
+    pub async fn update_category(
+        self: &Arc<Self>,
+        handle: &ManagedTorrentHandle,
+        category: Option<String>,
+    ) -> anyhow::Result<()> {
+        handle.update_category(category)?;
+        self.try_update_persistence_metadata(handle).await;
+        Ok(())
     }
 }
 

--- a/crates/librqbit/src/session_persistence/json.rs
+++ b/crates/librqbit/src/session_persistence/json.rs
@@ -148,7 +148,13 @@ impl JsonSessionPersistenceStore {
             only_files: torrent.only_files().clone(),
             is_paused: torrent.is_paused(),
             output_folder: torrent.shared().options.output_folder.clone(),
+            category: torrent
+                .metadata
+                .load()
+                .as_ref()
+                .and_then(|m| m.category.clone()),
         };
+        tracing::debug!(id = ?id, category = ?st.category, "persistence update");
 
         let torrent_bytes = torrent
             .metadata

--- a/crates/librqbit/src/session_persistence/mod.rs
+++ b/crates/librqbit/src/session_persistence/mod.rs
@@ -30,6 +30,7 @@ pub struct SerializedTorrent {
     output_folder: PathBuf,
     only_files: Option<Vec<usize>>,
     is_paused: bool,
+    category: Option<String>,
 }
 
 impl SerializedTorrent {
@@ -59,6 +60,7 @@ impl SerializedTorrent {
             ),
             only_files: self.only_files,
             overwrite: true,
+            category: self.category,
             ..Default::default()
         };
 

--- a/crates/librqbit/src/session_persistence/postgres.rs
+++ b/crates/librqbit/src/session_persistence/postgres.rs
@@ -26,6 +26,7 @@ struct TorrentsTableRecord {
     output_folder: String,
     only_files: Option<Vec<i32>>,
     is_paused: bool,
+    category: Option<String>,
 }
 
 impl TorrentsTableRecord {
@@ -41,6 +42,7 @@ impl TorrentsTableRecord {
                     .only_files
                     .map(|v| v.into_iter().map(|v| v as usize).collect()),
                 is_paused: self.is_paused,
+                category: self.category,
             },
         ))
     }
@@ -102,8 +104,13 @@ impl SessionPersistenceStore for PostgresSessionStorage {
             .as_ref()
             .map(|i| i.torrent_bytes.clone())
             .unwrap_or_default();
-        let q = "INSERT INTO torrents (id, info_hash, torrent_bytes, trackers, output_folder, only_files, is_paused)
-        VALUES($1, $2, $3, $4, $5, $6, $7)
+        let category = torrent
+            .metadata
+            .load()
+            .as_ref()
+            .and_then(|m| m.category.clone());
+        let q = "INSERT INTO torrents (id, info_hash, torrent_bytes, trackers, output_folder, only_files, is_paused, category)
+        VALUES($1, $2, $3, $4, $5, $6, $7, $8)
         ON CONFLICT(id) DO NOTHING";
         sqlx::query(q)
             .bind::<i32>(id.try_into()?)
@@ -132,6 +139,7 @@ impl SessionPersistenceStore for PostgresSessionStorage {
                     .collect::<Vec<i32>>()
             }))
             .bind(torrent.is_paused())
+            .bind(category)
             .execute(&self.pool)
             .await
             .context("error executing INSERT INTO torrents")?;

--- a/crates/librqbit/src/torrent_state/mod.rs
+++ b/crates/librqbit/src/torrent_state/mod.rs
@@ -117,6 +117,7 @@ pub(crate) struct ManagedTorrentOptions {
     pub ratelimits: LimitsConfig,
     pub initial_peers: Vec<SocketAddr>,
     pub peer_limit: Option<usize>,
+    pub category: Option<String>,
     #[cfg(feature = "disable-upload")]
     pub _disable_upload: bool,
 }
@@ -139,6 +140,7 @@ pub struct TorrentMetadata {
     pub torrent_bytes: Bytes,
     pub info_bytes: Bytes,
     pub file_infos: FileInfos,
+    pub category: Option<String>,
 }
 
 impl TorrentMetadata {
@@ -146,6 +148,7 @@ impl TorrentMetadata {
         info: ValidatedTorrentMetaV1Info<ByteBufOwned>,
         torrent_bytes: Bytes,
         info_bytes: Bytes,
+        category: Option<String>,
     ) -> anyhow::Result<Self> {
         let file_infos = info
             .iter_file_details_ext()
@@ -165,6 +168,7 @@ impl TorrentMetadata {
             torrent_bytes,
             info_bytes,
             file_infos,
+            category,
         })
     }
 
@@ -199,6 +203,20 @@ pub struct ManagedTorrentShared {
 impl ManagedTorrentShared {
     pub(crate) fn client_name_and_version(&self) -> &str {
         &self.client_name_and_version
+    }
+
+    pub fn category(&self) -> Option<&str> {
+        self.options.category.as_deref()
+    }
+}
+
+impl ManagedTorrent {
+    /// The user-assigned category/label of the torrent, if any.
+    pub fn category(&self) -> Option<String> {
+        self.metadata
+            .load()
+            .as_ref()
+            .and_then(|m| m.category.clone())
     }
 }
 
@@ -642,6 +660,27 @@ impl ManagedTorrent {
         };
 
         g.only_files = Some(only_files.iter().copied().collect());
+        Ok(())
+    }
+
+    /// Update the user-assigned category/label. The category lives on the (immutable) torrent
+    /// metadata, so this swaps in a fresh metadata value carrying the new category.
+    pub(crate) fn update_category(&self, category: Option<String>) -> anyhow::Result<()> {
+        let cur = self
+            .metadata
+            .load_full()
+            .context("torrent is not resolved")?;
+        if cur.category == category {
+            return Ok(());
+        }
+        let new = Arc::new(TorrentMetadata {
+            info: cur.info.clone(),
+            torrent_bytes: cur.torrent_bytes.clone(),
+            info_bytes: cur.info_bytes.clone(),
+            file_infos: cur.file_infos.clone(),
+            category,
+        });
+        self.metadata.store(Some(new));
         Ok(())
     }
 }

--- a/crates/librqbit/webui/src/api-types.ts
+++ b/crates/librqbit/webui/src/api-types.ts
@@ -35,6 +35,7 @@ export interface TorrentListItem {
   info_hash: string;
   name: string | null;
   output_folder: string;
+  category: string | null;
   total_pieces: number;
   stats?: TorrentStats;
 }
@@ -201,6 +202,7 @@ export interface AddTorrentOptions {
   list_only?: boolean;
   output_folder?: string | null;
   sub_folder?: string | null;
+  category?: string | null;
   peer_opts?: PeerConnectionOptions | null;
   force_tracker_interval?: Duration | null;
   initial_peers?: string[] | null; // Assuming SocketAddr is equivalent to a string in TypeScript
@@ -255,6 +257,7 @@ export interface RqbitAPI {
   listTorrents: (opts?: {
     withStats?: boolean;
   }) => Promise<ListTorrentsResponse>;
+  listCategories: () => Promise<string[]>;
   getTorrentDetails: (index: number) => Promise<TorrentDetails>;
   getTorrentStats: (index: number) => Promise<TorrentStats>;
   getTorrentHaves: (index: number) => Promise<Uint8Array>;
@@ -271,6 +274,7 @@ export interface RqbitAPI {
 
   pause: (index: number) => Promise<void>;
   updateOnlyFiles: (index: number, files: number[]) => Promise<void>;
+  updateCategory: (index: number, category: string | null) => Promise<void>;
   start: (index: number) => Promise<void>;
   forget: (index: number) => Promise<void>;
   delete: (index: number) => Promise<void>;

--- a/crates/librqbit/webui/src/components/CardLayout.tsx
+++ b/crates/librqbit/webui/src/components/CardLayout.tsx
@@ -17,6 +17,7 @@ import {
   isTorrentVisible,
 } from "../helper/torrentFilters";
 import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts";
+import { CategoryFilterSelect } from "./CategoryFilterSelect";
 
 const DEFAULT_SORT_COLUMN: TorrentSortColumn = "id";
 const DEFAULT_SORT_DIRECTION: SortDirection = "desc";
@@ -29,6 +30,7 @@ export const CardLayout = (props: {
   const setSearchQuery = useUIStore((state) => state.setSearchQuery);
   const statusFilter = useUIStore((state) => state.statusFilter);
   const setStatusFilter = useUIStore((state) => state.setStatusFilter);
+  const categoryFilter = useUIStore((state) => state.categoryFilter);
 
   // Keyboard shortcuts (Ctrl+A, Ctrl+F, Escape)
   useKeyboardShortcuts();
@@ -76,12 +78,15 @@ export const CardLayout = (props: {
   const filteredTorrents = useMemo(() => {
     if (!props.torrents) return null;
     return [...props.torrents]
-      .filter((t) => isTorrentVisible(t, normalizedQuery, statusFilter))
+      .filter((t) =>
+        isTorrentVisible(t, normalizedQuery, statusFilter, categoryFilter),
+      )
       .sort((a, b) => compareTorrents(a, b, sortColumn, sortDirection));
   }, [
     props.torrents,
     normalizedQuery,
     statusFilter,
+    categoryFilter,
     sortColumn,
     sortDirection,
   ]);
@@ -137,6 +142,9 @@ export const CardLayout = (props: {
             ),
           )}
         </select>
+
+        {/* Category filter */}
+        <CategoryFilterSelect className="py-1.5 sm:py-2 px-2 sm:px-3 text-sm bg-surface border border-divider rounded-lg focus:outline-none focus:border-primary" />
 
         {/* Sort dropdown */}
         <select

--- a/crates/librqbit/webui/src/components/CategoryEditor.tsx
+++ b/crates/librqbit/webui/src/components/CategoryEditor.tsx
@@ -1,0 +1,58 @@
+import { useContext, useEffect, useState, useMemo } from "react";
+import { APIContext } from "../context";
+import { useTorrentStore } from "../stores/torrentStore";
+import { useErrorStore } from "../stores/errorStore";
+import { ErrorDetails } from "../api-types";
+
+// Inline editor for a torrent's category, usable after the torrent was created.
+// Uses a dropdown populated from the server's configured categories.
+export const CategoryEditor: React.FC<{
+  torrentId: number;
+  category: string | null | undefined;
+}> = ({ torrentId, category }) => {
+  const API = useContext(APIContext);
+  const refreshTorrents = useTorrentStore((state) => state.refreshTorrents);
+  const setCloseableError = useErrorStore((state) => state.setCloseableError);
+
+  const [saving, setSaving] = useState(false);
+  const [categories, setCategories] = useState<string[]>([]);
+
+  useEffect(() => {
+    API.listCategories()
+      .then((cats) => setCategories(cats))
+      .catch(() => setCategories([]));
+  }, [API]);
+
+  const save = async (newCategory: string) => {
+    setSaving(true);
+    try {
+      await API.updateCategory(torrentId, newCategory || null);
+      refreshTorrents();
+    } catch (e) {
+      setCloseableError({
+        text: "Error updating category",
+        details: e as ErrorDetails,
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <span className="inline-flex items-center gap-2">
+      <select
+        value={category ?? ""}
+        onChange={(e) => save(e.target.value)}
+        disabled={saving}
+        className="border border-divider rounded bg-transparent px-1 py-0.5 text-sm focus:outline-none focus:border-primary disabled:opacity-50"
+      >
+        <option value="">None</option>
+        {categories.map((cat) => (
+          <option key={cat} value={cat}>
+            {cat}
+          </option>
+        ))}
+      </select>
+    </span>
+  );
+};

--- a/crates/librqbit/webui/src/components/CategoryFilterSelect.tsx
+++ b/crates/librqbit/webui/src/components/CategoryFilterSelect.tsx
@@ -1,0 +1,42 @@
+import { useContext, useEffect, useState } from "react";
+import { APIContext } from "../context";
+import { useUIStore } from "../stores/uiStore";
+import {
+  CATEGORY_FILTER_ALL,
+  CATEGORY_FILTER_NONE,
+} from "../helper/torrentFilters";
+
+// A dropdown to filter the torrent list by category.
+// Populated from the server's configured categories, with "All" and "Uncategorized" options.
+// Filtering itself is done client-side via isTorrentVisible.
+export const CategoryFilterSelect: React.FC<{ className?: string }> = ({
+  className,
+}) => {
+  const API = useContext(APIContext);
+  const categoryFilter = useUIStore((state) => state.categoryFilter);
+  const setCategoryFilter = useUIStore((state) => state.setCategoryFilter);
+  const [categories, setCategories] = useState<string[]>([]);
+
+  useEffect(() => {
+    API.listCategories()
+      .then((cats) => setCategories(cats))
+      .catch(() => setCategories([]));
+  }, [API]);
+
+  return (
+    <select
+      value={categoryFilter}
+      onChange={(e) => setCategoryFilter(e.target.value)}
+      title="Filter by category"
+      className={className}
+    >
+      <option value={CATEGORY_FILTER_ALL}>All categories</option>
+      <option value={CATEGORY_FILTER_NONE}>Uncategorized</option>
+      {categories.map((c) => (
+        <option key={c} value={c}>
+          {c}
+        </option>
+      ))}
+    </select>
+  );
+};

--- a/crates/librqbit/webui/src/components/TorrentCardContent.tsx
+++ b/crates/librqbit/webui/src/components/TorrentCardContent.tsx
@@ -55,6 +55,11 @@ export const TorrentCardContent: React.FC<{
             </div>
             <div className="text-left text-sm sm:text-base lg:text-lg text-ellipsis break-all line-clamp-2 sm:line-clamp-none">
               {torrent.name}
+              {torrent.category && (
+                <span className="ml-1.5 px-1.5 py-0.5 text-xs bg-secondary/20 text-secondary rounded">
+                  {torrent.category}
+                </span>
+              )}
             </div>
           </div>
           {error ? (

--- a/crates/librqbit/webui/src/components/compact/ActionBar.tsx
+++ b/crates/librqbit/webui/src/components/compact/ActionBar.tsx
@@ -19,6 +19,7 @@ import {
   StatusFilter,
   STATUS_FILTER_LABELS,
 } from "../../helper/torrentFilters";
+import { CategoryFilterSelect } from "../CategoryFilterSelect";
 
 interface ActionBarProps {
   // When true, hides search/filter/selection count (for use in modal)
@@ -34,7 +35,6 @@ export const ActionBar: React.FC<ActionBarProps> = ({ hideFilters }) => {
   const torrents = useTorrentStore((state) => state.torrents);
   const refreshTorrents = useTorrentStore((state) => state.refreshTorrents);
   const setCloseableError = useErrorStore((state) => state.setCloseableError);
-
   const [disabled, setDisabled] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [torrentsToDelete, setTorrentsToDelete] = useState<
@@ -169,6 +169,9 @@ export const ActionBar: React.FC<ActionBarProps> = ({ hideFilters }) => {
               ),
             )}
           </select>
+
+          {/* Category filter */}
+          <CategoryFilterSelect className="py-1 px-2 text-sm bg-surface border border-divider rounded focus:outline-none focus:border-primary" />
 
           {/* Search input */}
           <div className="relative">

--- a/crates/librqbit/webui/src/components/compact/OverviewTab.tsx
+++ b/crates/librqbit/webui/src/components/compact/OverviewTab.tsx
@@ -7,6 +7,7 @@ import {
 import { formatBytes } from "../../helper/formatBytes";
 import { getCompletionETA } from "../../helper/getCompletionETA";
 import { PlaylistLink } from "../buttons/PlaylistButton";
+import { CategoryEditor } from "../CategoryEditor";
 import { PiecesCanvas } from "./PiecesCanvas";
 
 interface OverviewTabProps {
@@ -162,6 +163,17 @@ export const OverviewTab: React.FC<OverviewTabProps> = ({ torrent }) => {
         </div>
         <div className="truncate">
           <LV label="Output" value={torrent.output_folder} mono />
+        </div>
+        <div>
+          <LV
+            label="Category"
+            value={
+              <CategoryEditor
+                torrentId={torrent.id}
+                category={torrent.category}
+              />
+            }
+          />
         </div>
         <div className="truncate">
           <LV

--- a/crates/librqbit/webui/src/components/compact/TorrentTable.tsx
+++ b/crates/librqbit/webui/src/components/compact/TorrentTable.tsx
@@ -77,6 +77,7 @@ export const TorrentTable: React.FC<TorrentTableProps> = ({
   const clearSelection = useUIStore((state) => state.clearSelection);
   const searchQuery = useUIStore((state) => state.searchQuery);
   const statusFilter = useUIStore((state) => state.statusFilter);
+  const categoryFilter = useUIStore((state) => state.categoryFilter);
 
   const normalizedQuery = searchQuery.toLowerCase().trim();
 
@@ -103,7 +104,9 @@ export const TorrentTable: React.FC<TorrentTableProps> = ({
     if (!torrents) return null;
 
     return [...torrents]
-      .filter((t) => isTorrentVisible(t, normalizedQuery, statusFilter))
+      .filter((t) =>
+        isTorrentVisible(t, normalizedQuery, statusFilter, categoryFilter),
+      )
       .sort((a, b) => {
         const aVal = getTableSortValue(a, sortColumn);
         const bVal = getTableSortValue(b, sortColumn);
@@ -113,7 +116,14 @@ export const TorrentTable: React.FC<TorrentTableProps> = ({
             : (aVal as number) - (bVal as number);
         return sortDirection === "asc" ? cmp : -cmp;
       });
-  }, [torrents, normalizedQuery, statusFilter, sortColumn, sortDirection]);
+  }, [
+    torrents,
+    normalizedQuery,
+    statusFilter,
+    categoryFilter,
+    sortColumn,
+    sortDirection,
+  ]);
 
   // Compute visible IDs for keyboard navigation
   const visibleTorrentIds = useMemo(() => {

--- a/crates/librqbit/webui/src/components/compact/TorrentTableRow.tsx
+++ b/crates/librqbit/webui/src/components/compact/TorrentTableRow.tsx
@@ -94,6 +94,11 @@ const TorrentTableRowUnmemoized: React.FC<TorrentTableRowProps> = ({
           <td className={cellBase}>
             <div className="truncate" title={name}>
               {name || "Loading..."}
+              {torrent.category && (
+                <span className="ml-1.5 px-1 py-0.5 text-xs bg-secondary/20 text-secondary rounded">
+                  {torrent.category}
+                </span>
+              )}
             </div>
             {error && (
               <div className="truncate text-sm text-error" title={error}>

--- a/crates/librqbit/webui/src/components/modal/FileSelectionModal.tsx
+++ b/crates/librqbit/webui/src/components/modal/FileSelectionModal.tsx
@@ -13,6 +13,7 @@ import { FormInput } from "../forms/FormInput";
 import { Form } from "../forms/Form";
 import { FileListInput } from "../FileListInput";
 import { useTorrentStore } from "../../stores/torrentStore";
+import { useUIStore } from "../../stores/uiStore";
 
 export const FileSelectionModal = (props: {
   onHide: () => void;
@@ -35,9 +36,14 @@ export const FileSelectionModal = (props: {
   const [unpopularTorrent, setUnpopularTorrent] = useState(false);
   const [outputFolder, setOutputFolder] = useState<string>("");
   const refreshTorrents = useTorrentStore((state) => state.refreshTorrents);
+  const [categories, setCategories] = useState<string[]>([]);
+  const [category, setCategory] = useState<string>("");
   const API = useContext(APIContext);
 
   useEffect(() => {
+    API.listCategories()
+      .then((cats) => setCategories(cats))
+      .catch(() => setCategories([]));
     setSelectedFiles(
       new Set(
         listTorrentResponse?.details.files.flatMap((file, idx) => {
@@ -85,6 +91,7 @@ export const FileSelectionModal = (props: {
       only_files: allSelected ? undefined : Array.from(selectedFiles),
       initial_peers: initialPeers,
       output_folder: outputFolder,
+      category: category || undefined,
     };
     if (unpopularTorrent) {
       opts.peer_opts = {
@@ -120,6 +127,23 @@ export const FileSelectionModal = (props: {
             value={outputFolder}
             onChange={(e) => setOutputFolder(e.target.value)}
           />
+
+          {categories.length > 0 && (
+            <Fieldset label="Category">
+              <select
+                value={category}
+                onChange={(e) => setCategory(e.target.value)}
+                className="py-1 px-2 text-sm bg-surface border border-divider rounded focus:outline-none focus:border-primary"
+              >
+                <option value="">None</option>
+                {categories.map((cat) => (
+                  <option key={cat} value={cat}>
+                    {cat}
+                  </option>
+                ))}
+              </select>
+            </Fieldset>
+          )}
 
           <Fieldset>
             <FileListInput

--- a/crates/librqbit/webui/src/context.tsx
+++ b/crates/librqbit/webui/src/context.tsx
@@ -5,6 +5,7 @@ export const APIContext = createContext<RqbitAPI>({
   listTorrents: () => {
     throw new Error("Function not implemented.");
   },
+  listCategories: () => Promise.resolve([]),
   getTorrentDetails: () => {
     throw new Error("Function not implemented.");
   },
@@ -18,6 +19,9 @@ export const APIContext = createContext<RqbitAPI>({
     throw new Error("Function not implemented.");
   },
   updateOnlyFiles: () => {
+    throw new Error("Function not implemented.");
+  },
+  updateCategory: () => {
     throw new Error("Function not implemented.");
   },
   pause: () => {

--- a/crates/librqbit/webui/src/helper/torrentFilters.ts
+++ b/crates/librqbit/webui/src/helper/torrentFilters.ts
@@ -22,6 +22,23 @@ export type StatusFilter =
   | "paused"
   | "error";
 
+// Category filter sentinels. A category name is any other string.
+export const CATEGORY_FILTER_ALL = ""; // show all categories (default)
+// Sentinel for "torrents without a category". Uses a control char so it can't
+// collide with a real user-assigned category name.
+export const CATEGORY_FILTER_NONE = "\u0000__uncategorized__";
+
+// The set of category names present in the given torrents, sorted alphabetically.
+export function availableCategories(
+  torrents: TorrentListItem[] | null,
+): string[] {
+  const set = new Set<string>();
+  for (const t of torrents ?? []) {
+    if (t.category) set.add(t.category);
+  }
+  return Array.from(set).sort((a, b) => a.localeCompare(b));
+}
+
 // Sort column display labels
 export const SORT_COLUMN_LABELS: Record<TorrentSortColumn, string> = {
   id: "ID",
@@ -117,11 +134,26 @@ export function matchesStatus(
   }
 }
 
+// Check if torrent matches category filter
+export function matchesCategory(t: TorrentListItem, filter: string): boolean {
+  if (filter === CATEGORY_FILTER_ALL) return true;
+  const category = t.category ?? null;
+  if (filter === CATEGORY_FILTER_NONE) {
+    return category == null || category === "";
+  }
+  return category === filter;
+}
+
 // Combined visibility check
 export function isTorrentVisible(
   t: TorrentListItem,
   searchQuery: string,
   statusFilter: StatusFilter,
+  categoryFilter: string = CATEGORY_FILTER_ALL,
 ): boolean {
-  return matchesSearch(t.name, searchQuery) && matchesStatus(t, statusFilter);
+  return (
+    matchesSearch(t.name, searchQuery) &&
+    matchesStatus(t, statusFilter) &&
+    matchesCategory(t, categoryFilter)
+  );
 }

--- a/crates/librqbit/webui/src/hooks/useKeyboardShortcuts.ts
+++ b/crates/librqbit/webui/src/hooks/useKeyboardShortcuts.ts
@@ -15,6 +15,7 @@ export function useKeyboardShortcuts(actions?: KeyboardShortcutActions) {
   const torrents = useTorrentStore((state) => state.torrents);
   const searchQuery = useUIStore((state) => state.searchQuery);
   const statusFilter = useUIStore((state) => state.statusFilter);
+  const categoryFilter = useUIStore((state) => state.categoryFilter);
   const selectAll = useUIStore((state) => state.selectAll);
   const clearSelection = useUIStore((state) => state.clearSelection);
   const selectedTorrentIds = useUIStore((state) => state.selectedTorrentIds);
@@ -44,7 +45,14 @@ export function useKeyboardShortcuts(actions?: KeyboardShortcutActions) {
         if (torrents) {
           const normalizedQuery = searchQuery.toLowerCase();
           const visibleIds = torrents
-            .filter((t) => isTorrentVisible(t, normalizedQuery, statusFilter))
+            .filter((t) =>
+              isTorrentVisible(
+                t,
+                normalizedQuery,
+                statusFilter,
+                categoryFilter,
+              ),
+            )
             .map((t) => t.id);
           selectAll(visibleIds);
         }
@@ -86,6 +94,7 @@ export function useKeyboardShortcuts(actions?: KeyboardShortcutActions) {
     torrents,
     searchQuery,
     statusFilter,
+    categoryFilter,
     selectAll,
     clearSelection,
     selectedTorrentIds,

--- a/crates/librqbit/webui/src/http-api.ts
+++ b/crates/librqbit/webui/src/http-api.ts
@@ -108,8 +108,25 @@ export const API: RqbitAPI & { getVersion: () => Promise<string> } = {
   listTorrents: (opts?: {
     withStats?: boolean;
   }): Promise<ListTorrentsResponse> => {
-    const url = opts?.withStats ? "/torrents?with_stats=true" : "/torrents";
+    const params = new URLSearchParams();
+    if (opts?.withStats) params.set("with_stats", "true");
+    const qs = params.toString();
+    const url = qs ? `/torrents?${qs}` : "/torrents";
     return makeRequest("GET", url);
+  },
+  listCategories: (): Promise<string[]> => {
+    return makeRequest("GET", "/categories");
+  },
+  updateCategory: (index: number, category: string | null): Promise<void> => {
+    let url = `/torrents/${index}/update_category`;
+    return makeRequest(
+      "POST",
+      url,
+      {
+        category: category,
+      },
+      true,
+    );
   },
   getTorrentDetails: (index: number): Promise<TorrentDetails> => {
     return makeRequest("GET", `/torrents/${index}`);
@@ -143,6 +160,9 @@ export const API: RqbitAPI & { getVersion: () => Promise<string> } = {
     }
     if (opts?.output_folder) {
       url += `&output_folder=${opts.output_folder}`;
+    }
+    if (opts?.category) {
+      url += `&category=${opts.category}`;
     }
     if (typeof data === "string") {
       url += "&is_url=true";

--- a/crates/librqbit/webui/src/mock-api.ts
+++ b/crates/librqbit/webui/src/mock-api.ts
@@ -313,6 +313,8 @@ function generateTorrentListItem(
     info_hash: generateInfoHash(id),
     name: generateTorrentName(id),
     output_folder: `/downloads/torrent_${id}`,
+    category:
+      id % 2 === 0 ? (id % 2 === 0 ? "diskimages" : "archive.org") : null,
     total_pieces: totalPieces,
   };
 
@@ -409,6 +411,10 @@ export const MockAPI: RqbitAPI & { getVersion: () => Promise<string> } = {
     }
 
     return { torrents };
+  },
+
+  listCategories: (): Promise<string[]> => {
+    return Promise.resolve(["diskimages", "archive.org"]);
   },
 
   getTorrentDetails: async (index: number): Promise<TorrentDetails> => {
@@ -543,6 +549,10 @@ export const MockAPI: RqbitAPI & { getVersion: () => Promise<string> } = {
   },
 
   updateOnlyFiles: async (): Promise<void> => {
+    await new Promise((r) => setTimeout(r, 100));
+  },
+
+  updateCategory: async (): Promise<void> => {
     await new Promise((r) => setTimeout(r, 100));
   },
 

--- a/crates/librqbit/webui/src/rqbit-web.tsx
+++ b/crates/librqbit/webui/src/rqbit-web.tsx
@@ -6,6 +6,7 @@ import { customSetInterval } from "./helper/customSetInterval";
 import { LogStreamModal } from "./components/modal/LogStreamModal";
 import { Header } from "./components/Header";
 import { useTorrentStore } from "./stores/torrentStore";
+import { useUIStore } from "./stores/uiStore";
 import { useErrorStore } from "./stores/errorStore";
 import { AlertModal } from "./components/modal/AlertModal";
 import { useStatsStore } from "./stores/statsStore";
@@ -43,7 +44,9 @@ export const RqbitWebUI = (props: {
   const refreshTorrents = async (): Promise<number> => {
     setTorrentsLoading(true);
     try {
-      const response = await API.listTorrents({ withStats: true });
+      const response = await API.listTorrents({
+        withStats: true,
+      });
       setTorrents(response.torrents);
       setOtherError(null);
 

--- a/crates/librqbit/webui/src/stores/uiStore.ts
+++ b/crates/librqbit/webui/src/stores/uiStore.ts
@@ -3,6 +3,7 @@ import {
   TorrentSortColumn,
   SortDirection,
   StatusFilter,
+  CATEGORY_FILTER_ALL,
 } from "../helper/torrentFilters";
 
 const LARGE_SCREEN_BREAKPOINT = 1024;
@@ -21,6 +22,11 @@ export interface UIStore {
 
   statusFilter: StatusFilter;
   setStatusFilter: (filter: StatusFilter) => void;
+
+  categoryFilter: string;
+  setCategoryFilter: (category: string) => void;
+  categories: string[];
+  setCategories: (categories: string[]) => void;
 
   selectedTorrentIds: Set<number>;
   lastSelectedId: number | null;
@@ -56,6 +62,13 @@ export const useUIStore = create<UIStore>((set, get) => ({
   setStatusFilter: (filter) => {
     set({ statusFilter: filter });
   },
+
+  categoryFilter: CATEGORY_FILTER_ALL,
+  setCategoryFilter: (filter) => {
+    set({ categoryFilter: filter });
+  },
+  categories: [],
+  setCategories: (categories) => set({ categories }),
 
   selectedTorrentIds: new Set<number>(),
   lastSelectedId: null,

--- a/crates/rqbit/src/main.rs
+++ b/crates/rqbit/src/main.rs
@@ -294,6 +294,10 @@ struct Opts {
     /// Disable trackers (for debugging DHT, LSD and --initial-peers)
     #[arg(long = "disable-trackers", env = "RQBIT_TRACKERS_DISABLE")]
     disable_trackers: bool,
+
+    /// Categories for tagging torrents. Can be specified multiple times.
+    #[arg(long = "category", env = "RQBIT_CATEGORY", value_delimiter = ',')]
+    categories: Vec<String>,
 }
 
 #[derive(Parser)]
@@ -691,6 +695,7 @@ async fn async_main(mut opts: Opts, cancel: CancellationToken) -> anyhow::Result
         runtime_worker_threads: Some(opts.max_blocking_threads as usize),
         ipv4_only: opts.ipv4_only,
         client_name_and_version: None,
+        categories: opts.categories.clone(),
     };
 
     #[allow(clippy::needless_update)]


### PR DESCRIPTION
closes #267

- each torrent can be associated with a category
- categories must be defined using the cli or env vars
- in the webui categories can be assigned when adding torrent or on a later stage in the details view
- the torrent list can be filtered by categories
- the api also supports filtering by categories, so external application can filter for only their torrents

disclamer: this was implemented using ai