### PR TITLE
fix(peer): detect peer capabilities from the peer's handshake on incoming connections

### DIFF
--- a/crates/librqbit/src/peer_connection.rs
+++ b/crates/librqbit/src/peer_connection.rs
@@ -170,8 +170,8 @@ impl<H: PeerConnectionHandler> PeerConnection<H> {
         );
 
         let mut write_buf = Box::new([0u8; MAX_MSG_LEN]);
-        let handshake = Handshake::new(self.info_hash, self.peer_id);
-        let hlen = handshake.serialize_unchecked_len(&mut *write_buf);
+        let my_handshake = Handshake::new(self.info_hash, self.peer_id);
+        let hlen = my_handshake.serialize_unchecked_len(&mut *write_buf);
         with_timeout(
             "writing handshake",
             rwtimeout,
@@ -182,10 +182,11 @@ impl<H: PeerConnectionHandler> PeerConnection<H> {
         )
         .await?;
 
-        let handshake_supports_extended = handshake.supports_extended();
+        // What the peer supports is in the peer's handshake, not in ours.
+        let handshake_supports_extended = incoming.handshake.supports_extended();
 
         self.handler
-            .on_handshake(handshake, incoming.kind)
+            .on_handshake(incoming.handshake, incoming.kind)
             .map_err(Error::Anyhow)?;
 
         self.manage_peer(ManagePeerArgs {


### PR DESCRIPTION
On an incoming connection we built our own handshake and then read the extension bits back out of it, so every incoming peer was assumed to support BEP-10 regardless of what it actually sent. The peer's handshake was already available (it is used for the info hash check just above), it just wasn't consulted.

Also pass the peer's handshake to on_handshake(), which is what every implementation of it expects (the outgoing path already does this).

Created by my friendly Claude Opus 5