### PR TITLE
feat(streaming): make lookahead configurable per stream

### DIFF
--- a/crates/librqbit/src/api.rs
+++ b/crates/librqbit/src/api.rs
@@ -512,8 +512,18 @@ impl Api {
     }
 
     pub async fn api_stream(&self, idx: TorrentIdOrHash, file_id: usize) -> Result<FileStream> {
+        self.api_stream_with_options(idx, file_id, Default::default())
+            .await
+    }
+
+    pub async fn api_stream_with_options(
+        &self,
+        idx: TorrentIdOrHash,
+        file_id: usize,
+        options: crate::FileStreamOptions,
+    ) -> Result<FileStream> {
         let mgr = self.mgr_handle(idx)?;
-        Ok(mgr.stream(file_id).await?)
+        Ok(mgr.stream_with_options(file_id, options).await?)
     }
 }
 

--- a/crates/librqbit/src/http_api/handlers/streaming.rs
+++ b/crates/librqbit/src/http_api/handlers/streaming.rs
@@ -2,7 +2,7 @@ use std::{io::SeekFrom, sync::Arc};
 
 use anyhow::Context;
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     response::IntoResponse,
 };
 use bytes::Bytes;
@@ -25,13 +25,30 @@ pub struct StreamPathParams {
     _filename: Option<Arc<str>>,
 }
 
+#[derive(Default, Deserialize)]
+pub struct StreamQueryParams {
+    lookahead_bytes: Option<u64>,
+}
+
 pub async fn h_torrent_stream_file(
     State(state): State<ApiState>,
     Path(StreamPathParams { id, file_id, .. }): Path<StreamPathParams>,
+    Query(query): Query<StreamQueryParams>,
     headers: http::HeaderMap,
 ) -> Result<impl IntoResponse> {
     trace!(?id, ?file_id, "acquiring stream");
-    let mut stream = state.api.api_stream(id, file_id).await?;
+    let mut options = crate::FileStreamOptions::default();
+    if let Some(lookahead_bytes) = query.lookahead_bytes {
+        if lookahead_bytes == 0 {
+            return Err(anyhow::anyhow!("lookahead_bytes must be positive"))
+                .with_status(StatusCode::BAD_REQUEST);
+        }
+        options.lookahead_bytes = lookahead_bytes;
+    }
+    let mut stream = state
+        .api
+        .api_stream_with_options(id, file_id, options)
+        .await?;
     let mut status = StatusCode::OK;
     let mut output_headers = HeaderMap::new();
     output_headers.insert("Accept-Ranges", HeaderValue::from_static("bytes"));

--- a/crates/librqbit/src/lib.rs
+++ b/crates/librqbit/src/lib.rs
@@ -97,8 +97,8 @@ pub use session::{
 };
 pub use stream_connect::ConnectionOptions;
 pub use torrent_state::{
-    ManagedTorrent, ManagedTorrentShared, ManagedTorrentState, TorrentMetadata, TorrentStats,
-    TorrentStatsState,
+    FileStreamOptions, ManagedTorrent, ManagedTorrentShared, ManagedTorrentState, TorrentMetadata,
+    TorrentStats, TorrentStatsState,
 };
 pub use type_aliases::FileInfos;
 

--- a/crates/librqbit/src/torrent_state/mod.rs
+++ b/crates/librqbit/src/torrent_state/mod.rs
@@ -53,7 +53,7 @@ use initializing::TorrentStateInitializing;
 
 use self::paused::TorrentStatePaused;
 pub use self::stats::{TorrentStats, TorrentStatsState};
-pub use self::streaming::FileStream;
+pub use self::streaming::{FileStream, FileStreamOptions};
 
 // State machine transitions.
 //

--- a/crates/librqbit/src/torrent_state/streaming.rs
+++ b/crates/librqbit/src/torrent_state/streaming.rs
@@ -25,14 +25,28 @@ use super::{ManagedTorrentHandle, TorrentMetadata};
 
 type StreamId = usize;
 
-// 32 mb lookahead by default.
-const PER_STREAM_BUF_DEFAULT: u64 = 32 * 1024 * 1024;
+/// Default number of bytes prioritized ahead of a streaming reader.
+pub const DEFAULT_STREAM_LOOKAHEAD_BYTES: u64 = 32 * 1024 * 1024;
+
+#[derive(Debug, Clone, Copy)]
+pub struct FileStreamOptions {
+    pub lookahead_bytes: u64,
+}
+
+impl Default for FileStreamOptions {
+    fn default() -> Self {
+        Self {
+            lookahead_bytes: DEFAULT_STREAM_LOOKAHEAD_BYTES,
+        }
+    }
+}
 
 struct StreamState {
     file_id: usize,
     file_len: u64,
     file_abs_offset: u64,
     position: u64,
+    lookahead_bytes: u64,
     waker: Option<Waker>,
 }
 
@@ -43,7 +57,9 @@ impl StreamState {
 
     fn queue<'a>(&self, lengths: &'a Lengths) -> impl Iterator<Item = ValidPieceIndex> + use<'a> {
         let start = self.file_abs_offset + self.position;
-        let end = (start + PER_STREAM_BUF_DEFAULT).min(self.file_abs_offset + self.file_len);
+        let end = start
+            .saturating_add(self.lookahead_bytes)
+            .min(self.file_abs_offset + self.file_len);
         let dpl = lengths.default_piece_length();
         let start_id = (start / dpl as u64).try_into().unwrap();
         let end_id = end.div_ceil(dpl as u64).try_into().unwrap();
@@ -335,6 +351,19 @@ impl ManagedTorrent {
     }
 
     pub async fn stream(self: Arc<Self>, file_id: usize) -> anyhow::Result<FileStream> {
+        self.stream_with_options(file_id, FileStreamOptions::default())
+            .await
+    }
+
+    pub async fn stream_with_options(
+        self: Arc<Self>,
+        file_id: usize,
+        options: FileStreamOptions,
+    ) -> anyhow::Result<FileStream> {
+        anyhow::ensure!(
+            options.lookahead_bytes > 0,
+            "stream lookahead must be positive"
+        );
         let metadata = self
             .metadata
             .load_full()
@@ -364,6 +393,7 @@ impl ManagedTorrent {
             StreamState {
                 file_id,
                 position: 0,
+                lookahead_bytes: options.lookahead_bytes,
                 waker: None,
                 file_len: fd_len,
                 file_abs_offset: fd_offset,
@@ -397,5 +427,31 @@ impl FileStream {
 
     pub fn len(&self) -> u64 {
         self.file_len
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use librqbit_core::lengths::Lengths;
+
+    use super::StreamState;
+
+    #[test]
+    fn stream_queue_uses_the_configured_lookahead() {
+        let lengths = Lengths::new(1024 * 1024, 64 * 1024).unwrap();
+        let state = StreamState {
+            file_id: 0,
+            file_len: 1024 * 1024,
+            file_abs_offset: 0,
+            position: 128 * 1024,
+            lookahead_bytes: 128 * 1024,
+            waker: None,
+        };
+
+        let queued = state
+            .queue(&lengths)
+            .map(|piece| piece.get())
+            .collect::<Vec<_>>();
+        assert_eq!(queued, vec![2, 3]);
     }
 }


### PR DESCRIPTION
## Summary

- add a public FileStreamOptions type with configurable lookahead_bytes
- preserve the existing 32 MiB behavior for callers using stream() or api_stream()
- add an optional lookahead_bytes query parameter to the HTTP streaming endpoint
- reject a zero-byte lookahead as an invalid request

## Motivation

Streaming clients sometimes issue small, concurrent range probes before choosing a source. Applying the fixed 32 MiB priority window to every probe can prioritize substantially more data than the caller needs and create avoidable contention. This lets each stream request bound its own lookahead while retaining the current default for existing users.

## Testing

- cargo test -p librqbit stream_queue_uses_the_configured_lookahead
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- integrated into Remux against rqbit 9 and exercised through its browser playback flow
- uncached 1080p playback: The Shawshank Redemption started in 20.2s and played 60s without a stall
- uncached patient-fallback playback: 12th Fail started in 36.5s and played 60s without a stall
- Remux torrent proxy tests passed, including bounded finite-range forwarding