### PR TITLE
perf(storage): don't lose vectored writes through wrapping and boxing

### DIFF
--- a/crates/librqbit/src/storage/middleware/slow.rs
+++ b/crates/librqbit/src/storage/middleware/slow.rs
@@ -105,6 +105,18 @@ impl<U: TorrentStorage> TorrentStorage for SlowStorage<U> {
         self.underlying.pwrite_all(file_id, offset, buf)
     }
 
+    fn pwrite_all_vectored(
+        &self,
+        file_id: usize,
+        offset: u64,
+        bufs: [std::io::IoSlice<'_>; 2],
+    ) -> anyhow::Result<usize> {
+        // One write, so one sleep: the default would split it into two pwrite_all() calls
+        // and charge the caller twice for a write the storage does once.
+        sleep_from_reader(&self.pwrite_all_bufread);
+        self.underlying.pwrite_all_vectored(file_id, offset, bufs)
+    }
+
     fn remove_file(&self, file_id: usize, filename: &std::path::Path) -> anyhow::Result<()> {
         self.underlying.remove_file(file_id, filename)
     }
@@ -127,5 +139,22 @@ impl<U: TorrentStorage> TorrentStorage for SlowStorage<U> {
         metadata: &TorrentMetadata,
     ) -> anyhow::Result<()> {
         self.underlying.init(shared, metadata)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::test_util::{Probe, assert_forwards_vectored_writes};
+
+    #[test]
+    fn test_a_vectored_write_reaches_the_underlying_storage() {
+        let storage = SlowStorage {
+            underlying: Probe::default(),
+            // Sleep for nothing at all, however many times it is asked to.
+            pwrite_all_bufread: Mutex::new(Box::new(std::iter::repeat(0))),
+            pread_exact_bufread: Mutex::new(Box::new(std::iter::repeat(0))),
+        };
+        assert_forwards_vectored_writes(&storage, &storage.underlying);
     }
 }

--- a/crates/librqbit/src/storage/middleware/timing.rs
+++ b/crates/librqbit/src/storage/middleware/timing.rs
@@ -90,6 +90,24 @@ impl<U: TorrentStorage> TorrentStorage for TimingStorage<U> {
         )
     }
 
+    fn pwrite_all_vectored(
+        &self,
+        file_id: usize,
+        offset: u64,
+        bufs: [std::io::IoSlice<'_>; 2],
+    ) -> anyhow::Result<usize> {
+        let storage = &self.name;
+        let len = bufs[0].len() + bufs[1].len();
+        timeit!(
+            "pwrite_all_vectored",
+            self.underlying.pwrite_all_vectored(file_id, offset, bufs),
+            file_id,
+            offset,
+            storage,
+            len
+        )
+    }
+
     fn remove_file(&self, file_id: usize, filename: &std::path::Path) -> anyhow::Result<()> {
         self.underlying.remove_file(file_id, filename)
     }
@@ -115,5 +133,20 @@ impl<U: TorrentStorage> TorrentStorage for TimingStorage<U> {
         metadata: &TorrentMetadata,
     ) -> anyhow::Result<()> {
         self.underlying.init(shared, metadata)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::test_util::{Probe, assert_forwards_vectored_writes};
+
+    #[test]
+    fn test_a_vectored_write_reaches_the_underlying_storage() {
+        let storage = TimingStorage {
+            name: "test".to_owned(),
+            underlying: Probe::default(),
+        };
+        assert_forwards_vectored_writes(&storage, &storage.underlying);
     }
 }

--- a/crates/librqbit/src/storage/middleware/write_through_cache.rs
+++ b/crates/librqbit/src/storage/middleware/write_through_cache.rs
@@ -71,6 +71,34 @@ pub struct WriteThroughCacheStorage<U> {
     underlying: U,
 }
 
+impl<U> WriteThroughCacheStorage<U> {
+    // Put the bytes in the cache. Handing them on to the storage underneath is the
+    // caller's job: both write paths cache the same way and differ only in how they write.
+    //
+    // The bufs are one write: consecutive from offset, and the second half is empty for a
+    // plain pwrite_all(). A write covers one piece, so both halves go in under one lock
+    // and one LRU lookup - taking them one at a time would cost two of each for a write
+    // the storage does once.
+    fn cache(&self, file_id: usize, offset: u64, bufs: [&[u8]; 2]) -> anyhow::Result<()> {
+        let file = self.file_infos.get(file_id).context("wrong file")?;
+        let current = self
+            .lengths
+            .compute_current_piece(offset, file.offset_in_torrent)
+            .context("wrong piece")?;
+        let mut g = self.lru.write();
+        let pbuf = g.get_or_insert_mut(current.id, || {
+            vec![0; self.lengths.piece_length(current.id) as usize].into_boxed_slice()
+        });
+        let start = current.piece_offset as usize;
+        let end = start + bufs[0].len() + bufs[1].len();
+        let dest = pbuf.get_mut(start..end).context("bugged range")?;
+        let (first, second) = dest.split_at_mut(bufs[0].len());
+        first.copy_from_slice(bufs[0]);
+        second.copy_from_slice(bufs[1]);
+        Ok(())
+    }
+}
+
 impl<U: TorrentStorage> TorrentStorage for WriteThroughCacheStorage<U> {
     fn pread_exact(&self, file_id: usize, offset: u64, buf: &mut [u8]) -> anyhow::Result<()> {
         let file = self.file_infos.get(file_id).context("wrong file")?;
@@ -90,21 +118,21 @@ impl<U: TorrentStorage> TorrentStorage for WriteThroughCacheStorage<U> {
     }
 
     fn pwrite_all(&self, file_id: usize, offset: u64, buf: &[u8]) -> anyhow::Result<()> {
-        let file = self.file_infos.get(file_id).context("wrong file")?;
-        let current = self
-            .lengths
-            .compute_current_piece(offset, file.offset_in_torrent)
-            .context("wrong piece")?;
-        let mut g = self.lru.write();
-        let pbuf = g.get_or_insert_mut(current.id, || {
-            vec![0; self.lengths.piece_length(current.id) as usize].into_boxed_slice()
-        });
-        let start = current.piece_offset as usize;
-        let end = start + buf.len();
-        pbuf.get_mut(start..end)
-            .context("bugged range")?
-            .copy_from_slice(buf);
+        self.cache(file_id, offset, [buf, &[]])?;
         self.underlying.pwrite_all(file_id, offset, buf)
+    }
+
+    fn pwrite_all_vectored(
+        &self,
+        file_id: usize,
+        offset: u64,
+        bufs: [std::io::IoSlice<'_>; 2],
+    ) -> anyhow::Result<usize> {
+        // Cache both halves, then hand the write on as one call. The default would turn it
+        // into two pwrite_all()s, and the storage underneath would lose the single
+        // positioned vectored write it is written to do.
+        self.cache(file_id, offset, [&bufs[0], &bufs[1]])?;
+        self.underlying.pwrite_all_vectored(file_id, offset, bufs)
     }
 
     fn remove_file(&self, file_id: usize, filename: &std::path::Path) -> anyhow::Result<()> {
@@ -136,5 +164,31 @@ impl<U: TorrentStorage> TorrentStorage for WriteThroughCacheStorage<U> {
         metadata: &TorrentMetadata,
     ) -> anyhow::Result<()> {
         self.underlying.init(shared, metadata)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::test_util::{Probe, assert_forwards_vectored_writes};
+
+    const PIECE_LEN: u32 = librqbit_core::constants::CHUNK_SIZE * 2;
+    const NUM_PIECES: u32 = 2;
+
+    #[test]
+    fn test_a_vectored_write_reaches_the_underlying_storage() {
+        let storage = WriteThroughCacheStorage {
+            lru: RwLock::new(LruCache::new(NonZeroUsize::new(1).unwrap())),
+            lengths: Lengths::new(PIECE_LEN as u64 * NUM_PIECES as u64, PIECE_LEN).unwrap(),
+            file_infos: vec![crate::file_info::FileInfo {
+                relative_filename: "test.dat".into(),
+                offset_in_torrent: 0,
+                len: PIECE_LEN as u64 * NUM_PIECES as u64,
+                piece_range: 0..NUM_PIECES,
+                attrs: Default::default(),
+            }],
+            underlying: Probe::default(),
+        };
+        assert_forwards_vectored_writes(&storage, &storage.underlying);
     }
 }

--- a/crates/librqbit/src/storage/mod.rs
+++ b/crates/librqbit/src/storage/mod.rs
@@ -30,6 +30,9 @@ pub mod examples;
 #[cfg(feature = "storage_middleware")]
 pub mod middleware;
 
+#[cfg(test)]
+pub(crate) mod test_util;
+
 use std::{
     any::{Any, TypeId},
     io::IoSlice,
@@ -188,6 +191,15 @@ impl<U: TorrentStorage + ?Sized> TorrentStorage for Box<U> {
         (**self).pwrite_all(file_id, offset, buf)
     }
 
+    fn pwrite_all_vectored(
+        &self,
+        file_id: usize,
+        offset: u64,
+        bufs: [IoSlice<'_>; 2],
+    ) -> anyhow::Result<usize> {
+        (**self).pwrite_all_vectored(file_id, offset, bufs)
+    }
+
     fn remove_file(&self, file_id: usize, filename: &Path) -> anyhow::Result<()> {
         (**self).remove_file(file_id, filename)
     }
@@ -222,7 +234,9 @@ mod tests {
     use std::any::TypeId;
 
     use super::{
-        BoxStorageFactory, StorageFactory, StorageFactoryExt, filesystem::FilesystemStorageFactory,
+        BoxStorageFactory, StorageFactory, StorageFactoryExt,
+        filesystem::FilesystemStorageFactory,
+        test_util::{Probe, assert_forwards_vectored_writes},
     };
     use crate::torrent_state::{ManagedTorrentShared, TorrentMetadata};
 
@@ -278,5 +292,13 @@ mod tests {
             .boxed()
             .is_type_id(TypeId::of::<Middleware<FilesystemStorageFactory>>())
         );
+    }
+
+    // What a torrent holds is a Box<dyn TorrentStorage>, so a method this impl doesn't
+    // forward is one no storage in rqbit ever gets asked.
+    #[test]
+    fn test_vectored_writes_survive_boxing() {
+        let boxed: Box<Probe> = Box::default();
+        assert_forwards_vectored_writes(&boxed, &boxed);
     }
 }

--- a/crates/librqbit/src/storage/test_util.rs
+++ b/crates/librqbit/src/storage/test_util.rs
@@ -1,0 +1,79 @@
+// A storage that records what reached it, to check the wrappers around one against.
+//
+// A wrapper around a storage is transparent: anything it has no opinion about has to
+// reach what it wraps. The methods that make that easy to get wrong are the ones
+// [`TorrentStorage`] gives a default, because forgetting one still compiles and then
+// quietly does something of its own instead of asking the storage underneath.
+
+use std::{io::IoSlice, path::Path};
+
+use parking_lot::Mutex;
+
+use crate::{ManagedTorrentShared, TorrentMetadata, storage::TorrentStorage};
+
+#[derive(Default)]
+pub(crate) struct Probe {
+    /// The vectored writes that arrived as one call, as (offset, total length).
+    pub vectored: Mutex<Vec<(u64, usize)>>,
+}
+
+impl TorrentStorage for Probe {
+    fn init(
+        &mut self,
+        _shared: &ManagedTorrentShared,
+        _metadata: &TorrentMetadata,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn pread_exact(&self, _file_id: usize, _offset: u64, _buf: &mut [u8]) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn pwrite_all(&self, _file_id: usize, _offset: u64, _buf: &[u8]) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn pwrite_all_vectored(
+        &self,
+        _file_id: usize,
+        offset: u64,
+        bufs: [IoSlice<'_>; 2],
+    ) -> anyhow::Result<usize> {
+        let len = bufs[0].len() + bufs[1].len();
+        self.vectored.lock().push((offset, len));
+        Ok(len)
+    }
+
+    fn remove_file(&self, _file_id: usize, _filename: &Path) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn remove_directory_if_empty(&self, _path: &Path) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn ensure_file_length(&self, _file_id: usize, _length: u64) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn take(&self) -> anyhow::Result<Box<dyn TorrentStorage>> {
+        anyhow::bail!("not used")
+    }
+}
+
+// A vectored write has to reach the storage underneath as one call. Called from each
+// wrapper's own tests, where its private fields are.
+pub(crate) fn assert_forwards_vectored_writes<S: TorrentStorage>(storage: &S, probe: &Probe) {
+    let (a, b) = (&[1u8; 4][..], &[2u8; 6][..]);
+    let written = storage
+        .pwrite_all_vectored(0, 0, [IoSlice::new(a), IoSlice::new(b)])
+        .unwrap();
+    assert_eq!(written, a.len() + b.len());
+    assert_eq!(
+        *probe.vectored.lock(),
+        vec![(0, a.len() + b.len())],
+        "pwrite_all_vectored() didn't reach the storage whole: the default split it into \
+         two pwrite_all()s, which is the one call this exists to avoid"
+    );
+}


### PR DESCRIPTION
pwrite_all_vectored() is the write path the storage module's own header argues for: one positioned write call for a chunk that isn't contiguous in memory. The peer's read buffer is a ringbuffer, so a Piece message's payload comes out of it as two slices whenever it wrapped around the end, and file_ops::write_chunk hands the pair to the storage as it is - on unix the filesystem storage turns that into a single pwritev, with nothing to join first. That is every chunk whose bytes happened to wrap, not some boundary case in the torrent: a chunk lives inside one piece and never straddles two, and one that spans a file boundary is already one vectored call per file.

It has a default that splits the call into two pwrite_all()s, there for storages that can't do better - and every wrapper around a storage took that default instead of passing the call on, so the storage underneath never saw a vectored write.

Box<U> is the one that matters most, because Box<dyn TorrentStorage> is what a torrent holds: anything it doesn't forward, no storage in rqbit is ever asked. The three middlewares are the same shape.

Forward it in all four. The timing middleware logs it as the single operation it is rather than as two writes; the slow one sleeps once, not twice, for a write the storage does once; the cache copies both halves into the piece under one lock and one LRU lookup - where taking them one at a time cost two of each - and hands the write on whole, which is what factoring the cache update out of pwrite_all() is for. Each wrapper is checked against a probe that records the vectored writes that arrive as one call, so one that drops back to the default fails the test.

Yet another PR produced by my helpful Claude Fable.