### PR TITLE
fix(storage): don't hide or lose is_type_id

### DIFF
--- a/crates/librqbit/src/storage/middleware/write_through_cache.rs
+++ b/crates/librqbit/src/storage/middleware/write_through_cache.rs
@@ -55,6 +55,10 @@ impl<U: StorageFactory + Clone> StorageFactory for WriteThroughCacheStorageFacto
         })
     }
 
+    fn is_type_id(&self, type_id: std::any::TypeId) -> bool {
+        self.underlying.is_type_id(type_id)
+    }
+
     fn clone_box(&self) -> crate::storage::BoxStorageFactory {
         self.clone().boxed()
     }

--- a/crates/librqbit/src/storage/mod.rs
+++ b/crates/librqbit/src/storage/mod.rs
@@ -58,6 +58,11 @@ pub trait StorageFactory: Send + Sync + Any {
         Ok(storage)
     }
 
+    /// Whether this factory, or the one it ultimately wraps, is of the given type.
+    ///
+    /// It has to survive both wrapping and boxing: this is how e.g. session persistence
+    /// asks whether it's dealing with a FilesystemStorageFactory, and a middleware in
+    /// between must not hide it. A middleware forwards this to what it wraps.
     fn is_type_id(&self, type_id: TypeId) -> bool {
         Self::type_id(self) == type_id
     }
@@ -89,7 +94,7 @@ impl<SF: StorageFactory> StorageFactoryExt for SF {
             }
 
             fn is_type_id(&self, type_id: TypeId) -> bool {
-                self.sf.type_id() == type_id
+                self.sf.is_type_id(type_id)
             }
 
             fn clone_box(&self) -> BoxStorageFactory {
@@ -110,6 +115,10 @@ impl<U: StorageFactory + ?Sized> StorageFactory for Box<U> {
         metadata: &TorrentMetadata,
     ) -> anyhow::Result<U::Storage> {
         (**self).create(shared, metadata)
+    }
+
+    fn is_type_id(&self, type_id: TypeId) -> bool {
+        (**self).is_type_id(type_id)
     }
 
     fn clone_box(&self) -> BoxStorageFactory {
@@ -205,5 +214,69 @@ impl<U: TorrentStorage + ?Sized> TorrentStorage for Box<U> {
 
     fn on_piece_completed(&self, piece_id: ValidPieceIndex) -> anyhow::Result<()> {
         (**self).on_piece_completed(piece_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::any::TypeId;
+
+    use super::{
+        BoxStorageFactory, StorageFactory, StorageFactoryExt, filesystem::FilesystemStorageFactory,
+    };
+    use crate::torrent_state::{ManagedTorrentShared, TorrentMetadata};
+
+    // A middleware like the ones in storage::middleware: it wraps another factory and
+    // forwards is_type_id, so that what it wraps stays recognizable through it.
+    #[derive(Clone)]
+    struct Middleware<U> {
+        underlying_factory: U,
+    }
+
+    impl<U: StorageFactory + Clone> StorageFactory for Middleware<U> {
+        type Storage = U::Storage;
+
+        fn create(
+            &self,
+            shared: &ManagedTorrentShared,
+            metadata: &TorrentMetadata,
+        ) -> anyhow::Result<Self::Storage> {
+            self.underlying_factory.create(shared, metadata)
+        }
+
+        fn is_type_id(&self, type_id: TypeId) -> bool {
+            self.underlying_factory.is_type_id(type_id)
+        }
+
+        fn clone_box(&self) -> BoxStorageFactory {
+            self.clone().boxed()
+        }
+    }
+
+    #[test]
+    fn test_is_type_id_survives_boxing() {
+        let fs = TypeId::of::<FilesystemStorageFactory>();
+
+        assert!(FilesystemStorageFactory::default().is_type_id(fs));
+        // Box<U> has to forward, or the answer is the TypeId of the box itself.
+        assert!(FilesystemStorageFactory::default().boxed().is_type_id(fs));
+
+        // And boxed() has to forward too, or every middleware's override is lost and the
+        // answer is the middleware's own type.
+        let wrapped = Middleware {
+            underlying_factory: FilesystemStorageFactory::default(),
+        };
+        assert!(wrapped.is_type_id(fs));
+        assert!(wrapped.clone().boxed().is_type_id(fs));
+        assert!(wrapped.boxed().clone_box().is_type_id(fs));
+
+        // A factory that isn't the one asked about still says so.
+        assert!(
+            !Middleware {
+                underlying_factory: FilesystemStorageFactory::default(),
+            }
+            .boxed()
+            .is_type_id(TypeId::of::<Middleware<FilesystemStorageFactory>>())
+        );
     }
 }


### PR DESCRIPTION
My agent claims this is a bug, and it kind of seems to be when I look at the code - the is_type_id seems to be meant to return the bottom level storage type, in which case middlewares shouldn't return their own types.

Just close it if I'm wrong I guess.