### PR TITLE
fix(storage): write past 2 GiB where pwritev takes a 32-bit off_t

### DIFF
--- a/crates/librqbit/src/storage/filesystem/opened_file.rs
+++ b/crates/librqbit/src/storage/filesystem/opened_file.rs
@@ -19,7 +19,16 @@ pub trait OurFileExt {
 impl OurFileExt for File {
     #[cfg(unix)]
     fn pwrite_all_vectored(&self, offset: u64, bufs: [IoSlice<'_>; 2]) -> anyhow::Result<usize> {
-        nix::sys::uio::pwritev(self, &bufs, offset.try_into()?).context("error calling pwritev")
+        // off_t is 32 bits on 32-bit Android (and on 32-bit Linux built without
+        // _FILE_OFFSET_BITS=64), so pwritev cannot address anything past 2 GiB there.
+        // pwrite_all goes through pwrite64 and takes the u64 as is, so past that point
+        // write the two buffers one after the other instead.
+        match nix::libc::off_t::try_from(offset) {
+            Ok(offset) => {
+                nix::sys::uio::pwritev(self, &bufs, offset).context("error calling pwritev")
+            }
+            Err(_) => pwrite_all_unvectored(self, offset, bufs),
+        }
     }
 
     #[cfg(not(unix))]
@@ -104,6 +113,21 @@ impl OurFileExt for File {
     fn pwrite_all(&self, offset: u64, buf: &[u8]) -> anyhow::Result<()> {
         anyhow::bail!("pwrite_all not implemented for your platform")
     }
+}
+
+/// What pwrite_all_vectored() falls back to when the offset does not fit the platform's
+/// pwritev: the same bytes, in two plain positional writes.
+#[cfg(unix)]
+fn pwrite_all_unvectored(
+    file: &File,
+    mut offset: u64,
+    bufs: [IoSlice<'_>; 2],
+) -> anyhow::Result<usize> {
+    for buf in &bufs {
+        file.pwrite_all(offset, buf)?;
+        offset += buf.len() as u64;
+    }
+    Ok(bufs[0].len() + bufs[1].len())
 }
 
 #[derive(Default, Debug)]
@@ -195,7 +219,7 @@ impl OpenedFile {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Read;
+    use std::io::{IoSlice, Read};
 
     use librqbit_core::constants::CHUNK_SIZE;
     use peer_binary_protocol::DoubleBufHelper;
@@ -203,9 +227,16 @@ mod tests {
 
     use crate::storage::filesystem::opened_file::OurFileExt;
 
-    #[test]
-    fn test_pwrite_all_vectored() {
-        let td = TempDir::with_prefix("test_pwrite_all_vectored").unwrap();
+    // Writes every split of a random buffer at `offset` with `write`, and checks the file
+    // holds exactly those bytes there.
+    fn check_pwrite_all_vectored(
+        name: &str,
+        offset: u64,
+        write: impl Fn(&std::fs::File, u64, [IoSlice<'_>; 2]) -> anyhow::Result<usize>,
+    ) {
+        use std::io::Seek;
+
+        let td = TempDir::with_prefix(name).unwrap();
         let mut tmp_buf = [0u8; CHUNK_SIZE as usize];
         for bufsize in [10000usize, CHUNK_SIZE as usize] {
             let mut buf = vec![0u8; bufsize];
@@ -219,13 +250,56 @@ mod tests {
                     .unwrap();
                 let (first, second) = buf.split_at(split_point);
                 let bufs = DoubleBufHelper::new(first, second).as_ioslices(bufsize);
-                file.pwrite_all_vectored(0, bufs).unwrap();
+                assert_eq!(write(&file, offset, bufs).unwrap(), bufsize, "{path:?}");
 
                 let mut file = std::fs::File::open(&path).unwrap();
-                assert_eq!(file.metadata().unwrap().len(), bufsize as u64, "{path:?}");
+                assert_eq!(
+                    file.metadata().unwrap().len(),
+                    offset + bufsize as u64,
+                    "{path:?}"
+                );
+                file.seek(std::io::SeekFrom::Start(offset)).unwrap();
                 file.read_exact(&mut tmp_buf[..bufsize]).unwrap();
                 assert_eq!(&tmp_buf[..bufsize], buf);
             }
         }
+    }
+
+    #[test]
+    fn test_pwrite_all_vectored() {
+        check_pwrite_all_vectored("test_pwrite_all_vectored", 0, |f, offset, bufs| {
+            f.pwrite_all_vectored(offset, bufs)
+        });
+    }
+
+    // 2 GiB is where a 32-bit off_t runs out. On a 64-bit host this still goes through
+    // pwritev, so it cannot reproduce the 32-bit failure; on a 32-bit target the same
+    // test takes the fallback.
+    //
+    // Unix only, and not because the code under test is: writing at this offset leaves a
+    // 2 GiB hole, which is free where files are sparse by default and is not on NTFS,
+    // where Windows zero-fills it -- six files of it, more than a CI runner has room or
+    // time for. Windows takes the seek_write path below, whose offset is a u64 with no
+    // such boundary, so there is nothing there for this test to find.
+    #[cfg(unix)]
+    #[test]
+    fn test_pwrite_all_vectored_past_2gib() {
+        check_pwrite_all_vectored(
+            "test_pwrite_all_vectored_past_2gib",
+            1u64 << 31,
+            |f, offset, bufs| f.pwrite_all_vectored(offset, bufs),
+        );
+    }
+
+    // The fallback itself, at an offset a 32-bit off_t cannot hold: the path a 32-bit
+    // Android device takes for every write past 2 GiB into a file.
+    #[cfg(unix)]
+    #[test]
+    fn test_pwrite_all_unvectored_past_2gib() {
+        check_pwrite_all_vectored(
+            "test_pwrite_all_unvectored_past_2gib",
+            (1u64 << 31) + 12345,
+            super::pwrite_all_unvectored,
+        );
     }
 }


### PR DESCRIPTION
nix::pwritev takes libc::off_t, which is 32 bits on 32-bit Android and on 32-bit Linux built without _FILE_OFFSET_BITS=64. The filesystem storage fed it `offset.try_into()?`, so on such a target every vectored write at an offset of 2 GiB or more failed the conversion and the torrent errored out. pwrite_all was never affected: std's write_all_at goes through pwrite64 and takes the u64 as is. Only the vectored path was broken, and it is the path a Piece payload that wrapped the peer's ring buffer takes, so on a 32-bit device a single file over 2 GiB could not be downloaded.

Observed on a Chromecast with Google TV (armeabi-v7a, its only ABI) streaming a 20+ GB single-file torrent:

    failed to initialize: error writing to file 0 ("...")
    Caused by: out of range integral type conversion attempted

Keep pwritev where the offset fits off_t, and past that fall back to one plain positional write per buffer - what the trait default does anyway. This stays free of unsafe and of per-OS cfg for pwritev64 (which exists on linux/android but not elsewhere); the cost is one extra syscall per wrapped chunk, and only past 2 GiB on a 32-bit target.

The tests write 2 GiB into a file through both pwrite_all_vectored and the fallback directly. On a 64-bit host off_t is 64 bits, so the first still goes through pwritev and cannot reproduce the failure; the second covers what a 32-bit target runs instead, and on such a target the first takes that path too. The fallback also compiles clean under clippy for armv7-linux-androideabi, where off_t is verified to be 4 bytes.

Yet another PR from my friendly Claude Opus 5.