### PR TITLE
fix(session): don't panic in task_listener when all select! branches are disabled (SIGABRT after boot on large libraries)

### DIFF
--- a/crates/librqbit/src/session.rs
+++ b/crates/librqbit/src/session.rs
@@ -972,6 +972,9 @@ impl Session {
         l: A,
         max_pending_incoming_handshake_checks: usize,
     ) -> anyhow::Result<()> {
+        // Cap of 0 would make both select! branches below permanently disabled,
+        // which panics ("all branches are disabled").
+        let max_pending_incoming_handshake_checks = max_pending_incoming_handshake_checks.max(1);
         let mut futs = FuturesUnordered::new();
         let session = Arc::downgrade(&self);
         drop(self);
@@ -1002,7 +1005,16 @@ impl Session {
                         }
                     }
                 },
-                Some(Ok((live, checked))) = futs.next(), if !futs.is_empty() => {
+                Some(res) = futs.next(), if !futs.is_empty() => {
+                    // Match on the full result. Matching only Ok here would
+                    // disable the branch on Err: with the queue at the cap
+                    // that leaves both select! branches disabled, which
+                    // panics. The queue itself pops on any completion.
+                    let (live, checked) = match res {
+                        Ok(v) => v,
+                        // Already logged in the map_err() above.
+                        Err(_) => continue,
+                    };
                     let (addr, kind) = (checked.addr, checked.kind);
                     if let Err(e) = live.add_incoming_peer(checked) {
                         warn!(?addr, ?kind, "error handing over incoming connection: {e:#}");
@@ -1811,6 +1823,19 @@ mod tests {
     use librqbit_core::torrent_metainfo::{TorrentMetaV1, torrent_from_bytes};
 
     use super::torrent_file_from_info_bytes;
+    use super::{Accept, ConnectionKind, Session, SessionOptions};
+    use crate::tests::test_util::{setup_test_logging, wait_until};
+    use crate::vectored_traits::{AsyncReadVectored, AsyncReadVectoredIntoCompat};
+    use anyhow::{Context, bail};
+    use std::{
+        net::SocketAddr,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+        time::Duration,
+    };
+    use tokio::io::{AsyncWrite, DuplexStream};
 
     #[test]
     fn test_torrent_file_from_info_and_bytes() {
@@ -1832,5 +1857,142 @@ mod tests {
         assert_eq!(parsed.info_hash, generated_parsed.info_hash);
         assert_eq!(parsed.info, generated_parsed.info);
         assert_eq!(parsed_trackers, get_trackers(&generated_parsed));
+    }
+
+    struct ListenerTest {
+        handle: tokio::task::JoinHandle<()>,
+        accepted: Arc<AtomicUsize>,
+        tx: tokio::sync::mpsc::Sender<DuplexStream>,
+        // task_listener() consumes its Arc<Session> and downgrades it; keep the
+        // session alive for the test duration.
+        _session: Arc<Session>,
+    }
+
+    struct StubListener {
+        rx: tokio::sync::Mutex<tokio::sync::mpsc::Receiver<DuplexStream>>,
+        accepted: Arc<AtomicUsize>,
+    }
+
+    impl Accept for StubListener {
+        const KIND: ConnectionKind = ConnectionKind::Tcp;
+
+        async fn accept(
+            &self,
+        ) -> anyhow::Result<(
+            SocketAddr,
+            (
+                impl AsyncReadVectored + Send + 'static,
+                impl AsyncWrite + Unpin + Send + 'static,
+            ),
+        )> {
+            let stream = self
+                .rx
+                .lock()
+                .await
+                .recv()
+                .await
+                .context("stub listener channel dropped")?;
+            self.accepted.fetch_add(1, Ordering::Relaxed);
+            let (read, write) = tokio::io::split(stream);
+            Ok((
+                "127.0.0.1:10000".parse().unwrap(),
+                (read.into_vectored_compat(), write),
+            ))
+        }
+    }
+
+    // Spawns task_listener() with the given cap and queues num_conns incoming
+    // connections whose handshake checks all fail fast (EOF), as happens in
+    // production when e.g. the torrent is still initializing.
+    async fn spawn_task_listener(cap: usize, num_conns: usize) -> ListenerTest {
+        setup_test_logging();
+        let session = Session::new_with_opts(
+            std::env::temp_dir().join("does_not_exist"),
+            SessionOptions {
+                dht: None,
+                disable_trackers: true,
+                disable_local_service_discovery: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        let accepted = Arc::new(AtomicUsize::new(0));
+        let (tx, rx) = tokio::sync::mpsc::channel(num_conns);
+        let keepalive = session.clone();
+        let handle = tokio::spawn({
+            let accepted = accepted.clone();
+            async move {
+                let _ = session
+                    .task_listener(
+                        StubListener {
+                            rx: tokio::sync::Mutex::new(rx),
+                            accepted,
+                        },
+                        cap,
+                    )
+                    .await;
+            }
+        });
+
+        for _ in 0..num_conns {
+            let (client, server) = tokio::io::duplex(128);
+            tx.send(server).await.unwrap();
+            // Dropping the client half makes the check fail immediately with
+            // EOF instead of waiting for the read timeout.
+            drop(client);
+        }
+
+        ListenerTest {
+            handle,
+            accepted,
+            tx,
+            _session: keepalive,
+        }
+    }
+
+    async fn wait_for_accepted(t: &ListenerTest, want: usize) {
+        wait_until(
+            || {
+                let accepted = t.accepted.load(Ordering::Relaxed);
+                if accepted >= want {
+                    return Ok(());
+                }
+                if t.handle.is_finished() {
+                    bail!("listener task exited prematurely");
+                }
+                bail!("accepted {accepted}/{want} connections")
+            },
+            Duration::from_secs(10),
+        )
+        .await
+        .unwrap();
+    }
+
+    async fn wait_accepted(t: &ListenerTest, want: usize) {
+        wait_for_accepted(t, want).await;
+        // The loop must keep running after draining everything queued so far:
+        // prove it accepts one more connection.
+        let (client, server) = tokio::io::duplex(128);
+        t.tx.send(server).await.unwrap();
+        drop(client);
+        wait_for_accepted(t, want + 1).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_task_listener_survives_failing_handshake_checks_at_cap() {
+        // Regression: with the queue at the cap and failing checks, the drain
+        // branch didn't match on Err, and the select! panicked with "all
+        // branches are disabled and there is no else branch".
+        let t = spawn_task_listener(2, 6).await;
+        wait_accepted(&t, 6).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_task_listener_accepts_with_zero_cap() {
+        // Regression: cap=0 used to panic on the very first select! evaluation.
+        let t = spawn_task_listener(0, 2).await;
+        wait_accepted(&t, 2).await;
     }
 }


### PR DESCRIPTION
## Problem

`Session::task_listener` (both TCP and uTP listeners) runs a `tokio::select!` over two branches: accepting new connections (guarded by `futs.len() < max_pending_incoming_handshake_checks`) and draining a `FuturesUnordered` of pending handshake checks. The drain branch pattern-matched the inner `Ok`:

```rust
Some(Ok((live, checked))) = futs.next(), if !futs.is_empty() => { ... }
```

A failed handshake check resolves to `Err(..)`, which fails that pattern and disables the branch. With the queue at the cap, both branches are then disabled and tokio panics:

```
thread 'main' panicked at crates/librqbit/src/session.rs:980:
all branches are disabled and there is no else branch
```

This is a fatal SIGABRT under `panic = "abort"` (the release profile), taking the whole daemon down.

The window is real in production: handshake checks fail while torrents are still doing their initial hash check (`live_wait_initializing`'s 5s timeout at session.rs:953), so any burst of inbound connections shortly after boot — e.g. restarting a daemon seeding a multi-TB library, where hundreds of torrents are initializing simultaneously — fills the queue to the cap (default 256) and the first failed check aborts the process. I hit this ~90 seconds after boot on a host with a 4TB library, reproducibly across restarts.

## Fix

Match on the full result, so a failed check pops the queue like a successful one:

```rust
Some(res) = futs.next(), if !futs.is_empty() => {
    let (live, checked) = match res {
        Ok(v) => v,
        Err(_) => continue, // already logged via .map_err() at push time
    };
    ...
}
```

This makes the all-branches-disabled state unreachable for any cap, and restores the cap's intended memory bound (bounded by in-flight checks — failures previously wedged slots open, which is why downstream workarounds set the cap to `usize::MAX`).

Also clamp `max_pending_incoming_handshake_checks` to at least 1: with a cap of 0 (a public `ListenerOptions` field) both branches were disabled on the very first `select!` poll, panicking deterministically even without any traffic.

## Why this shape

A generic `else` branch on the `select!` would mask the condition instead of fixing it, and never-disabling accept (shedding connections at the cap instead) changes the backpressure mechanism. Draining on any completion is also exactly what the two neighboring `select!` loops in this crate already do (the persistence-add loop and `dht_utils.rs`), so this makes `task_listener` consistent with the codebase.

## Tests

Two regression tests in `session.rs` (`StubListener` implementing the crate-internal `Accept` trait with tokio duplex streams; dropping the client half makes each check fail fast with EOF, the same path as a disconnected peer):

- `test_task_listener_survives_failing_handshake_checks_at_cap`: queue at cap=2 with failing checks — panics against the pre-fix code with the exact production message, passes with the fix
- `test_task_listener_accepts_with_zero_cap`: cap=0 — panicked on the first `select!` evaluation pre-fix

Both pass 10/10 consecutive runs. `cargo test -p librqbit` is green (34 passed, including the existing TCP and uTP e2e download tests), and `cargo fmt --check` / `cargo clippy --all-targets` are clean. Also ran the `simulate_traffic` example (10 sessions, mixed TCP/uTP) through two full boots — zero panics with failed handshake checks being drained continuously.

Disclosure: I am still learning Rust; this PR was developed and tested with heavy assistance from GLM 5.3 Flash.
