### PR TITLE
Fix incoming connection listener starving its own drain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2794,7 +2794,7 @@ dependencies = [
 
 [[package]]
 name = "librqbit"
-version = "8.1.0"
+version = "8.1.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2912,7 +2912,7 @@ dependencies = [
 
 [[package]]
 name = "librqbit-dht"
-version = "5.3.0"
+version = "5.3.1"
 dependencies = [
  "anyhow",
  "backoff",
@@ -4606,7 +4606,7 @@ dependencies = [
 
 [[package]]
 name = "rqbit"
-version = "8.1.0"
+version = "8.1.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4635,7 +4635,7 @@ dependencies = [
 
 [[package]]
 name = "rqbit-desktop"
-version = "8.1.0"
+version = "8.1.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/crates/dht/Cargo.toml
+++ b/crates/dht/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "librqbit-dht"
-version = "5.3.0"
+version = "5.3.1"
 edition = "2021"
 description = "DHT implementation, used in rqbit torrent client."
 license = "Apache-2.0"

--- a/crates/dht/src/dht.rs
+++ b/crates/dht/src/dht.rs
@@ -971,9 +971,10 @@ impl DhtWorker {
             loop {
                 interval.tick().await;
                 let mut found = 0;
+                let now = Instant::now();
                 for node in self.dht.routing_table.read().iter() {
                     if matches!(
-                        node.status(),
+                        node.status(now),
                         NodeStatus::Questionable | NodeStatus::Unknown
                     ) {
                         found += 1;

--- a/crates/librqbit/Cargo.toml
+++ b/crates/librqbit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "librqbit"
-version = "8.1.0"
+version = "8.1.1"
 authors = ["Igor Katson <igor.katson@gmail.com>"]
 edition = "2021"
 description = "The main library used by rqbit torrent client. The binary is just a small wrapper on top of it."
@@ -56,7 +56,7 @@ librqbit-core = { path = "../librqbit_core", default-features = false, version =
 clone_to_owned = { path = "../clone_to_owned", package = "librqbit-clone-to-owned", version = "3" }
 peer_binary_protocol = { path = "../peer_binary_protocol", default-features = false, package = "librqbit-peer-protocol", version = "4.3" }
 sha1w = { path = "../sha1w", default-features = false, package = "librqbit-sha1-wrapper", version = "4.1" }
-dht = { path = "../dht", package = "librqbit-dht", default-features = false, version = "5.3.0" }
+dht = { path = "../dht", package = "librqbit-dht", default-features = false, version = "5.3.1" }
 librqbit-upnp = { path = "../upnp", version = "1" }
 upnp-serve = { path = "../upnp-serve", package = "librqbit-upnp-serve", default-features = false, version = "1", optional = true }
 

--- a/crates/librqbit/src/api.rs
+++ b/crates/librqbit/src/api.rs
@@ -566,9 +566,13 @@ fn make_torrent_details(
     Ok(TorrentDetailsResponse {
         id,
         info_hash: info_hash.as_string(),
-        name: name
-            .map(|s| s.to_owned())
-            .or_else(|| info.and_then(|i| i.name.as_ref().map(|b| b.to_string()))),
+        name: name.map(|s| s.to_owned()).or_else(|| {
+            info.and_then(|i| {
+                i.name
+                    .as_ref()
+                    .map(|b| String::from_utf8_lossy(b.as_ref()).into())
+            })
+        }),
         files: Some(files),
         output_folder,
         stats: None,

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -1473,6 +1473,9 @@ pub(crate) struct ResolveMagnetResult {
 fn remove_files_and_dirs(infos: &FileInfos, files: &dyn TorrentStorage) {
     let mut all_dirs = HashSet::new();
     for (id, fi) in infos.iter().enumerate() {
+        if fi.attrs.padding {
+            continue;
+        }
         let mut fname = &*fi.relative_filename;
         if let Err(e) = files.remove_file(id, fname) {
             warn!(?fi.relative_filename, error=?e, "could not delete file");

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -1006,11 +1006,12 @@ impl Session {
         }
 
         if let Some(name) = &info.name {
-            let s =
-                std::str::from_utf8(name.as_slice()).context("invalid UTF-8 in torrent name")?;
-            let pb = PathBuf::from(s);
-            check_valid(&pb)?;
-            return Ok(Some(pb));
+            let s = String::from_utf8_lossy(name.as_slice());
+            if !s.is_empty() {
+                let pb = PathBuf::from(s.as_ref());
+                check_valid(&pb)?;
+                return Ok(Some(pb));
+            }
         };
         if let Some(name) = magnet_name {
             let pb = PathBuf::from(name);

--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -799,6 +799,40 @@ impl Session {
 
         loop {
             tokio::select! {
+                // Finish the checks already in hand before taking on more. Without
+                // `biased` the branches are polled in a random order, so while
+                // `accept()` is continuously ready it wins roughly half the time and
+                // the in-flight set grows at about half the arrival rate.
+                biased;
+
+                Some(res) = futs.next(), if !futs.is_empty() => {
+                    // Annotated because the `Err` arm no longer names the error type,
+                    // and nothing else in the loop pins it.
+                    let res: anyhow::Result<(Arc<TorrentStateLive>, CheckedIncomingConnection)> =
+                        res;
+                    match res {
+                        Ok((live, checked)) => {
+                            if let Err(e) = live.add_incoming_peer(checked) {
+                                warn!("error handing over incoming connection: {e:#}");
+                            }
+                        }
+                        // A failed check is the COMMON case rather than an anomaly: a
+                        // peer asking for an infohash this session no longer holds, a
+                        // torrent that is paused, an address in the blocklist. Matching
+                        // only `Some(Ok(..))` made the pattern refutable, and a
+                        // non-matching branch is disabled for the rest of that `select!`
+                        // call — so every failed check cost the loop its chance to
+                        // drain, while `accept()` kept adding. The accepted sockets then
+                        // accumulated unread (`Recv-Q` 68, one whole BitTorrent
+                        // handshake) until the process ran out of descriptors.
+                        //
+                        // The persistence loop in `Session::new_with_opts` already uses
+                        // this shape, `Some(res)` plus an explicit `Err` arm; this is
+                        // the same idiom applied here.
+                        // Already logged where it happened, by the `map_err` below.
+                        Err(_) => {}
+                    }
+                },
                 r = l.accept() => {
                     match r {
                         Ok((stream, addr)) => {
@@ -818,11 +852,6 @@ impl Session {
                             error!("error accepting: {e:#}");
                             continue;
                         }
-                    }
-                },
-                Some(Ok((live, checked))) = futs.next(), if !futs.is_empty() => {
-                    if let Err(e) = live.add_incoming_peer(checked) {
-                        warn!("error handing over incoming connection: {e:#}");
                     }
                 },
             }

--- a/crates/librqbit/webui/src/components/FileListInput.tsx
+++ b/crates/librqbit/webui/src/components/FileListInput.tsx
@@ -25,13 +25,13 @@ type FileTree = {
 
 const newFileTree = (
   torrentDetails: TorrentDetails,
-  stats: TorrentStats | null,
+  stats: TorrentStats | null
 ): FileTree => {
   const newFileTreeInner = (
     name: string,
     id: string,
     files: TorrentFileForCheckbox[],
-    depth: number,
+    depth: number
   ): FileTree => {
     let directFiles: TorrentFileForCheckbox[] = [];
     let groups: FileTree[] = [];
@@ -54,7 +54,7 @@ const newFileTree = (
 
     let sortedGroupsByName = sortBy(
       Object.entries(groupsByName),
-      ([k, _]) => k,
+      ([k, _]) => k
     );
 
     let childId = 0;
@@ -87,7 +87,7 @@ const newFileTree = (
         };
       })
       .filter((f) => f !== null),
-    0,
+    0
   );
 };
 
@@ -177,7 +177,7 @@ const FileTreeComponent: React.FC<{
           label={`${
             tree.name ? tree.name + ", " : ""
           } ${getTotalSelectedFiles()} files, ${formatBytes(
-            getTotalSelectedBytes(),
+            getTotalSelectedBytes()
           )}`}
           name={tree.id}
           onChange={handleToggleTree}
@@ -253,7 +253,7 @@ export const FileListInput: React.FC<{
 }) => {
   let fileTree = useMemo(
     () => newFileTree(torrentDetails, torrentStats),
-    [torrentDetails, torrentStats],
+    [torrentDetails, torrentStats]
   );
 
   return (

--- a/crates/librqbit/webui/src/components/modal/FileSelectionModal.tsx
+++ b/crates/librqbit/webui/src/components/modal/FileSelectionModal.tsx
@@ -39,7 +39,15 @@ export const FileSelectionModal = (props: {
 
   useEffect(() => {
     setSelectedFiles(
-      new Set(listTorrentResponse?.details.files.map((_, i) => i)),
+      new Set(
+        listTorrentResponse?.details.files.flatMap((file, idx) => {
+          if (file.attributes.padding) {
+            return [];
+          } else {
+            return [idx];
+          }
+        })
+      )
     );
     setOutputFolder(listTorrentResponse?.output_folder || "");
   }, [listTorrentResponse]);
@@ -79,7 +87,7 @@ export const FileSelectionModal = (props: {
         },
         (e) => {
           setUploadError({ text: "Error starting torrent", details: e });
-        },
+        }
       )
       .finally(() => setUploading(false));
   };

--- a/crates/librqbit_core/src/hash_id.rs
+++ b/crates/librqbit_core/src/hash_id.rs
@@ -1,8 +1,8 @@
 use data_encoding::BASE32;
 use serde::{Deserialize, Deserializer, Serialize};
-use std::{cmp::Ordering, str::FromStr};
+use std::str::FromStr;
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Id<const N: usize>(pub [u8; N]);
 
 impl<const N: usize> Id<N> {
@@ -163,25 +163,6 @@ impl<'de, const N: usize> Deserialize<'de> for Id<N> {
         }
 
         deserializer.deserialize_any(IdVisitor {})
-    }
-}
-
-impl<const N: usize> PartialOrd<Id<N>> for Id<N> {
-    fn partial_cmp(&self, other: &Id<N>) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl<const N: usize> Ord for Id<N> {
-    fn cmp(&self, other: &Id<N>) -> Ordering {
-        for (s, o) in self.0.iter().copied().zip(other.0.iter().copied()) {
-            match s.cmp(&o) {
-                Ordering::Less => return Ordering::Less,
-                Ordering::Equal => continue,
-                Ordering::Greater => return Ordering::Greater,
-            }
-        }
-        Ordering::Equal
     }
 }
 

--- a/crates/rqbit/Cargo.toml
+++ b/crates/rqbit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rqbit"
-version = "8.1.0"
+version = "8.1.1"
 authors = ["Igor Katson <igor.katson@gmail.com>"]
 edition = "2021"
 description = "A bittorrent command line client and server."
@@ -24,7 +24,7 @@ postgres = ["librqbit/postgres"]
 disable-upload = ["librqbit/disable-upload"]
 
 [dependencies]
-librqbit = { version = "8.0.0", path = "../librqbit", default-features = false, features = [
+librqbit = { version = "8.1.1", path = "../librqbit", default-features = false, features = [
     "http-api",
     "http-api-client",
     "tracing-subscriber-utils",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rqbit-desktop"
-version = "8.1.0"
+version = "8.1.1"
 description = "rqbit torrent client"
 authors = ["you"]
 license = ""


### PR DESCRIPTION
`task_tcp_listener` matches `Some(Ok(..)) = futs.next()`. A failed check is the common case (unknown infohash, paused torrent, blocklist), and the refutable pattern disables that branch for the rest of the `select!` call while `accept()` keeps adding, so accepted sockets accumulate unread.

Observed on a live host: ~990 fds/min, reaching 13.6k, with Recv-Q 68 on each and 628 in CLOSE_WAIT. After the fix: 17.

Matches on `Some(res)` with an explicit `Err` arm, as the persistence loop in the same file already does, plus `biased` so pending checks drain before more are accepted.