### PR TITLE
feat(stats): count connected peers that have the full torrent

### DIFF
--- a/crates/librqbit/src/torrent_state/live/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/mod.rs
@@ -1543,11 +1543,10 @@ impl PeerHandler {
                     }
                 };
                 trace!("updated bitfield with have={}", have);
-                if let Some(true) = live
-                    .bitfield
-                    .get(..self.state.lengths.total_pieces() as usize)
-                    .map(|s| s.all())
-                {
+                self.state
+                    .peers
+                    .update_seeder_flag(live, self.state.lengths.total_pieces() as usize);
+                if live.seeder {
                     debug!("peer has full torrent");
                 }
             });
@@ -1569,7 +1568,9 @@ impl PeerHandler {
         {
             debug!("peer has full torrent");
         }
-        self.state.peers.update_bitfield(self.addr, bf);
+        self.state
+            .peers
+            .update_bitfield(self.addr, bf, self.state.lengths.total_pieces() as usize);
         self.on_bitfield_notify.notify_waiters();
         Ok(())
     }

--- a/crates/librqbit/src/torrent_state/live/peer/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/peer/mod.rs
@@ -260,6 +260,12 @@ pub(crate) struct LivePeerState {
     // This is used to track the pieces the peer has.
     pub bitfield: BF,
 
+    // Whether the bitfield above covers the whole torrent, i.e. the peer is a seeder.
+    // Cached so that the aggregate seeder counter can be maintained on transitions
+    // instead of scanning every peer's bitfield on each stats call. Kept in sync
+    // with the bitfield by PeerStates::update_seeder_flag.
+    pub seeder: bool,
+
     // When the peer sends us data this is used to track if we asked for it.
     inflight_requests: HashSet<InflightRequest>,
 
@@ -288,6 +294,7 @@ impl LivePeerState {
             client_name: None,
             peer_interested: initial_interested,
             bitfield: BF::default(),
+            seeder: false,
             inflight_requests: Default::default(),
             late_cancelled_request_tolerance: 0,
             request_slots_changed: Default::default(),

--- a/crates/librqbit/src/torrent_state/live/peers/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/peers/mod.rs
@@ -111,10 +111,29 @@ impl PeerStates {
         })
     }
 
-    pub fn update_bitfield(&self, handle: PeerHandle, bitfield: BF) -> Option<()> {
+    pub fn update_bitfield(
+        &self,
+        handle: PeerHandle,
+        bitfield: BF,
+        total_pieces: usize,
+    ) -> Option<()> {
         self.with_live_mut(handle, "update_bitfield", |live| {
             live.bitfield = bitfield;
+            self.update_seeder_flag(live, total_pieces);
         })
+    }
+
+    // Recompute the cached "this peer has the full torrent" flag after its bitfield
+    // changed, keeping the aggregate seeder counters in sync. Must be called on every
+    // bitfield change of a live peer.
+    pub fn update_seeder_flag(&self, live: &mut LivePeerState, total_pieces: usize) {
+        let seeder = live.has_full_torrent(total_pieces);
+        if seeder == live.seeder {
+            return;
+        }
+        live.seeder = seeder;
+        self.stats.seeder_flag_changed(seeder);
+        self.session_stats.seeder_flag_changed(seeder);
     }
 
     pub fn mark_peer_connecting(&self, h: PeerHandle) -> crate::Result<(PeerRx, PeerTx)> {
@@ -158,5 +177,135 @@ impl PeerStates {
         self.with_live_mut(from_peer, "send_cancellations", |live| {
             live.cancel_inflight_requests_for_piece(stolen_idx);
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use librqbit_core::hash_id::Id20;
+
+    use super::*;
+    use crate::stream_connect::ConnectionKind;
+
+    const TOTAL_PIECES: usize = 8;
+
+    fn full_bitfield() -> BF {
+        BF::from_boxed_slice(vec![0xffu8; 1].into_boxed_slice())
+    }
+
+    fn empty_bitfield() -> BF {
+        BF::from_boxed_slice(vec![0u8; 1].into_boxed_slice())
+    }
+
+    fn make_peer_states() -> PeerStates {
+        PeerStates {
+            session_stats: Default::default(),
+            live_outgoing_peers: Default::default(),
+            stats: Default::default(),
+            states: Default::default(),
+        }
+    }
+
+    // Returns the peer handle, keeping the receiving end of the peer channel alive.
+    fn add_live_peer(peers: &PeerStates, addr: &str) -> (PeerHandle, PeerRx) {
+        let addr: SocketAddr = addr.parse().unwrap();
+        peers.add_if_not_seen(addr).unwrap();
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        peers
+            .with_peer_mut(addr, "test", |peer| {
+                peer.incoming_connection(Id20::default(), tx, peers, ConnectionKind::Tcp)
+            })
+            .unwrap()
+            .unwrap();
+        (addr, rx)
+    }
+
+    fn live_seeders(peers: &PeerStates) -> (u32, u32) {
+        (
+            peers.stats().live_seeders,
+            peers.session_stats.snapshot().live_seeders,
+        )
+    }
+
+    #[test]
+    fn full_bitfield_counts_as_seeder_and_is_uncounted_on_disconnect() {
+        let peers = make_peer_states();
+        let (addr, _rx) = add_live_peer(&peers, "127.0.0.1:1234");
+        assert_eq!(live_seeders(&peers), (0, 0));
+
+        peers
+            .update_bitfield(addr, empty_bitfield(), TOTAL_PIECES)
+            .unwrap();
+        assert_eq!(live_seeders(&peers), (0, 0));
+
+        peers
+            .update_bitfield(addr, full_bitfield(), TOTAL_PIECES)
+            .unwrap();
+        assert_eq!(live_seeders(&peers), (1, 1));
+
+        // Repeated updates must not double-count.
+        peers
+            .update_bitfield(addr, full_bitfield(), TOTAL_PIECES)
+            .unwrap();
+        assert_eq!(live_seeders(&peers), (1, 1));
+
+        peers.drop_peer(addr).unwrap();
+        assert_eq!(live_seeders(&peers), (0, 0));
+    }
+
+    #[test]
+    fn bitfield_completed_piece_by_piece_counts_as_seeder() {
+        let peers = make_peer_states();
+        let (addr, _rx) = add_live_peer(&peers, "127.0.0.1:1234");
+        peers
+            .update_bitfield(addr, empty_bitfield(), TOTAL_PIECES)
+            .unwrap();
+
+        for piece in 0..TOTAL_PIECES {
+            peers
+                .with_live_mut(addr, "test", |live| {
+                    *live.bitfield.get_mut(piece).unwrap() = true;
+                    peers.update_seeder_flag(live, TOTAL_PIECES);
+                })
+                .unwrap();
+            let expected = u32::from(piece == TOTAL_PIECES - 1);
+            assert_eq!(live_seeders(&peers), (expected, expected));
+        }
+    }
+
+    #[test]
+    fn seeder_is_uncounted_when_peer_leaves_live_state() {
+        let peers = make_peer_states();
+        let (addr, _rx) = add_live_peer(&peers, "127.0.0.1:1234");
+        peers
+            .update_bitfield(addr, full_bitfield(), TOTAL_PIECES)
+            .unwrap();
+        assert_eq!(live_seeders(&peers), (1, 1));
+
+        peers.mark_peer_not_needed(addr).unwrap();
+        assert_eq!(live_seeders(&peers), (0, 0));
+    }
+
+    #[test]
+    fn seeders_are_counted_per_peer() {
+        let peers = make_peer_states();
+        let (a, _rx_a) = add_live_peer(&peers, "127.0.0.1:1234");
+        let (b, _rx_b) = add_live_peer(&peers, "127.0.0.1:1235");
+
+        peers
+            .update_bitfield(a, full_bitfield(), TOTAL_PIECES)
+            .unwrap();
+        peers
+            .update_bitfield(b, empty_bitfield(), TOTAL_PIECES)
+            .unwrap();
+        assert_eq!(live_seeders(&peers), (1, 1));
+
+        peers
+            .update_bitfield(b, full_bitfield(), TOTAL_PIECES)
+            .unwrap();
+        assert_eq!(live_seeders(&peers), (2, 2));
+
+        peers.drop_peer(a).unwrap();
+        assert_eq!(live_seeders(&peers), (1, 1));
     }
 }

--- a/crates/librqbit/src/torrent_state/live/peers/stats/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/peers/stats/mod.rs
@@ -16,6 +16,7 @@ gen_stats!(AggregatePeerStatsAtomic AggregatePeerStats, [
     live_tcp u32,
     live_utp u32,
     live_socks u32,
+    live_seeders u32,
     seen u32,
     dead u32,
     not_needed u32,
@@ -44,6 +45,9 @@ impl AggregatePeerStatsAtomic {
     pub(crate) fn inc(&self, state: &PeerState) {
         if let PeerState::Live(l) = state {
             atomic_inc(self.live_kind_counter(l));
+            if l.seeder {
+                atomic_inc(&self.live_seeders);
+            }
         }
         atomic_inc(self.counter(state));
     }
@@ -51,8 +55,19 @@ impl AggregatePeerStatsAtomic {
     pub(crate) fn dec(&self, state: &PeerState) {
         if let PeerState::Live(l) = state {
             atomic_dec(self.live_kind_counter(l));
+            if l.seeder {
+                atomic_dec(&self.live_seeders);
+            }
         }
         atomic_dec(self.counter(state));
+    }
+
+    pub(crate) fn seeder_flag_changed(&self, seeder: bool) {
+        if seeder {
+            atomic_inc(&self.live_seeders);
+        } else {
+            atomic_dec(&self.live_seeders);
+        }
     }
 
     pub(crate) fn incdec(&self, old: &PeerState, new: &PeerState) {


### PR DESCRIPTION
The live peer state already tracks whether a peer's bitfield covers the whole torrent (LivePeerState::has_full_torrent), and that is used for choking and for dropping peers that neither side needs any more. The number of such peers was never surfaced though, so a consumer of the stats API could not show "seeds" next to "peers": per-peer stats expose counters, state, connection kind and client name, none of which say whether a peer is a seeder, and the aggregate has no seeder counter.

Add `live_seeders` to AggregatePeerStats, alongside the existing live/live_tcp/live_utp/live_socks counters. It counts currently connected peers whose bitfield is complete, and it is maintained on transitions like every other aggregate counter rather than recomputed per stats call: LivePeerState caches a `seeder` flag refreshed whenever the peer's bitfield changes (bitfield and have messages), and inc/dec adjust the counter as peers enter and leave the live state. Reading stats stays O(1) instead of scanning every peer's bitfield.

Purely additive: no behaviour change, and the new JSON field does not affect existing consumers.

Produced by my friendly Claude Opus 5 agent.

This ought to be a new feature, not inadvertently stolen from another PR 😅 