### PR TITLE
fix(live): release the state lock before update_only_files touches the peer table

### DIFF
--- a/crates/librqbit/src/torrent_state/live/mod.rs
+++ b/crates/librqbit/src/torrent_state/live/mod.rs
@@ -802,9 +802,13 @@ impl TorrentStateLive {
     }
 
     pub(crate) fn update_only_files(&self, only_files: &HashSet<usize>) -> anyhow::Result<()> {
-        let mut g = self.lock_write("update_only_files");
-        let pt = g.get_pieces_mut()?;
-        let hns = pt.update_only_files(&self.metadata.file_infos, only_files)?;
+        let hns = self
+            .lock_write("update_only_files")
+            .get_pieces_mut()?
+            .update_only_files(&self.metadata.file_infos, only_files)?;
+        // With the state lock released. A dying peer holds its shard of the peer table
+        // while it asks whether the torrent is finished (on_peer_died), so touching the
+        // table under the state lock is the reverse order, and the two deadlock.
         if !hns.finished() {
             self.reconnect_all_not_needed_peers();
         }


### PR DESCRIPTION
A live torrent has two locks its peer tasks take in a fixed order: a shard of the peer table first, then the torrent's state lock. A dying peer holds its shard (on_peer_died's get_mut) while it asks whether the torrent is finished, which reads the state lock; the chunk requester reserves a piece the same way round. update_only_files() was the one site taking them the other way: it held the state lock while it re-queued the not-needed peers, which walks every shard.

One peer dying at the wrong moment - while a selection change that left the torrent unfinished was under way - deadlocked the two, and every task that then touched either lock parked behind them: with peers churning that was every peer-death task, until the runtime's workers were all blocked and nothing on it, including things touching neither lock, ran again. An embedder that changes the selection of an unfinished torrent under peer churn saw it about one run in ten.

The state lock is released first now, like finish_release() and reselect_pieces() already do: the selection is updated under the lock, and the peers are re-queued after it. Nothing in between needs the lock; re-queueing only touches the peer table and the peer queue.

Debug builds now check the order: guards on the state lock count how many this thread holds, and the peer table asserts that count is zero on every access through it (its destructor is the one access that is not; it runs only with the whole torrent state, when no guard on that state's lock can be held). Peer tasks taking a shard and then the state lock is the allowed order and is untouched by the check. The test flips the selection of an unfinished torrent in a tight loop while thousands of peers die. In a debug build the assertion fails it deterministically at the first flip on the old code; without the assertion the race itself caught the old code in 10 of 10 runs, on a watchdog thread since a stuck runtime cannot fire its own timeouts.

Another thing found by my Claude. This one is pretty nice, a tiny change to remove a potential deadlock.