### PR TITLE
fix: bound read_chunk to the requested chunk when serving a piece

### DIFF
--- a/crates/librqbit/src/peer_connection.rs
+++ b/crates/librqbit/src/peer_connection.rs
@@ -433,7 +433,7 @@ impl<H: PeerConnectionHandler> PeerConnection<H> {
                             self.spawner
                                 .block_in_place_with_semaphore(|| {
                                     self.handler
-                                        .read_chunk(&chunk, &mut write_buf[preamble_len..])
+                                        .read_chunk(&chunk, &mut write_buf[preamble_len..full_len])
                                 })
                                 .await
                                 .map_err(Error::ReadChunk)?;


### PR DESCRIPTION
Fixes #635.

`full_len` is already computed from `chunk.size` one line above, and returned just below as the write length — but `read_chunk` is handed `&mut write_buf[preamble_len..]`, the whole remaining buffer.

`FileOps::read_chunk` fills whatever buffer it is given, advancing through `file_infos` until the buffer is exhausted. With an oversized buffer it walks past the requested chunk into subsequent files, and `pread_exact` fails on the first file that is not on disk:

```
error managing peer: error reading chunk: error reading 1 bytes, file_id: 16
```

On a complete torrent this is only a wasted read, since only `full_len` bytes are ever transmitted. On a **partially selected** torrent the unselected files do not exist, so serving any piece that is not in the final file fails and seeding cannot work.

8.1.1 avoided this by sizing the buffer before reading (`write_buf.resize(full_len, 0)`); the ring-buffer/vectored-I/O rework in 9.0.0 replaced `write_buf` with a fixed `Box<[u8; MAX_MSG_LEN]>` and the resize went away with it. This restores the same bound at the call site instead.

Verified `cargo check -p librqbit` is clean. Confirming the behaviour downstream: creating the absent file as a stub makes a previously failing selective-seed test pass, and this change fixes it without the stub.

Happy to adjust the approach if you'd prefer the bound applied inside `read_chunk` instead.