### PR TITLE
feat(peers): allow updating connection timeout

### DIFF
--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -1348,7 +1348,7 @@ impl Session {
                 storage_factory,
                 options: ManagedTorrentOptions {
                     force_tracker_interval: opts.force_tracker_interval,
-                    peer_connect_timeout: peer_opts.connect_timeout,
+                    peer_connect_timeout: RwLock::new(peer_opts.connect_timeout),
                     peer_read_write_timeout: peer_opts.read_write_timeout,
                     allow_overwrite: opts.overwrite,
                     output_folder,

--- a/crates/librqbit/src/torrent_state/live/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/mod.rs
@@ -485,7 +485,7 @@ impl TorrentStateLive {
         };
         let _token_guard = handler.cancel_token.clone().drop_guard();
         let options = PeerConnectionOptions {
-            connect_timeout: self.shared.options.peer_connect_timeout,
+            connect_timeout: self.shared.options.peer_connect_timeout(),
             read_write_timeout: self.shared.options.peer_read_write_timeout,
             ..Default::default()
         };
@@ -550,7 +550,7 @@ impl TorrentStateLive {
         let _token_guard = handler.cancel_token.clone().drop_guard();
 
         let options = PeerConnectionOptions {
-            connect_timeout: state.shared.options.peer_connect_timeout,
+            connect_timeout: state.shared.options.peer_connect_timeout(),
             read_write_timeout: state.shared.options.peer_read_write_timeout,
             ..Default::default()
         };

--- a/crates/librqbit/src/torrent_state/mod.rs
+++ b/crates/librqbit/src/torrent_state/mod.rs
@@ -110,7 +110,7 @@ pub(crate) struct ManagedTorrentLocked {
 #[derive(Default)]
 pub(crate) struct ManagedTorrentOptions {
     pub force_tracker_interval: Option<Duration>,
-    pub peer_connect_timeout: Option<Duration>,
+    pub(crate) peer_connect_timeout: RwLock<Option<Duration>>,
     pub peer_read_write_timeout: Option<Duration>,
     pub allow_overwrite: bool,
     pub output_folder: PathBuf,
@@ -119,6 +119,16 @@ pub(crate) struct ManagedTorrentOptions {
     pub peer_limit: Option<usize>,
     #[cfg(feature = "disable-upload")]
     pub _disable_upload: bool,
+}
+
+impl ManagedTorrentOptions {
+    pub(crate) fn peer_connect_timeout(&self) -> Option<Duration> {
+        *self.peer_connect_timeout.read()
+    }
+
+    pub(crate) fn set_peer_connect_timeout(&self, timeout: Option<Duration>) {
+        *self.peer_connect_timeout.write() = timeout;
+    }
 }
 
 impl ManagedTorrentOptions {
@@ -229,6 +239,16 @@ impl ManagedTorrent {
 
     pub fn shared(&self) -> &ManagedTorrentShared {
         &self.shared
+    }
+
+    /// Update the timeout used by future outgoing peer connection attempts.
+    /// Existing peer connections are not interrupted.
+    pub fn set_peer_connect_timeout(&self, timeout: Option<Duration>) {
+        self.shared.options.set_peer_connect_timeout(timeout);
+    }
+
+    pub fn peer_connect_timeout(&self) -> Option<Duration> {
+        self.shared.options.peer_connect_timeout()
     }
 
     /// The resolved on-disk folder this torrent's files are written under.
@@ -718,4 +738,23 @@ fn spawn_peer_adder(live: &Arc<TorrentStateLive>, mut peer_rx: PeerStream) {
             }
         },
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::ManagedTorrentOptions;
+
+    #[test]
+    fn peer_connect_timeout_can_be_updated_for_future_connections() {
+        let options = ManagedTorrentOptions::default();
+        assert_eq!(options.peer_connect_timeout(), None);
+
+        options.set_peer_connect_timeout(Some(Duration::from_secs(3)));
+        assert_eq!(options.peer_connect_timeout(), Some(Duration::from_secs(3)));
+
+        options.set_peer_connect_timeout(None);
+        assert_eq!(options.peer_connect_timeout(), None);
+    }
 }


### PR DESCRIPTION
## Summary

- store the per-torrent peer connection timeout behind an RwLock
- expose getter and setter methods on ManagedTorrent
- read the current timeout when starting each future outbound peer connection
- leave established peer connections untouched

## Motivation

Callers may want a short connection timeout during latency-sensitive startup, then allow slower peers more time if the torrent has not found sufficient throughput. Recreating the managed torrent loses useful state and existing peer connections. A runtime setter permits that adaptive strategy while limiting the change to future connection attempts.

## Testing

- cargo test -p librqbit peer_connect_timeout_can_be_updated_for_future_connections
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- integrated into Remux with a 1.2s fast timeout and a 3s patient-fallback timeout
- 12th Fail exhausted the 15s fast hedge, entered patient probing, started in 36.5s, and played 60s without a stall
- after restarting Remux, the persisted source resumed in 28.6s and played 60s without a stall