### PR TITLE
Add opt-in SessionOptions::trust_fastresume to skip the startup rechecka

### DIFF
--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -130,6 +130,7 @@ pub struct Session {
     peer_opts: PeerConnectionOptions,
     default_storage_factory: Option<BoxStorageFactory>,
     persistence: Option<Arc<dyn SessionPersistenceStore>>,
+    pub(crate) trust_fastresume: bool,
     trackers: HashSet<url::Url>,
 
     lsd: Option<LocalServiceDiscovery>,
@@ -430,6 +431,12 @@ pub struct SessionOptions {
     /// Enable fastresume, to restore state quickly after restart.
     pub fastresume: bool,
 
+    /// With `fastresume`, trust a valid persisted piece bitfield and skip the
+    /// on-startup sampling recheck (which otherwise reads and hashes at least
+    /// one piece per file for every torrent on every launch). A torrent that
+    /// previously errored is still fully rechecked.
+    pub trust_fastresume: bool,
+
     /// Turn on to dump session contents into a file periodically, so that on next start
     /// all remembered torrents will continue where they left off.
     pub persistence: Option<SessionPersistenceConfig>,
@@ -488,6 +495,7 @@ impl Default for SessionOptions {
             bind_device_name: None,
             disable_trackers: false,
             fastresume: false,
+            trust_fastresume: false,
             persistence: None,
             peer_id: None,
             listen: None,
@@ -779,6 +787,7 @@ impl Session {
 
             let session = Arc::new(Self {
                 persistence,
+                trust_fastresume: opts.trust_fastresume,
                 bitv_factory,
                 peer_id,
                 dht,

--- a/crates/librqbit/src/torrent_state/initializing.rs
+++ b/crates/librqbit/src/torrent_state/initializing.rs
@@ -86,6 +86,7 @@ impl TorrentStateInitializing {
         &self,
         bitv_factory: &dyn BitVFactory,
         have_pieces: Option<Box<dyn BitV>>,
+        trust: bool,
     ) -> Option<Box<dyn BitV>> {
         let hp = have_pieces?;
         let actual = hp.as_bytes().len();
@@ -97,6 +98,15 @@ impl TorrentStateInitializing {
                 "the bitfield loaded isn't of correct length, ignoring it, will do full check"
             );
             return None;
+        }
+
+        // With `trust_fastresume`, a length-valid persisted bitfield is taken at
+        // face value: skip the sampling recheck below (which reads and hashes at
+        // least one piece per file). On-disk corruption is still caught later at
+        // the per-piece level while seeding/downloading.
+        if trust {
+            trace!("trust_fastresume set, trusting the persisted bitfield without rechecking");
+            return Some(hp);
         }
 
         let is_broken = self
@@ -187,13 +197,9 @@ impl TorrentStateInitializing {
 
     pub async fn check(&self) -> anyhow::Result<TorrentStatePaused> {
         let id: TorrentIdOrHash = self.shared.info_hash.into();
-        let bitv_factory = self
-            .shared
-            .session
-            .upgrade()
-            .context("session is dead")?
-            .bitv_factory
-            .clone();
+        let session = self.shared.session.upgrade().context("session is dead")?;
+        let bitv_factory = session.bitv_factory.clone();
+        let trust_fastresume = session.trust_fastresume;
         let have_pieces = if self.previously_errored {
             if let Err(e) = bitv_factory.clear(id).await {
                 warn!(id=?self.shared.id, info_hash = ?self.shared.info_hash, error=?e, "error clearing bitfield");
@@ -206,7 +212,9 @@ impl TorrentStateInitializing {
                 .context("error loading have_pieces")?
         };
 
-        let have_pieces = self.validate_fastresume(&*bitv_factory, have_pieces).await;
+        let have_pieces = self
+            .validate_fastresume(&*bitv_factory, have_pieces, trust_fastresume)
+            .await;
 
         let have_pieces = match have_pieces {
             Some(h) => h,


### PR DESCRIPTION
### Problem

With `fastresume: true`, librqbit still re-verifies every restored torrent on
every session start. `TorrentStateInitializing::validate_fastresume` loads the
persisted piece bitfield and then, even when it is present and the correct
length, SHA-1-validates a sample of pieces: **at least one piece per file**,
plus a ~2% random sample of the rest.

For a large library of many-file torrents (music discographies, season packs
with hundreds of files each) the "≥1 piece per file" minimum alone forces
thousands of piece reads on every launch. On one user's Windows session this
was **~410s to restore 26 torrents** (22 complete and seeding), re-hashing data
it already had a valid bitfield for. Since `Session::new_with_opts` doesn't
return until every torrent is added and the checks contend for the disk, the
client is unusable until it finishes.

There's no way to opt out today: `paused` still checks, `list_only` skips
adding the torrent, and `concurrent_init_limit` only changes parallelism.

### Change

Add an opt-in `SessionOptions::trust_fastresume` (default `false`, so existing
behavior is unchanged). When it is set and `validate_fastresume` loads a
bitfield whose length matches `piece_bitfield_bytes()`, it trusts the bitfield
and returns immediately, skipping the sampling loop.

Safety is preserved for the risky cases:
- a **previously-errored** torrent still has its bitfield cleared and gets a
 full recheck (`have_pieces` is `None` before `validate_fastresume`);
- a **missing or wrong-length** bitfield still falls through to the full
  `initial_check`;
- on-disk corruption is still caught at the per-piece level while
  seeding/downloading.

This matches clients like qBittorrent/Transmission, which trust fast-resume
data on start and recheck only on explicit request.

### Testing

Ran against a real session of complete torrents with `trust_fastresume: true`:
the trust branch is taken for every restored torrent and `initial_check`
("Doing initial checksum validation…") never runs. With the flag `false`
(default), behavior is unchanged.