### PR TITLE
Fall back to a read-only handle on a Windows sharing violation

### DIFF
--- a/crates/librqbit/src/storage/filesystem/fs.rs
+++ b/crates/librqbit/src/storage/filesystem/fs.rs
@@ -16,6 +16,25 @@ use crate::storage::{StorageFactory, TorrentStorage};
 
 use super::opened_file::OpenedFile;
 
+/// Whether an open failed because another process holds the file.
+///
+/// Windows refuses an open whose access conflicts with the sharing mode an
+/// existing handle was created with. Asking for write access on a file another
+/// application opened with `FILE_SHARE_READ` is exactly that conflict.
+///
+/// `ERROR_SHARING_VIOLATION` (32) and `ERROR_LOCK_VIOLATION` (33) are the two
+/// this can surface as. Nothing equivalent happens on Unix, where an open
+/// handle does not restrict other opens, so the check is compiled out.
+#[cfg(windows)]
+fn is_sharing_violation(e: &std::io::Error) -> bool {
+    matches!(e.raw_os_error(), Some(32) | Some(33))
+}
+
+#[cfg(not(windows))]
+fn is_sharing_violation(_: &std::io::Error) -> bool {
+    false
+}
+
 #[derive(Default, Clone, Copy)]
 pub struct FilesystemStorageFactory {}
 
@@ -139,13 +158,42 @@ impl TorrentStorage for FilesystemStorage {
             };
             std::fs::create_dir_all(full_path.parent().context("bug: no parent")?)?;
             let f = if shared.options.allow_overwrite {
-                OpenOptions::new()
+                let opened = OpenOptions::new()
                     .create(true)
                     .truncate(false)
                     .read(true)
                     .write(true)
-                    .open(&full_path)
-                    .with_context(|| format!("error opening {full_path:?} in read/write mode"))?
+                    .open(&full_path);
+
+                match opened {
+                    Ok(f) => f,
+                    // Another process holds this file in a way that permits
+                    // reading but not writing. Seeding only ever reads, so
+                    // falling back to a read-only handle lets a completed
+                    // torrent be served instead of failing the whole add.
+                    //
+                    // A torrent that still has data to fetch will fail on the
+                    // first write instead, which is a narrower failure than
+                    // refusing to add it at all.
+                    Err(e) if is_sharing_violation(&e) => {
+                        warn!(
+                            path=?full_path,
+                            error=?e,
+                            "opening read/write failed because another process holds the file; \
+                             falling back to read-only. This torrent can be seeded but not written to."
+                        );
+                        OpenOptions::new().read(true).open(&full_path).with_context(|| {
+                            format!(
+                                "error opening {full_path:?} read-only after a sharing violation"
+                            )
+                        })?
+                    }
+                    Err(e) => {
+                        return Err(e).with_context(|| {
+                            format!("error opening {full_path:?} in read/write mode")
+                        });
+                    }
+                }
             } else {
                 // create_new does not seem to work with read(true), so calling this twice.
                 OpenOptions::new()


### PR DESCRIPTION
On Windows, a torrent whose files another application holds open cannot be
added at all — not even a completed one that would only ever be seeded.

```
error opening "...\ubuntu.iso" in read/write mode

Caused by:
    The process cannot access the file because it is being used by
    another process. (os error 32)
```

## Cause

`FilesystemStorage::init` opens every file read **and** write when
`allow_overwrite` is set:

```rust
let f = if shared.options.allow_overwrite {
    OpenOptions::new()
        .create(true)
        .truncate(false)
        .read(true)
        .write(true)
        .open(&full_path)
```

On Windows an open succeeds only if its requested access is compatible with the
sharing mode of every existing handle. Asking for **write** access on a file
another process opened with `FILE_SHARE_READ` is exactly that conflict — even
though reading it is permitted, and even though a complete torrent will only
ever be read.

A media player, indexer, backup agent or antivirus scanner holding a downloaded
file that way is enough to break the add.

## Fix

Retry read-only on a sharing violation, and log the degraded mode. `pread_exact`
is all seeding needs, so a completed torrent is served normally. A torrent with
data still to fetch fails on its first write instead of failing to be added,
which is a narrower failure.

Unix is unaffected: an open handle does not restrict other opens there, so
`is_sharing_violation` compiles to `false` and the path is unreachable.

## Verified on real hardware

Windows Server, x86, against 9.0.1, via a reproduction that holds the completed
file at a given share mode and then adds the torrent:

| Holder's share mode | Before | After |
| --- | --- | --- |
| `FILE_SHARE_READ` — reads permitted, writes refused | fails | **passes** |
| `share_mode(0)` — no sharing at all | fails | fails, as it must |

The second is not a regression and cannot be fixed: `share_mode(0)` refuses
every other open, read-only included. Its error text does change, from
`in read/write mode` to `read-only after a sharing violation`, which is how the
reproduction now asserts that the fallback actually ran.

Conflating those two share modes is why this went unconfirmed for a long time
downstream — the scenario usually described is the unfixable one.

## Notes

The reproduction lives in my own project rather than here, since it is
`#[cfg(windows)]` and I did not want to add a test your CI may not run. Happy
to port it if you would like it, in whatever shape suits.

Unrelated to #644, and based on `main` rather than that branch.
