### PR TITLE
fix(chunk_tracker): count a piece into its files as it becomes have

### DIFF
--- a/crates/librqbit/src/chunk_tracker.rs
+++ b/crates/librqbit/src/chunk_tracker.rs
@@ -269,7 +269,11 @@ impl ChunkTracker {
         }
     }
 
-    pub fn mark_piece_downloaded(&mut self, idx: ValidPieceIndex) {
+    /// The piece passed its hash check: it is ours. Sets the have-bit and moves every
+    /// count that is derived from it - the totals and the per-file bytes - in the same
+    /// call, so that nothing holding the lock between two calls can see a piece that is
+    /// have but not counted, or counted but not have.
+    pub fn mark_piece_downloaded(&mut self, idx: ValidPieceIndex, file_infos: &FileInfos) {
         let id = idx.get() as usize;
         if !self.have.as_slice()[id] {
             self.have.as_slice_mut().set(id, true);
@@ -277,6 +281,18 @@ impl ChunkTracker {
             self.hns.have_bytes += len;
             if self.selected[id] {
                 self.hns.needed_bytes -= len;
+            }
+            // A filter over all files and not a scan that stops at the first
+            // non-overlapping one: a zero-length file sitting inside a piece has an empty
+            // piece range, and would stop such a scan short of the files after it.
+            for (file_id, fi) in file_infos
+                .iter()
+                .enumerate()
+                .filter(|(_, fi)| fi.piece_range.contains(&idx.get()))
+            {
+                self.per_file_bytes[file_id] +=
+                    self.lengths
+                        .size_of_piece_in_file(idx.get(), fi.offset_in_torrent, fi.len);
             }
         }
     }
@@ -384,22 +400,6 @@ impl ChunkTracker {
 
     pub fn per_file_have_bytes(&self) -> &[u64] {
         &self.per_file_bytes
-    }
-
-    // Returns remaining bytes
-    pub fn update_file_have_on_piece_completed(
-        &mut self,
-        piece_id: ValidPieceIndex,
-        file_id: usize,
-        file_info: &FileInfo,
-    ) -> u64 {
-        let diff_have = self.lengths.size_of_piece_in_file(
-            piece_id.get(),
-            file_info.offset_in_torrent,
-            file_info.len,
-        );
-        self.per_file_bytes[file_id] += diff_have;
-        file_info.len.saturating_sub(self.per_file_bytes[file_id])
     }
 }
 
@@ -512,15 +512,11 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_update_only_files() {
-        let piece_len = CHUNK_SIZE * 2 + 1;
-        let total_len = piece_len as u64 * 2 + 1;
-        let l = Lengths::new(total_len, piece_len).unwrap();
-        assert_eq!(l.total_pieces(), 3);
-        assert_eq!(l.total_chunks(), 7);
-
-        let all_files = vec![
+    // Four files over 3 pieces of 2 chunks + 1 byte: file 0 is piece 0 exactly; piece 1
+    // holds the 1-byte file 1, the zero-length file 2 and the start of file 3, which runs
+    // to the end of the torrent.
+    fn four_files(piece_len: u32) -> Vec<FileInfo> {
+        vec![
             FileInfo {
                 relative_filename: "0".into(),
                 offset_in_torrent: 0,
@@ -549,7 +545,60 @@ mod tests {
                 len: piece_len as u64,
                 attrs: Default::default(),
             },
-        ];
+        ]
+    }
+
+    // The per-file count moves with the have-bit, in the same call. It used to be added
+    // in a second step, under a second lock, so the two could be observed apart; and that
+    // step walked the files with skip_while/take_while, which stopped at the zero-length
+    // file 2 and never counted piece 1 into file 3.
+    #[test]
+    fn test_per_file_bytes_follow_the_have_bit() {
+        let piece_len = CHUNK_SIZE * 2 + 1;
+        let total_len = piece_len as u64 * 2 + 1;
+        let l = Lengths::new(total_len, piece_len).unwrap();
+        let files = four_files(piece_len);
+
+        let bf_len = l.piece_bitfield_bytes();
+        let have = BF::from_boxed_slice(vec![0u8; bf_len].into_boxed_slice());
+        let mut selected = BF::from_boxed_slice(vec![0u8; bf_len].into_boxed_slice());
+        selected.get_mut(0..3).unwrap().fill(true);
+        let mut ct = ChunkTracker::new(have.into_dyn(), selected, l, &files).unwrap();
+        assert_eq!(ct.per_file_have_bytes(), [0, 0, 0, 0]);
+
+        // Piece 1 is shared by three files, one of them empty.
+        ct.mark_piece_downloaded(l.validate_piece_index(1).unwrap(), &files);
+        assert_eq!(
+            ct.per_file_have_bytes(),
+            [0, 1, 0, piece_len as u64 - 1],
+            "the bytes of piece 1 in every file it overlaps"
+        );
+
+        // Marking a piece we already have counts nothing twice.
+        ct.mark_piece_downloaded(l.validate_piece_index(1).unwrap(), &files);
+        assert_eq!(ct.per_file_have_bytes(), [0, 1, 0, piece_len as u64 - 1]);
+
+        ct.mark_piece_downloaded(l.validate_piece_index(0).unwrap(), &files);
+        ct.mark_piece_downloaded(l.validate_piece_index(2).unwrap(), &files);
+        assert_eq!(
+            ct.per_file_have_bytes(),
+            [piece_len as u64, 1, 0, piece_len as u64],
+            "every file is complete"
+        );
+        for fi in &files {
+            assert!(ct.is_file_finished(fi));
+        }
+    }
+
+    #[test]
+    fn test_update_only_files() {
+        let piece_len = CHUNK_SIZE * 2 + 1;
+        let total_len = piece_len as u64 * 2 + 1;
+        let l = Lengths::new(total_len, piece_len).unwrap();
+        assert_eq!(l.total_pieces(), 3);
+        assert_eq!(l.total_chunks(), 7);
+
+        let all_files = four_files(piece_len);
 
         let bf_len = l.piece_bitfield_bytes();
         let initial_have = BF::from_boxed_slice(vec![0u8; bf_len].into_boxed_slice());

--- a/crates/librqbit/src/piece_tracker.rs
+++ b/crates/librqbit/src/piece_tracker.rs
@@ -20,7 +20,6 @@ use peer_binary_protocol::Piece;
 
 use crate::{
     chunk_tracker::{ChunkMarkingResult, ChunkTracker},
-    file_info::FileInfo,
     type_aliases::{FileInfos, FilePriorities, PeerHandle},
 };
 
@@ -229,9 +228,10 @@ impl PieceTracker {
         Some(inflight.started.elapsed())
     }
 
-    /// Mark piece as downloaded after successful hash verification.
-    pub fn mark_piece_hash_ok(&mut self, piece: ValidPieceIndex) {
-        self.chunks.mark_piece_downloaded(piece);
+    /// Mark piece as downloaded after successful hash verification. Moves the per-file
+    /// counts with it: see [`ChunkTracker::mark_piece_downloaded`].
+    pub fn mark_piece_hash_ok(&mut self, piece: ValidPieceIndex, file_infos: &FileInfos) {
+        self.chunks.mark_piece_downloaded(piece, file_infos);
     }
 
     /// Mark piece as failed after hash verification failure - requeues the piece.
@@ -296,17 +296,6 @@ impl PieceTracker {
         new_only_files: &HashSet<usize>,
     ) -> anyhow::Result<crate::chunk_tracker::HaveNeededSelected> {
         self.chunks.update_only_files(file_infos, new_only_files)
-    }
-
-    /// Update per-file have bytes when a piece completes. Returns remaining bytes for the file.
-    pub fn update_file_have_on_piece_completed(
-        &mut self,
-        piece_id: ValidPieceIndex,
-        file_id: usize,
-        file_info: &FileInfo,
-    ) -> u64 {
-        self.chunks
-            .update_file_have_on_piece_completed(piece_id, file_id, file_info)
     }
 
     /// Flush the have pieces bitfield to disk.
@@ -469,7 +458,7 @@ mod tests {
         assert!(duration.is_some());
         assert!(!tracker.is_inflight(piece));
         // Simulate successful hash check
-        tracker.mark_piece_hash_ok(piece);
+        tracker.mark_piece_hash_ok(piece, &file_infos);
         assert!(tracker.chunks().is_piece_have(piece));
     }
 

--- a/crates/librqbit/src/torrent_state/live/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/mod.rs
@@ -841,19 +841,6 @@ impl TorrentStateLive {
         }
         let mut g = self.lock_write("on_piece_completed");
         let locked = &mut **g;
-        let pieces = locked.get_pieces_mut()?;
-
-        // if we have all the pieces of the file, reopen it read only
-        for (idx, file_info) in self
-            .metadata
-            .file_infos
-            .iter()
-            .enumerate()
-            .skip_while(|(_, fi)| !fi.piece_range.contains(&id.get()))
-            .take_while(|(_, fi)| fi.piece_range.contains(&id.get()))
-        {
-            let _remaining = pieces.update_file_have_on_piece_completed(id, idx, file_info);
-        }
 
         self.streams
             .wake_streams_on_piece_completed(id, self.metadata.lengths());
@@ -1921,14 +1908,20 @@ impl PeerHandler {
                 .with_context(|| format!("error checking piece={index}"))?
             {
                 true => {
+                    let piece_len = state.lengths.piece_length(chunk_info.piece_index) as u64;
                     {
                         let mut g = state.lock_write("mark_piece_downloaded");
                         g.get_pieces_mut()?
-                            .mark_piece_hash_ok(chunk_info.piece_index);
+                            .mark_piece_hash_ok(chunk_info.piece_index, &state.metadata.file_infos);
+                        // Under the same lock as the have-bit, so the two are never seen
+                        // apart.
+                        state
+                            .stats
+                            .have_bytes
+                            .fetch_add(piece_len, Ordering::Relaxed);
                     }
 
                     // Global piece counters.
-                    let piece_len = state.lengths.piece_length(chunk_info.piece_index) as u64;
                     state
                         .stats
                         .downloaded_and_checked_bytes
@@ -1941,10 +1934,6 @@ impl PeerHandler {
                         // This counter is used to compute "is_finished", so using
                         // stronger ordering.
                         .fetch_add(1, Ordering::Release);
-                    state
-                        .stats
-                        .have_bytes
-                        .fetch_add(piece_len, Ordering::Relaxed);
                     #[allow(clippy::cast_possible_truncation)]
                     state.stats.total_piece_download_ms.fetch_add(
                         full_piece_download_time.as_millis() as u64,


### PR DESCRIPTION
The have-bit was set under one lock and the per-file byte count added under a second one, after the storage callback, so the two could be observed apart. The second step also walked the files with skip_while / take_while: a zero-length file sitting inside a piece has an empty piece range and ended that walk early, so the files after it in the same piece were never counted - file_progress undercounted them for good.

mark_piece_downloaded() now moves the per-file count with the have-bit, filtering over all files, and update_file_have_on_piece_completed() goes. stats.have_bytes moves under the same lock for the same reason. The test puts a 1-byte file, a zero-length file and the start of a third file in one piece and checks each is counted.

Created by my friendly Claude Fable.