### PR TITLE
feat(streaming): make per-stream lookahead window configurable

### DIFF
--- a/crates/librqbit/src/api.rs
+++ b/crates/librqbit/src/api.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     session_stats::snapshot::SessionStatsSnapshot,
     torrent_state::{
-        FileStream, ManagedTorrentHandle,
+        FileStream, FileStreamOptions, ManagedTorrentHandle,
         peer::stats::snapshot::{PeerStatsFilter, PeerStatsSnapshot},
     },
     type_aliases::BF,
@@ -512,8 +512,18 @@ impl Api {
     }
 
     pub async fn api_stream(&self, idx: TorrentIdOrHash, file_id: usize) -> Result<FileStream> {
+        self.api_stream_with_options(idx, file_id, FileStreamOptions::default())
+            .await
+    }
+
+    pub async fn api_stream_with_options(
+        &self,
+        idx: TorrentIdOrHash,
+        file_id: usize,
+        options: FileStreamOptions,
+    ) -> Result<FileStream> {
         let mgr = self.mgr_handle(idx)?;
-        Ok(mgr.stream(file_id).await?)
+        Ok(mgr.stream_with_options(file_id, options).await?)
     }
 }
 

--- a/crates/librqbit/src/http_api/handlers/streaming.rs
+++ b/crates/librqbit/src/http_api/handlers/streaming.rs
@@ -2,7 +2,7 @@ use std::{io::SeekFrom, sync::Arc};
 
 use anyhow::Context;
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     response::IntoResponse,
 };
 use bytes::Bytes;
@@ -13,7 +13,7 @@ use tracing::{debug, trace};
 
 use super::ApiState;
 use crate::{
-    WithStatus,
+    FileStreamOptions, WithStatus,
     api::{Result, TorrentIdOrHash},
 };
 
@@ -25,13 +25,30 @@ pub struct StreamPathParams {
     _filename: Option<Arc<str>>,
 }
 
+#[derive(Default, Deserialize)]
+pub struct StreamQueryParams {
+    lookahead_bytes: Option<u64>,
+}
+
 pub async fn h_torrent_stream_file(
     State(state): State<ApiState>,
     Path(StreamPathParams { id, file_id, .. }): Path<StreamPathParams>,
+    Query(query): Query<StreamQueryParams>,
     headers: http::HeaderMap,
 ) -> Result<impl IntoResponse> {
     trace!(?id, ?file_id, "acquiring stream");
-    let mut stream = state.api.api_stream(id, file_id).await?;
+    let options = match query.lookahead_bytes {
+        Some(0) => {
+            return Err(anyhow::anyhow!("lookahead_bytes must be positive"))
+                .with_status(StatusCode::BAD_REQUEST);
+        }
+        Some(lookahead_bytes) => FileStreamOptions { lookahead_bytes },
+        None => FileStreamOptions::default(),
+    };
+    let mut stream = state
+        .api
+        .api_stream_with_options(id, file_id, options)
+        .await?;
     let mut status = StatusCode::OK;
     let mut output_headers = HeaderMap::new();
     output_headers.insert("Accept-Ranges", HeaderValue::from_static("bytes"));

--- a/crates/librqbit/src/lib.rs
+++ b/crates/librqbit/src/lib.rs
@@ -97,8 +97,8 @@ pub use session::{
 };
 pub use stream_connect::ConnectionOptions;
 pub use torrent_state::{
-    ManagedTorrent, ManagedTorrentShared, ManagedTorrentState, TorrentMetadata, TorrentStats,
-    TorrentStatsState,
+    DEFAULT_STREAM_LOOKAHEAD_BYTES, FileStreamOptions, ManagedTorrent, ManagedTorrentShared,
+    ManagedTorrentState, TorrentMetadata, TorrentStats, TorrentStatsState,
 };
 pub use type_aliases::FileInfos;
 

--- a/crates/librqbit/src/torrent_state/mod.rs
+++ b/crates/librqbit/src/torrent_state/mod.rs
@@ -53,7 +53,7 @@ use initializing::TorrentStateInitializing;
 
 use self::paused::TorrentStatePaused;
 pub use self::stats::{TorrentStats, TorrentStatsState};
-pub use self::streaming::FileStream;
+pub use self::streaming::{DEFAULT_STREAM_LOOKAHEAD_BYTES, FileStream, FileStreamOptions};
 
 // State machine transitions.
 //

--- a/crates/librqbit/src/torrent_state/streaming.rs
+++ b/crates/librqbit/src/torrent_state/streaming.rs
@@ -25,14 +25,30 @@ use super::{ManagedTorrentHandle, TorrentMetadata};
 
 type StreamId = usize;
 
-// 32 mb lookahead by default.
-const PER_STREAM_BUF_DEFAULT: u64 = 32 * 1024 * 1024;
+/// Default number of bytes prioritized ahead of a streaming reader.
+pub const DEFAULT_STREAM_LOOKAHEAD_BYTES: u64 = 32 * 1024 * 1024;
+
+/// Options controlling how a single file stream prioritizes pieces.
+#[derive(Debug, Clone, Copy)]
+pub struct FileStreamOptions {
+    /// How many bytes to prioritize ahead of the current reader position.
+    pub lookahead_bytes: u64,
+}
+
+impl Default for FileStreamOptions {
+    fn default() -> Self {
+        Self {
+            lookahead_bytes: DEFAULT_STREAM_LOOKAHEAD_BYTES,
+        }
+    }
+}
 
 struct StreamState {
     file_id: usize,
     file_len: u64,
     file_abs_offset: u64,
     position: u64,
+    lookahead_bytes: u64,
     waker: Option<Waker>,
 }
 
@@ -43,7 +59,9 @@ impl StreamState {
 
     fn queue<'a>(&self, lengths: &'a Lengths) -> impl Iterator<Item = ValidPieceIndex> + use<'a> {
         let start = self.file_abs_offset + self.position;
-        let end = (start + PER_STREAM_BUF_DEFAULT).min(self.file_abs_offset + self.file_len);
+        let end = start
+            .saturating_add(self.lookahead_bytes)
+            .min(self.file_abs_offset + self.file_len);
         let dpl = lengths.default_piece_length();
         let start_id = (start / dpl as u64).try_into().unwrap();
         let end_id = end.div_ceil(dpl as u64).try_into().unwrap();
@@ -335,6 +353,19 @@ impl ManagedTorrent {
     }
 
     pub async fn stream(self: Arc<Self>, file_id: usize) -> anyhow::Result<FileStream> {
+        self.stream_with_options(file_id, FileStreamOptions::default())
+            .await
+    }
+
+    pub async fn stream_with_options(
+        self: Arc<Self>,
+        file_id: usize,
+        options: FileStreamOptions,
+    ) -> anyhow::Result<FileStream> {
+        anyhow::ensure!(
+            options.lookahead_bytes > 0,
+            "stream lookahead must be positive"
+        );
         let metadata = self
             .metadata
             .load_full()
@@ -364,6 +395,7 @@ impl ManagedTorrent {
             StreamState {
                 file_id,
                 position: 0,
+                lookahead_bytes: options.lookahead_bytes,
                 waker: None,
                 file_len: fd_len,
                 file_abs_offset: fd_offset,
@@ -397,5 +429,40 @@ impl FileStream {
 
     pub fn len(&self) -> u64 {
         self.file_len
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn queued_piece_ids(lookahead_bytes: u64, lengths: &Lengths) -> Vec<u32> {
+        let state = StreamState {
+            file_id: 0,
+            file_len: lengths.total_length(),
+            file_abs_offset: 0,
+            position: 0,
+            lookahead_bytes,
+            waker: None,
+        };
+        state.queue(lengths).map(|p| p.get()).collect()
+    }
+
+    #[test]
+    fn stream_queue_uses_the_configured_lookahead() {
+        // 10 pieces of 1024 bytes each.
+        let lengths = Lengths::new(10 * 1024, 1024).unwrap();
+
+        // One piece worth of lookahead only queues the current piece.
+        assert_eq!(queued_piece_ids(1024, &lengths), vec![0]);
+
+        // Four pieces worth of lookahead queues four pieces.
+        assert_eq!(queued_piece_ids(4 * 1024, &lengths), vec![0, 1, 2, 3]);
+
+        // A lookahead past the end of the file is clamped to the file length.
+        assert_eq!(
+            queued_piece_ids(u64::MAX, &lengths),
+            (0..10).collect::<Vec<_>>()
+        );
     }
 }


### PR DESCRIPTION
The per-stream streaming lookahead was hardcoded as a private 32MiB const (PER_STREAM_BUF_DEFAULT), so callers could not tune how far ahead of the reader pieces are prioritized.

Replace it with a public DEFAULT_STREAM_LOOKAHEAD_BYTES const and a FileStreamOptions { lookahead_bytes } struct whose Default preserves the 32MiB value. Add ManagedTorrent::stream_with_options and Api::api_stream_with_options; the existing stream()/api_stream() now delegate with the default, so every current caller is unchanged. The HTTP streaming endpoint gains an optional lookahead_bytes query param (absent = default, 0 = 400 Bad Request).

Behavior is identical for existing callers: the default field produces the same piece range as before, and start + N becomes start.saturating_add(N) purely as overflow hardening.

Created by asking Claude Fable 5 to fix this with a lot of opinions about code style and quality.